### PR TITLE
feat: add swipe exit and per-step controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,11 +66,17 @@ export default function App() {
       ];
       const inst = new Ctor().toDestination();
       instrumentRefs.current[name] = inst;
-      newTriggers[name] = (time: number) => {
+      newTriggers[name] = (
+        time: number,
+        velocity = 1,
+        pitch = 0
+      ) => {
         if (inst instanceof Tone.NoiseSynth) {
-          inst.triggerAttackRelease(spec.note ?? "8n", time);
+          inst.triggerAttackRelease(spec.note ?? "8n", time, velocity);
         } else {
-          inst.triggerAttackRelease(spec.note ?? "C2", "8n", time);
+          const base = spec.note ?? "C2";
+          const note = Tone.Frequency(base).transpose(pitch).toNote();
+          inst.triggerAttackRelease(note, "8n", time, velocity);
         }
       };
     });

--- a/src/StepModal.tsx
+++ b/src/StepModal.tsx
@@ -1,16 +1,11 @@
-import type { Chunk } from "./chunks";
+import type { FC } from "react";
 
-export function ChunkModal({
-  chunk,
-  onChange,
-  onClose,
-}: {
-  chunk: Chunk;
-  onChange: (p: Partial<Chunk>) => void;
+export const StepModal: FC<{
+  velocity: number;
+  pitch: number;
+  onChange: (p: { velocity?: number; pitch?: number }) => void;
   onClose: () => void;
-}) {
-  const velocity = chunk.velocity ?? 1;
-  const pitch = chunk.pitch ?? 0;
+}> = ({ velocity, pitch, onChange, onClose }) => {
   return (
     <div
       style={{
@@ -76,4 +71,4 @@ export function ChunkModal({
       </div>
     </div>
   );
-}
+};

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -27,21 +27,31 @@
       "minItems": 16,
       "maxItems": 16
     },
+    "velocities": {
+      "type": "array",
+      "description": "Per-step hit intensity",
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "minItems": 16,
+      "maxItems": 16
+    },
+    "pitches": {
+      "type": "array",
+      "description": "Per-step pitch shift in semitones",
+      "items": {
+        "type": "number",
+        "minimum": -12,
+        "maximum": 12
+      },
+      "minItems": 16,
+      "maxItems": 16
+    },
     "note": {
       "type": "string",
       "description": "Pitch or root note"
-    },
-    "velocity": {
-      "type": "number",
-      "description": "Hit intensity",
-      "minimum": 0,
-      "maximum": 1
-    },
-    "pitch": {
-      "type": "number",
-      "description": "Pitch shift in semitones",
-      "minimum": -12,
-      "maximum": 12
     }
   }
 }

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -3,8 +3,8 @@ export interface Chunk {
   name: string;
   instrument: string;
   steps: number[];
+  velocities?: number[];
+  pitches?: number[];
   note?: string;
-  velocity?: number;
-  pitch?: number;
 }
 

--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -1,6 +1,9 @@
 import type { Chunk } from "./chunks";
 
-export type TriggerMap = Record<string, (time: number) => void>;
+export type TriggerMap = Record<
+  string,
+  (time: number, velocity?: number, pitch?: number) => void
+>;
 
 export interface Track {
   id: number;


### PR DESCRIPTION
## Summary
- swipe right on a track to leave edit mode while other tracks stay visible
- long-press a step for velocity/pitch sliders and tap to toggle steps
- support per-step velocity/pitch values through updated data model and triggers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c767dc15c08328b03b144cd5b4b327