### PR TITLE
feat: add Mushy arpeggiator instrument

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ export default function App() {
   const [tracks, setTracks] = useState<Track[]>([]);
   const [editing, setEditing] = useState<number | null>(null);
   const [triggers, setTriggers] = useState<TriggerMap>({});
-  const [tab, setTab] = useState<"arp" | "keyboard">("arp");
+  const [tab, setTab] = useState<"mushy" | "keyboard">("mushy");
 
   useEffect(() => {
     if (started) Tone.Transport.bpm.value = bpm;
@@ -105,12 +105,13 @@ export default function App() {
         }
       };
     });
+    let chordInst = instrumentRefs.current["chord"];
     if (!pack.instruments["chord"]) {
-      const chord = new Tone.Synth({
+      chordInst = new Tone.Synth({
         oscillator: { type: "triangle" },
         envelope: { attack: 0.005, decay: 0.2, sustain: 0.2, release: 0.4 },
       }).toDestination();
-      instrumentRefs.current["chord"] = chord;
+      instrumentRefs.current["chord"] = chordInst;
       newTriggers["chord"] = (
         time: number,
         velocity = 1,
@@ -119,9 +120,11 @@ export default function App() {
         sustain = 0.1
       ) => {
         const n = Tone.Frequency(note).transpose(pitch).toNote();
-        chord.triggerAttackRelease(n, sustain, time, velocity);
+        chordInst!.triggerAttackRelease(n, sustain, time, velocity);
       };
     }
+    instrumentRefs.current["arpeggiator"] = chordInst!;
+    newTriggers["arpeggiator"] = newTriggers["chord"];
     setTriggers(newTriggers);
   }, [packIndex, started]);
 
@@ -377,17 +380,17 @@ export default function App() {
               <div style={{ marginTop: 16 }}>
                 <div style={{ display: "flex", gap: 8, marginBottom: 8 }}>
                   <button
-                    onClick={() => setTab("arp")}
+                    onClick={() => setTab("mushy")}
                     style={{
                       flex: 1,
                       padding: "8px 0",
                       borderRadius: 8,
                       border: "1px solid #333",
-                      background: tab === "arp" ? "#27E0B0" : "#1f2532",
-                      color: tab === "arp" ? "#1F2532" : "#e6f2ff",
+                      background: tab === "mushy" ? "#27E0B0" : "#1f2532",
+                      color: tab === "mushy" ? "#1F2532" : "#e6f2ff",
                     }}
                   >
-                    Arp
+                    Mushy
                   </button>
                   <button
                     onClick={() => setTab("keyboard")}
@@ -403,7 +406,7 @@ export default function App() {
                     Keyboard
                   </button>
                 </div>
-                {tab === "arp" ? (
+                {tab === "mushy" ? (
                   <Arpeggiator
                     started={started}
                     subdiv={subdiv}

--- a/src/Arpeggiator.tsx
+++ b/src/Arpeggiator.tsx
@@ -57,17 +57,20 @@ export function Arpeggiator({
         ...ts,
         {
           id: nextId,
-          name: "Arp",
-          instrument: "chord",
+          name: "Mushy",
+          instrument: "arpeggiator",
           pattern: {
             id: `arp-${Date.now()}`,
-            name: "Arp",
-            instrument: "chord",
+            name: "Mushy Pattern",
+            instrument: "arpeggiator",
             steps,
             velocities,
             pitches,
             note: root,
             sustain,
+            notes: chord.length ? chord.slice() : [root],
+            style,
+            mode,
           },
         },
       ];
@@ -145,17 +148,20 @@ export function Arpeggiator({
                 ...ts,
                 {
                   id: tid,
-                  name: "Arp",
-                  instrument: "chord",
+                  name: "Mushy",
+                  instrument: "arpeggiator",
                   pattern: {
                     id: `arp-${Date.now()}`,
-                    name: "Arp",
-                    instrument: "chord",
+                    name: "Mushy Pattern",
+                    instrument: "arpeggiator",
                     steps,
                     velocities,
                     pitches,
                     note: root,
                     sustain,
+                    notes: [note],
+                    style,
+                    mode,
                   },
                 },
               ];
@@ -165,13 +171,16 @@ export function Arpeggiator({
               const pattern =
                 t.pattern ?? {
                   id: `arp-${Date.now()}`,
-                  name: "Arp",
-                  instrument: "chord",
+                  name: "Mushy Pattern",
+                  instrument: "arpeggiator",
                   steps: Array(16).fill(0),
                   velocities: Array(16).fill(1),
                   pitches: Array(16).fill(0),
                   note: root,
                   sustain,
+                  notes: [],
+                  style,
+                  mode,
                 };
               const steps = pattern.steps.slice();
               const velocities = pattern.velocities
@@ -180,12 +189,23 @@ export function Arpeggiator({
               const pitches = pattern.pitches
                 ? pattern.pitches.slice()
                 : Array(16).fill(0);
+              const notesArr = pattern.notes ? pattern.notes.slice() : [];
+              if (!notesArr.includes(note)) notesArr.push(note);
               steps[stepIndex] = 1;
               velocities[stepIndex] = 1;
               pitches[stepIndex] = pitch;
               return {
                 ...t,
-                pattern: { ...pattern, steps, velocities, pitches, sustain },
+                pattern: {
+                  ...pattern,
+                  steps,
+                  velocities,
+                  pitches,
+                  sustain,
+                  notes: notesArr,
+                  style,
+                  mode,
+                },
               };
             });
           });
@@ -195,7 +215,7 @@ export function Arpeggiator({
     return () => {
       loopRef.current?.dispose();
     };
-  }, [started, style, subdiv, record, setTracks, root, chord, sustain]);
+  }, [started, style, subdiv, record, setTracks, root, chord, sustain, mode]);
 
   useEffect(() => {
     if (!record) {

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -11,6 +11,7 @@ const instrumentColors: Record<string, string> = {
   snare: "#3498db",
   hat: "#f1c40f",
   chord: "#2ecc71",
+  arpeggiator: "#9b59b6",
 };
 
 const LABEL_WIDTH = 60;

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -52,6 +52,26 @@
     "note": {
       "type": "string",
       "description": "Pitch or root note"
+    },
+    "sustain": {
+      "type": "number",
+      "description": "Default note length in seconds",
+      "minimum": 0
+    },
+    "notes": {
+      "type": "array",
+      "description": "Chord notes for arpeggiator",
+      "items": { "type": "string" }
+    },
+    "style": {
+      "type": "string",
+      "description": "Arpeggiator style",
+      "enum": ["up", "down", "up-down", "random"]
+    },
+    "mode": {
+      "type": "string",
+      "description": "Arpeggiator playback mode",
+      "enum": ["continuous", "manual"]
     }
   }
 }

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -7,5 +7,8 @@ export interface Chunk {
   pitches?: number[];
   note?: string;
   sustain?: number;
+  notes?: string[];
+  style?: string;
+  mode?: string;
 }
 


### PR DESCRIPTION
## Summary
- introduce Mushy arpeggiator instrument tab with recordable patterns
- extend pattern schema with notes, style, mode fields
- wire arpeggiator triggers and colors into loop strip

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7ad3d93e88328857f818e85cae3a2