### PR TITLE
feat: add chunk edit modal

### DIFF
--- a/src/ChunkModal.tsx
+++ b/src/ChunkModal.tsx
@@ -1,0 +1,79 @@
+import type { Chunk } from "./chunks";
+
+export function ChunkModal({
+  chunk,
+  onChange,
+  onClose,
+}: {
+  chunk: Chunk;
+  onChange: (p: Partial<Chunk>) => void;
+  onClose: () => void;
+}) {
+  const velocity = chunk.velocity ?? 1;
+  const pitch = chunk.pitch ?? 0;
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          background: "#1f2532",
+          color: "white",
+          padding: 16,
+          borderRadius: 8,
+          width: "80%",
+          maxWidth: 320,
+        }}
+      >
+        <div style={{ marginBottom: 12 }}>
+          <label style={{ display: "block", marginBottom: 4 }}>
+            Velocity: {velocity.toFixed(2)}
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={velocity}
+            onChange={(e) => onChange({ velocity: Number(e.target.value) })}
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div style={{ marginBottom: 12 }}>
+          <label style={{ display: "block", marginBottom: 4 }}>
+            Pitch: {pitch}
+          </label>
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={pitch}
+            onChange={(e) => onChange({ pitch: Number(e.target.value) })}
+            style={{ width: "100%" }}
+          />
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            padding: "8px 12px",
+            borderRadius: 4,
+            border: "none",
+            background: "#27E0B0",
+            color: "#1F2532",
+            cursor: "pointer",
+          }}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -36,6 +36,12 @@
       "description": "Hit intensity",
       "minimum": 0,
       "maximum": 1
+    },
+    "pitch": {
+      "type": "number",
+      "description": "Pitch shift in semitones",
+      "minimum": -12,
+      "maximum": 12
     }
   }
 }

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -5,5 +5,6 @@ export interface Chunk {
   steps: number[];
   note?: string;
   velocity?: number;
+  pitch?: number;
 }
 


### PR DESCRIPTION
## Summary
- add pitch field to chunks and schema
- long-press on track to open chunk editor
- modal sliders update chunk velocity and pitch

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c7139843588328a60fd0be4f7110ec