### PR TITLE
Add chunk schema and starter drum presets

### DIFF
--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import * as Tone from "tone";
 import type { Track, TriggerMap } from "./tracks";
-import { presets, type Pattern } from "./patterns";
+import { presets, type Chunk } from "./chunks";
 
 /**
  * Top strip visualizing a 16-step loop.
@@ -58,7 +58,11 @@ export function LoopStrip({
 
   const updatePattern = (trackId: number, steps: number[]) => {
     setTracks((ts) =>
-      ts.map((t) => (t.id === trackId ? { ...t, pattern: { steps } } : t))
+      ts.map((t) =>
+        t.id === trackId && t.pattern
+          ? { ...t, pattern: { ...t.pattern, steps } }
+          : t
+      )
     );
   };
 
@@ -190,7 +194,7 @@ function PatternPlayer({
   trigger,
   started,
 }: {
-  pattern: Pattern;
+  pattern: Chunk;
   trigger: (time: number) => void;
   started: boolean;
 }) {

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Chunk",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name", "instrument", "steps", "note", "velocity"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique chunk identifier"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-friendly chunk name"
+    },
+    "instrument": {
+      "type": "string",
+      "description": "Maps to Tone.js instrument"
+    },
+    "steps": {
+      "type": "array",
+      "description": "16-step pattern (1 = hit, 0 = rest)",
+      "items": {
+        "type": "integer",
+        "enum": [0, 1]
+      },
+      "minItems": 16,
+      "maxItems": 16
+    },
+    "note": {
+      "type": "string",
+      "description": "Pitch or root note"
+    },
+    "velocity": {
+      "type": "number",
+      "description": "Hit intensity",
+      "minimum": 0,
+      "maximum": 1
+    }
+  }
+}

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -1,0 +1,35 @@
+export interface Chunk {
+  id: string;
+  name: string;
+  instrument: string;
+  steps: number[];
+  note: string;
+  velocity: number;
+}
+
+export const presets: Record<string, Chunk> = {
+  kick: {
+    id: "kick-basic",
+    name: "Kick Basic",
+    instrument: "kick",
+    steps: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+    note: "C2",
+    velocity: 0.9,
+  },
+  snare: {
+    id: "snare-backbeat",
+    name: "Backbeat Snare",
+    instrument: "snare",
+    steps: [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+    note: "D2",
+    velocity: 0.8,
+  },
+  hat: {
+    id: "hihat-straight",
+    name: "Straight Hi-Hat",
+    instrument: "hat",
+    steps: [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
+    note: "F#3",
+    velocity: 0.6,
+  },
+};

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1,8 +1,0 @@
-export interface Pattern {
-  steps: number[];
-}
-
-export const presets: Record<string, Pattern> = {
-  kick: { steps: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0] },
-  snare: { steps: [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0] },
-};

--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -1,4 +1,4 @@
-import type { Pattern } from "./patterns";
+import type { Chunk } from "./chunks";
 
 export type TriggerMap = Record<string, (time: number) => void>;
 
@@ -6,5 +6,5 @@ export interface Track {
   id: number;
   name: string;
   instrument: keyof TriggerMap;
-  pattern: Pattern | null;
+  pattern: Chunk | null;
 }


### PR DESCRIPTION
## Summary
- define JSON schema for chunk presets
- add kick, snare, and hi-hat starter chunks
- update track and loop components to use chunk metadata

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c70115201483288d1aa6188052ac11