### PR TITLE
feat: add dynamic pack tabs

### DIFF
--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -19,6 +19,8 @@ export function LoopStrip({
   editing,
   setEditing,
   setTracks,
+  packIndex,
+  setPackIndex,
 }: {
   started: boolean;
   isPlaying: boolean;
@@ -27,10 +29,15 @@ export function LoopStrip({
   editing: number | null;
   setEditing: Dispatch<SetStateAction<number | null>>;
   setTracks: Dispatch<SetStateAction<Track[]>>;
+  packIndex: number;
+  setPackIndex: Dispatch<SetStateAction<number>>;
 }) {
   const [step, setStep] = useState(0);
-  const [packIndex, setPackIndex] = useState(0);
   const [selectedChunk, setSelectedChunk] = useState("");
+
+  useEffect(() => {
+    setSelectedChunk("");
+  }, [packIndex]);
 
   // Schedule a step advance on each 16th note when audio has started.
   useEffect(() => {

--- a/src/packs.ts
+++ b/src/packs.ts
@@ -12,12 +12,9 @@ export interface Pack {
   chunks: Chunk[];
 }
 
-import phonk from "./packs/phonk.json" assert { type: "json" };
-import edm from "./packs/early-2000s-edm.json" assert { type: "json" };
-import kraftwerk from "./packs/kraftwerk.json" assert { type: "json" };
+const packModules = import.meta.glob("./packs/*.json", {
+  eager: true,
+  import: "default",
+}) as Record<string, Pack>;
 
-export const packs: Pack[] = [
-  phonk as Pack,
-  edm as Pack,
-  kraftwerk as Pack,
-];
+export const packs: Pack[] = Object.values(packModules);


### PR DESCRIPTION
## Summary
- load all pack JSON files dynamically
- provide tabbed UI to switch packs and their presets
- rebuild instruments and tracks when switching packs

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c70fd3ac4883288ebc8dfb4e60ccb9