### PR TITLE
Disable touch callout and text selection globally

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,16 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Disable text selection and callout menus globally */
+* {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 a {
   font-weight: 500;
   color: #646cff;


### PR DESCRIPTION
## Summary
- disable text selection and touch callouts globally to prevent copy/paste and long-press menus

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c65ffecc0883288e40d570eef7259f