### PR TITLE
Add loop strip playhead visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sequencer-instrument",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/material-symbols-outlined": "^5.2.22",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "tone": "^15.1.22"
@@ -854,6 +855,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/material-symbols-outlined": {
+      "version": "5.2.22",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-symbols-outlined/-/material-symbols-outlined-5.2.22.tgz",
+      "integrity": "sha512-IATnbbzFiJoDuWqtGpjfz6RThBJeG4DU8OpbGBLRWeRvSPfYgfW35K/daacp1aJ8pUlk4QD0WPjOIyR37H9Lkw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "preview": "vite preview"
+    "lint": "eslint src --ext .ts,.tsx",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fontsource/material-symbols-outlined": "^5.2.22",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "tone": "^15.1.22"
@@ -26,11 +27,5 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2"
-  },
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint src --ext .ts,.tsx",
-    "typecheck": "tsc --noEmit"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import * as Tone from "tone";
 
 import { startStarterLoop } from "./loop";
+import { LoopStrip } from "./LoopStrip";
 
 type Subdivision = "16n" | "8n" | "4n";
 
@@ -133,15 +134,16 @@ export default function App() {
     <div
       style={{
         minHeight: "100svh",
-        padding: 16,
         background: flash ? "#202a40" : "#0f1420",
         transition: "background 80ms linear",
         color: "#e6f2ff",
-        fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+        display: "flex",
+        flexDirection: "column"
       }}
     >
       {!started ? (
-        <div style={{ display: "grid", placeItems: "center", height: "100%" }}>
+        <div style={{ display: "grid", placeItems: "center", flex: 1 }}>
           <button
             onPointerDown={initAudioGraph}
             onPointerUp={(e) => e.currentTarget.blur()}
@@ -159,80 +161,83 @@ export default function App() {
         </div>
       ) : (
         <>
-          <div style={{ display: "flex", gap: 12, alignItems: "center", marginBottom: 12 }}>
-            <label>BPM</label>
-            <select
-              value={bpm}
-              onChange={(e) => setBpm(parseInt(e.target.value, 10))}
-              style={{ padding: 8, borderRadius: 8, background: "#121827", color: "white" }}
-            >
-              {[90, 100, 110, 120, 130].map((v) => (
-                <option key={v} value={v}>
-                  {v}
-                </option>
-              ))}
-            </select>
-            <label style={{ marginLeft: 12 }}>Quantize</label>
-            <select
-              value={subdiv}
-              onChange={(e) => setSubdiv(e.target.value as Subdivision)}
-              style={{ padding: 8, borderRadius: 8, background: "#121827", color: "white" }}
-            >
-              <option value="16n">1/16</option>
-              <option value="8n">1/8</option>
-              <option value="4n">1/4</option>
-            </select>
-            <button
-              onPointerDown={() => {
-                if (isPlaying) {
-                  Tone.Transport.pause();
-                } else {
-                  Tone.Transport.start();
-                }
-                setIsPlaying(!isPlaying);
-              }}
-              onPointerUp={(e) => e.currentTarget.blur()}
-              style={{
-                padding: "8px 12px",
-                borderRadius: 8,
-                border: "1px solid #333",
-                background: "#27E0B0",
-                color: "#1F2532"
-              }}
-            >
-              {isPlaying ? "Pause" : "Play"}
-            </button>
-            <button
-              onPointerDown={() => {
-                Tone.Transport.stop();
-                setIsPlaying(false);
-              }}
-              onPointerUp={(e) => e.currentTarget.blur()}
-              style={{
-                padding: "8px 12px",
-                borderRadius: 8,
-                border: "1px solid #333",
-                background: "#E02749",
-                color: "#e6f2ff"
-              }}
-            >
-              Stop
-            </button>
-          </div>
+          <LoopStrip started={started} isPlaying={isPlaying} />
+          <div style={{ padding: 16 }}>
+            <div style={{ display: "flex", gap: 12, alignItems: "center", marginBottom: 12 }}>
+              <label>BPM</label>
+              <select
+                value={bpm}
+                onChange={(e) => setBpm(parseInt(e.target.value, 10))}
+                style={{ padding: 8, borderRadius: 8, background: "#121827", color: "white" }}
+              >
+                {[90, 100, 110, 120, 130].map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+              <label style={{ marginLeft: 12 }}>Quantize</label>
+              <select
+                value={subdiv}
+                onChange={(e) => setSubdiv(e.target.value as Subdivision)}
+                style={{ padding: 8, borderRadius: 8, background: "#121827", color: "white" }}
+              >
+                <option value="16n">1/16</option>
+                <option value="8n">1/8</option>
+                <option value="4n">1/4</option>
+              </select>
+              <button
+                onPointerDown={() => {
+                  if (isPlaying) {
+                    Tone.Transport.pause();
+                  } else {
+                    Tone.Transport.start();
+                  }
+                  setIsPlaying(!isPlaying);
+                }}
+                onPointerUp={(e) => e.currentTarget.blur()}
+                style={{
+                  padding: "8px 12px",
+                  borderRadius: 8,
+                  border: "1px solid #333",
+                  background: "#27E0B0",
+                  color: "#1F2532"
+                }}
+              >
+                {isPlaying ? "Pause" : "Play"}
+              </button>
+              <button
+                onPointerDown={() => {
+                  Tone.Transport.stop();
+                  setIsPlaying(false);
+                }}
+                onPointerUp={(e) => e.currentTarget.blur()}
+                style={{
+                  padding: "8px 12px",
+                  borderRadius: 8,
+                  border: "1px solid #333",
+                  background: "#E02749",
+                  color: "#e6f2ff"
+                }}
+              >
+                Stop
+              </button>
+            </div>
 
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "1fr 1fr",
-              gap: 12,
-              maxWidth: 600,
-              margin: "0 auto"
-            }}
-          >
-            <Pad label="Kick" onTap={scheduleKick} />
-            <Pad label="Snare" onTap={scheduleSnare} />
-            <Pad label="Hat" onTap={scheduleHat} />
-            <Pad label="Chord" onTap={scheduleChord} />
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 12,
+                maxWidth: 600,
+                margin: "0 auto"
+              }}
+            >
+              <Pad label="Kick" onTap={scheduleKick} />
+              <Pad label="Snare" onTap={scheduleSnare} />
+              <Pad label="Hat" onTap={scheduleHat} />
+              <Pad label="Chord" onTap={scheduleChord} />
+            </div>
           </div>
         </>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,26 @@ import * as Tone from "tone";
 import { startStarterLoop } from "./loop";
 import { LoopStrip } from "./LoopStrip";
 
+// Simple icon components for transport controls
+const PlayIcon = ({ size = 20 }: { size?: number }) => (
+  <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+    <polygon points="8,5 19,12 8,19" />
+  </svg>
+);
+
+const PauseIcon = ({ size = 20 }: { size?: number }) => (
+  <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+    <rect x="6" y="5" width="4" height="14" />
+    <rect x="14" y="5" width="4" height="14" />
+  </svg>
+);
+
+const StopIcon = ({ size = 20 }: { size?: number }) => (
+  <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+    <rect x="5" y="5" width="14" height="14" />
+  </svg>
+);
+
 type Subdivision = "16n" | "8n" | "4n";
 
 function nextGridTime(subdivision: Subdivision): number {
@@ -187,6 +207,7 @@ export default function App() {
                 <option value="4n">1/4</option>
               </select>
               <button
+                aria-label={isPlaying ? "Pause" : "Play"}
                 onPointerDown={() => {
                   if (isPlaying) {
                     Tone.Transport.pause();
@@ -197,30 +218,39 @@ export default function App() {
                 }}
                 onPointerUp={(e) => e.currentTarget.blur()}
                 style={{
-                  padding: "8px 12px",
+                  width: 40,
+                  height: 40,
                   borderRadius: 8,
                   border: "1px solid #333",
                   background: "#27E0B0",
-                  color: "#1F2532"
+                  color: "#1F2532",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center"
                 }}
               >
-                {isPlaying ? "Pause" : "Play"}
+                {isPlaying ? <PauseIcon size={20} /> : <PlayIcon size={20} />}
               </button>
               <button
+                aria-label="Stop"
                 onPointerDown={() => {
                   Tone.Transport.stop();
                   setIsPlaying(false);
                 }}
                 onPointerUp={(e) => e.currentTarget.blur()}
                 style={{
-                  padding: "8px 12px",
+                  width: 40,
+                  height: 40,
                   borderRadius: 8,
                   border: "1px solid #333",
                   background: "#E02749",
-                  color: "#e6f2ff"
+                  color: "#e6f2ff",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center"
                 }}
               >
-                Stop
+                <StopIcon size={20} />
               </button>
             </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,26 +4,6 @@ import * as Tone from "tone";
 import { startStarterLoop } from "./loop";
 import { LoopStrip } from "./LoopStrip";
 
-// Simple icon components for transport controls
-const PlayIcon = ({ size = 20 }: { size?: number }) => (
-  <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
-    <polygon points="8,5 19,12 8,19" />
-  </svg>
-);
-
-const PauseIcon = ({ size = 20 }: { size?: number }) => (
-  <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
-    <rect x="6" y="5" width="4" height="14" />
-    <rect x="14" y="5" width="4" height="14" />
-  </svg>
-);
-
-const StopIcon = ({ size = 20 }: { size?: number }) => (
-  <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
-    <rect x="5" y="5" width="14" height="14" />
-  </svg>
-);
-
 type Subdivision = "16n" | "8n" | "4n";
 
 function nextGridTime(subdivision: Subdivision): number {
@@ -226,10 +206,13 @@ export default function App() {
                   color: "#1F2532",
                   display: "flex",
                   alignItems: "center",
-                  justifyContent: "center"
+                  justifyContent: "center",
+                  fontSize: 20
                 }}
               >
-                {isPlaying ? <PauseIcon size={20} /> : <PlayIcon size={20} />}
+                <span className="material-symbols-outlined">
+                  {isPlaying ? "pause" : "play_arrow"}
+                </span>
               </button>
               <button
                 aria-label="Stop"
@@ -247,10 +230,17 @@ export default function App() {
                   color: "#e6f2ff",
                   display: "flex",
                   alignItems: "center",
-                  justifyContent: "center"
+                  justifyContent: "center",
+                  fontSize: 40,
+                  padding: 0
                 }}
               >
-                <StopIcon size={20} />
+                <span
+                  className="material-symbols-outlined"
+                  style={{ lineHeight: 1, width: "100%", height: "100%" }}
+                >
+                  stop
+                </span>
               </button>
             </div>
 

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import * as Tone from "tone";
+
+/**
+ * Top strip visualizing a 16-step loop.
+ * - Occupies 25% of viewport height and full width.
+ * - Displays 16 horizontal steps.
+ * - Highlights the current step in sync with Tone.Transport.
+ */
+export function LoopStrip({ started, isPlaying }: { started: boolean; isPlaying: boolean }) {
+  const [step, setStep] = useState(0);
+
+  // Schedule a step advance on each 16th note when audio has started.
+  useEffect(() => {
+    if (!started) return;
+    const id = Tone.Transport.scheduleRepeat((time) => {
+      Tone.Draw.schedule(() => {
+        setStep((s) => (s + 1) % 16);
+      }, time);
+    }, "16n");
+    return () => {
+      Tone.Transport.clear(id);
+    };
+  }, [started]);
+
+  // Reset playhead when transport stops or is paused.
+  useEffect(() => {
+    if (!isPlaying) setStep(0);
+  }, [isPlaying]);
+
+  return (
+    <div
+      style={{
+        height: "25vh",
+        width: "100%",
+        background: "#2a2f3a",
+        display: "flex",
+        alignItems: "center",
+        padding: "0 8px",
+        boxSizing: "border-box"
+      }}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(16, 1fr)",
+          gap: 4,
+          width: "100%",
+          height: "60%"
+        }}
+      >
+        {Array.from({ length: 16 }).map((_, i) => (
+          <div
+            key={i}
+            style={{
+              border: "1px solid #555",
+              background: i === step ? "#27E0B0" : "#1f2532",
+              transition: "background 60ms linear"
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,22 @@
+@import "@fontsource/material-symbols-outlined";
+
+.material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 1em;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: "liga";
+  -webkit-font-smoothing: antialiased;
+  font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+}
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- add LoopStrip component that renders a 16-step top strip and highlights a playhead in sync with Tone.Transport
- refactor App layout to include the loop strip and use flex column layout

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c664b30b988328866c9f2a3bd1a0b2