### PR TITLE
Make keyboard controls panel scrollable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -345,7 +345,9 @@ export default function App() {
                 style={{
                   marginTop: 16,
                   flex: 1,
-                  overflowY: "auto",
+                  display: "flex",
+                  flexDirection: "column",
+                  overflowY: tab === "keyboard" ? "hidden" : "auto",
                   minHeight: 0,
                   WebkitOverflowScrolling: "touch",
                 }}

--- a/src/Keyboard.tsx
+++ b/src/Keyboard.tsx
@@ -292,7 +292,7 @@ export function Keyboard({
   };
 
   return (
-    <div style={{ display: "flex", flexDirection: "column" }}>
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
       <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
         <button
           onClick={addTrack}
@@ -456,6 +456,10 @@ export function Keyboard({
           flexWrap: "wrap",
           gap: 12,
           marginTop: 12,
+          flex: 1,
+          overflowY: "auto",
+          minHeight: 0,
+          WebkitOverflowScrolling: "touch",
         }}
       >
         <div style={{ flex: "1 0 45%" }}>


### PR DESCRIPTION
## Summary
- Make tab content container flex and hide overflow when keyboard tab is active
- Allow keyboard controls to scroll within available space

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c82a3d085483288155086c3c919780