### PR TITLE
Add modal workflow for configuring new tracks

### DIFF
--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -6,6 +6,7 @@ import { formatInstrumentLabel } from "./utils/instrument";
 
 interface AddTrackModalProps {
   isOpen: boolean;
+  mode: "add" | "edit";
   packs: Pack[];
   selectedPackId: string;
   selectedInstrumentId: string;
@@ -17,10 +18,12 @@ interface AddTrackModalProps {
   onSelectPreset: (presetId: string | null) => void;
   onCancel: () => void;
   onConfirm: () => void;
+  onDelete?: () => void;
 }
 
 export const AddTrackModal: FC<AddTrackModalProps> = ({
   isOpen,
+  mode,
   packs,
   selectedPackId,
   selectedInstrumentId,
@@ -32,6 +35,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
   onSelectPreset,
   onCancel,
   onConfirm,
+  onDelete,
 }) => {
   if (!isOpen) return null;
 
@@ -47,6 +51,12 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     : [];
 
   const confirmDisabled = !pack || !selectedInstrumentId;
+  const isEditMode = mode === "edit";
+  const title = isEditMode ? "Edit Track" : "Add Track";
+  const description = isEditMode
+    ? "Adjust the sound pack, instrument, character, and preset for this track."
+    : "Choose a sound pack, instrument, character, and optional preset to start a new groove.";
+  const confirmLabel = isEditMode ? "Update Track" : "Add Track";
 
   return (
     <div
@@ -77,11 +87,8 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
         }}
       >
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <span style={{ fontSize: 20, fontWeight: 700 }}>Add Track</span>
-          <span style={{ fontSize: 13, color: "#94a3b8" }}>
-            Choose a sound pack, instrument, character, and optional preset to
-            start a new groove.
-          </span>
+          <span style={{ fontSize: 20, fontWeight: 700 }}>{title}</span>
+          <span style={{ fontSize: 13, color: "#94a3b8" }}>{description}</span>
         </div>
 
         <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
@@ -190,43 +197,70 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
           </select>
         </label>
 
-        <div style={{ display: "flex", gap: 12, marginTop: 8 }}>
-          <button
-            type="button"
-            onClick={onCancel}
-            style={{
-              flex: 1,
-              padding: "10px 14px",
-              borderRadius: 999,
-              border: "1px solid #334155",
-              background: "#111827",
-              color: "#cbd5f5",
-              fontWeight: 600,
-              cursor: "pointer",
-            }}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={confirmDisabled}
-            style={{
-              flex: 1,
-              padding: "10px 14px",
-              borderRadius: 999,
-              border: "1px solid #1b4332",
-              background: confirmDisabled ? "#1f2532" : "#27E0B0",
-              color: confirmDisabled ? "#475569" : "#0f1420",
-              fontWeight: 700,
-              cursor: confirmDisabled ? "not-allowed" : "pointer",
-              boxShadow: confirmDisabled
-                ? "none"
-                : "0 8px 18px rgba(15, 32, 38, 0.45)",
-            }}
-          >
-            Add Track
-          </button>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            marginTop: 8,
+          }}
+        >
+          {isEditMode && onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              style={{
+                width: "100%",
+                padding: "10px 14px",
+                borderRadius: 999,
+                border: "1px solid #4c1d24",
+                background: "#E02749",
+                color: "#e6f2ff",
+                fontWeight: 700,
+                cursor: "pointer",
+              }}
+            >
+              Remove Track
+            </button>
+          )}
+          <div style={{ display: "flex", gap: 12 }}>
+            <button
+              type="button"
+              onClick={onCancel}
+              style={{
+                flex: 1,
+                padding: "10px 14px",
+                borderRadius: 999,
+                border: "1px solid #334155",
+                background: "#111827",
+                color: "#cbd5f5",
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={confirmDisabled}
+              style={{
+                flex: 1,
+                padding: "10px 14px",
+                borderRadius: 999,
+                border: "1px solid #1b4332",
+                background: confirmDisabled ? "#1f2532" : "#27E0B0",
+                color: confirmDisabled ? "#475569" : "#0f1420",
+                fontWeight: 700,
+                cursor: confirmDisabled ? "not-allowed" : "pointer",
+                boxShadow: confirmDisabled
+                  ? "none"
+                  : "0 8px 18px rgba(15, 32, 38, 0.45)",
+              }}
+            >
+              {confirmLabel}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -1,0 +1,235 @@
+import type { FC } from "react";
+
+import type { Pack } from "./packs";
+import { getCharacterOptions } from "./addTrackOptions";
+import { formatInstrumentLabel } from "./utils/instrument";
+
+interface AddTrackModalProps {
+  isOpen: boolean;
+  packs: Pack[];
+  selectedPackId: string;
+  selectedInstrumentId: string;
+  selectedCharacterId: string;
+  selectedPresetId: string | null;
+  onSelectPack: (packId: string) => void;
+  onSelectInstrument: (instrumentId: string) => void;
+  onSelectCharacter: (characterId: string) => void;
+  onSelectPreset: (presetId: string | null) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export const AddTrackModal: FC<AddTrackModalProps> = ({
+  isOpen,
+  packs,
+  selectedPackId,
+  selectedInstrumentId,
+  selectedCharacterId,
+  selectedPresetId,
+  onSelectPack,
+  onSelectInstrument,
+  onSelectCharacter,
+  onSelectPreset,
+  onCancel,
+  onConfirm,
+}) => {
+  if (!isOpen) return null;
+
+  const pack = packs.find((p) => p.id === selectedPackId) ?? packs[0] ?? null;
+  const instrumentOptions = pack
+    ? Object.keys(pack.instruments)
+    : [];
+  const characterOptions = selectedInstrumentId
+    ? getCharacterOptions(pack?.id ?? "", selectedInstrumentId)
+    : [];
+  const presetOptions = pack
+    ? pack.chunks.filter((chunk) => chunk.instrument === selectedInstrumentId)
+    : [];
+
+  const confirmDisabled = !pack || !selectedInstrumentId;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(12, 18, 30, 0.75)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 16,
+        zIndex: 30,
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: 420,
+          background: "#1b2231",
+          borderRadius: 16,
+          border: "1px solid #2f384a",
+          boxShadow: "0 24px 48px rgba(5, 9, 18, 0.65)",
+          padding: 24,
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+          color: "#e6f2ff",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span style={{ fontSize: 20, fontWeight: 700 }}>Add Track</span>
+          <span style={{ fontSize: 13, color: "#94a3b8" }}>
+            Choose a sound pack, instrument, character, and optional preset to
+            start a new groove.
+          </span>
+        </div>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: 13, color: "#cbd5f5" }}>Sound Pack</span>
+          <select
+            value={pack?.id ?? ""}
+            onChange={(event) => onSelectPack(event.target.value)}
+            style={{
+              padding: "8px 10px",
+              borderRadius: 10,
+              border: "1px solid #334155",
+              background: "#111827",
+              color: "#e6f2ff",
+            }}
+          >
+            {packs.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: 13, color: "#cbd5f5" }}>Instrument</span>
+          <select
+            value={selectedInstrumentId}
+            onChange={(event) => onSelectInstrument(event.target.value)}
+            style={{
+              padding: "8px 10px",
+              borderRadius: 10,
+              border: "1px solid #334155",
+              background: "#111827",
+              color: selectedInstrumentId ? "#e6f2ff" : "#64748b",
+            }}
+          >
+            {instrumentOptions.length === 0 ? (
+              <option value="" disabled>
+                No instruments available
+              </option>
+            ) : (
+              instrumentOptions.map((instrument) => (
+                <option key={instrument} value={instrument}>
+                  {formatInstrumentLabel(instrument)}
+                </option>
+              ))
+            )}
+          </select>
+        </label>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: 13, color: "#cbd5f5" }}>Character</span>
+          <select
+            value={selectedCharacterId}
+            onChange={(event) => onSelectCharacter(event.target.value)}
+            disabled={characterOptions.length === 0}
+            style={{
+              padding: "8px 10px",
+              borderRadius: 10,
+              border: "1px solid #334155",
+              background: "#111827",
+              color:
+                characterOptions.length > 0 ? "#e6f2ff" : "#64748b",
+            }}
+          >
+            {characterOptions.length === 0 ? (
+              <option value="" disabled>
+                No characters
+              </option>
+            ) : (
+              characterOptions.map((character) => (
+                <option key={character.id} value={character.id}>
+                  {character.name}
+                </option>
+              ))
+            )}
+          </select>
+        </label>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: 13, color: "#cbd5f5" }}>
+            Pattern Preset (optional)
+          </span>
+          <select
+            value={selectedPresetId ?? ""}
+            onChange={(event) =>
+              onSelectPreset(event.target.value ? event.target.value : null)
+            }
+            style={{
+              padding: "8px 10px",
+              borderRadius: 10,
+              border: "1px solid #334155",
+              background: "#111827",
+              color:
+                selectedPresetId || presetOptions.length > 0
+                  ? "#e6f2ff"
+                  : "#64748b",
+            }}
+          >
+            <option value="">None</option>
+            {presetOptions.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div style={{ display: "flex", gap: 12, marginTop: 8 }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            style={{
+              flex: 1,
+              padding: "10px 14px",
+              borderRadius: 999,
+              border: "1px solid #334155",
+              background: "#111827",
+              color: "#cbd5f5",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={confirmDisabled}
+            style={{
+              flex: 1,
+              padding: "10px 14px",
+              borderRadius: 999,
+              border: "1px solid #1b4332",
+              background: confirmDisabled ? "#1f2532" : "#27E0B0",
+              color: confirmDisabled ? "#475569" : "#0f1420",
+              fontWeight: 700,
+              cursor: confirmDisabled ? "not-allowed" : "pointer",
+              boxShadow: confirmDisabled
+                ? "none"
+                : "0 8px 18px rgba(15, 32, 38, 0.45)",
+            }}
+          >
+            Add Track
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -719,7 +719,6 @@ export default function App() {
               setEditing={setEditing}
               setTracks={setTracks}
               packIndex={packIndex}
-              setPackIndex={setPackIndex}
               patternGroups={patternGroups}
               setPatternGroups={setPatternGroups}
               selectedGroupId={selectedGroupId}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as Tone from "tone";
 
 import { LoopStrip, type LoopStripHandle } from "./LoopStrip";
@@ -11,6 +11,8 @@ import { SongView } from "./SongView";
 import { PatternPlaybackManager } from "./PatternPlaybackManager";
 import type { PatternGroup, SongRow } from "./song";
 import { createPatternGroupId, createSongRow } from "./song";
+import { AddTrackModal } from "./AddTrackModal";
+import { getCharacterOptions } from "./addTrackOptions";
 
 const createInitialPatternGroup = (): PatternGroup => ({
   id: createPatternGroupId(),
@@ -19,6 +21,42 @@ const createInitialPatternGroup = (): PatternGroup => ({
 });
 
 type Subdivision = "16n" | "8n" | "4n";
+
+interface AddTrackModalState {
+  isOpen: boolean;
+  packId: string;
+  instrumentId: string;
+  characterId: string;
+  presetId: string | null;
+}
+
+const createDefaultAddTrackState = (
+  packIdx: number
+): AddTrackModalState => {
+  const pack = packs[packIdx];
+  if (!pack) {
+    return {
+      isOpen: false,
+      packId: "",
+      instrumentId: "",
+      characterId: "",
+      presetId: null,
+    };
+  }
+  const instrumentId = Object.keys(pack.instruments)[0] ?? "";
+  const characters = instrumentId
+    ? getCharacterOptions(pack.id, instrumentId)
+    : [];
+  const characterId = characters[0]?.id ?? "";
+  const preset = pack.chunks.find((chunk) => chunk.instrument === instrumentId);
+  return {
+    isOpen: false,
+    packId: pack.id,
+    instrumentId,
+    characterId,
+    presetId: preset ? preset.id : null,
+  };
+};
 
 export default function App() {
   const [started, setStarted] = useState(false);
@@ -62,6 +100,131 @@ export default function App() {
   const [pendingLoopStripAction, setPendingLoopStripAction] = useState<
     "openLibrary" | "addTrack" | null
   >(null);
+  const [addTrackModalState, setAddTrackModalState] = useState<AddTrackModalState>(
+    () => createDefaultAddTrackState(packIndex)
+  );
+
+  const openAddTrackModal = useCallback(() => {
+    setAddTrackModalState(() => {
+      const pack = packs[packIndex];
+      if (!pack) {
+        return {
+          isOpen: true,
+          packId: "",
+          instrumentId: "",
+          characterId: "",
+          presetId: null,
+        };
+      }
+      const instrumentId = Object.keys(pack.instruments)[0] ?? "";
+      const characters = instrumentId
+        ? getCharacterOptions(pack.id, instrumentId)
+        : [];
+      const characterId = characters[0]?.id ?? "";
+      const preset = pack.chunks.find(
+        (chunk) => chunk.instrument === instrumentId
+      );
+      return {
+        isOpen: true,
+        packId: pack.id,
+        instrumentId,
+        characterId,
+        presetId: preset ? preset.id : null,
+      };
+    });
+  }, [packIndex]);
+
+  const closeAddTrackModal = useCallback(() => {
+    setAddTrackModalState((state) => ({ ...state, isOpen: false }));
+  }, []);
+
+  const handleSelectAddTrackPack = useCallback(
+    (packId: string) => {
+      const index = packs.findIndex((p) => p.id === packId);
+      if (index >= 0 && index !== packIndex) {
+        setPackIndex(index);
+      }
+      setAddTrackModalState((state) => ({ ...state, packId }));
+    },
+    [packIndex, setPackIndex]
+  );
+
+  const handleSelectAddTrackInstrument = useCallback((instrumentId: string) => {
+    setAddTrackModalState((state) => ({ ...state, instrumentId }));
+  }, []);
+
+  const handleSelectAddTrackCharacter = useCallback((characterId: string) => {
+    setAddTrackModalState((state) => ({ ...state, characterId }));
+  }, []);
+
+  const handleSelectAddTrackPreset = useCallback((presetId: string | null) => {
+    setAddTrackModalState((state) => ({ ...state, presetId }));
+  }, []);
+
+  useEffect(() => {
+    if (!addTrackModalState.isOpen) return;
+    const pack = packs.find((p) => p.id === addTrackModalState.packId);
+    if (!pack) return;
+    const instrumentOptions = Object.keys(pack.instruments);
+    if (instrumentOptions.length === 0) {
+      if (
+        addTrackModalState.instrumentId !== "" ||
+        addTrackModalState.characterId !== "" ||
+        addTrackModalState.presetId !== null
+      ) {
+        setAddTrackModalState((state) => ({
+          ...state,
+          instrumentId: "",
+          characterId: "",
+          presetId: null,
+        }));
+      }
+      return;
+    }
+    if (!instrumentOptions.includes(addTrackModalState.instrumentId)) {
+      const nextInstrument = instrumentOptions[0];
+      const characters = getCharacterOptions(pack.id, nextInstrument);
+      const nextCharacter = characters[0]?.id ?? "";
+      const presetOptions = pack.chunks.filter(
+        (chunk) => chunk.instrument === nextInstrument
+      );
+      setAddTrackModalState((state) => ({
+        ...state,
+        instrumentId: nextInstrument,
+        characterId: nextCharacter,
+        presetId: presetOptions[0]?.id ?? null,
+      }));
+      return;
+    }
+    const characters = getCharacterOptions(
+      pack.id,
+      addTrackModalState.instrumentId
+    );
+    if (
+      characters.length > 0 &&
+      !characters.some(
+        (character) => character.id === addTrackModalState.characterId
+      )
+    ) {
+      setAddTrackModalState((state) => ({
+        ...state,
+        characterId: characters[0].id,
+      }));
+      return;
+    }
+    const presetOptions = pack.chunks.filter(
+      (chunk) => chunk.instrument === addTrackModalState.instrumentId
+    );
+    if (
+      addTrackModalState.presetId &&
+      !presetOptions.some((preset) => preset.id === addTrackModalState.presetId)
+    ) {
+      setAddTrackModalState((state) => ({
+        ...state,
+        presetId: presetOptions[0]?.id ?? null,
+      }));
+    }
+  }, [addTrackModalState]);
 
   useEffect(() => {
     if (started) Tone.Transport.bpm.value = bpm;
@@ -285,13 +448,13 @@ export default function App() {
       if (pendingLoopStripAction === "openLibrary") {
         handle.openSequenceLibrary();
       } else if (pendingLoopStripAction === "addTrack") {
-        handle.addTrack();
+        openAddTrackModal();
       }
       setPendingLoopStripAction(null);
     };
     frame = window.requestAnimationFrame(run);
     return () => window.cancelAnimationFrame(frame);
-  }, [pendingLoopStripAction, viewMode]);
+  }, [pendingLoopStripAction, viewMode, openAddTrackModal]);
 
   const initAudioGraph = async () => {
     await Tone.start(); // iOS unlock
@@ -355,8 +518,22 @@ export default function App() {
       setPendingLoopStripAction("addTrack");
       return;
     }
-    loopStripRef.current?.addTrack();
+    openAddTrackModal();
   };
+
+  const handleConfirmAddTrack = useCallback(() => {
+    if (!addTrackModalState.instrumentId) {
+      closeAddTrackModal();
+      return;
+    }
+    loopStripRef.current?.addTrackWithOptions({
+      packId: addTrackModalState.packId,
+      instrumentId: addTrackModalState.instrumentId,
+      characterId: addTrackModalState.characterId,
+      presetId: addTrackModalState.presetId,
+    });
+    closeAddTrackModal();
+  }, [addTrackModalState, closeAddTrackModal]);
 
   return (
     <div
@@ -372,6 +549,20 @@ export default function App() {
         flexDirection: "column"
       }}
     >
+      <AddTrackModal
+        isOpen={addTrackModalState.isOpen}
+        packs={packs}
+        selectedPackId={addTrackModalState.packId}
+        selectedInstrumentId={addTrackModalState.instrumentId}
+        selectedCharacterId={addTrackModalState.characterId}
+        selectedPresetId={addTrackModalState.presetId}
+        onSelectPack={handleSelectAddTrackPack}
+        onSelectInstrument={handleSelectAddTrackInstrument}
+        onSelectCharacter={handleSelectAddTrackCharacter}
+        onSelectPreset={handleSelectAddTrackPreset}
+        onCancel={closeAddTrackModal}
+        onConfirm={handleConfirmAddTrack}
+      />
       {!started ? (
         <div style={{ display: "grid", placeItems: "center", flex: 1 }}>
           <button
@@ -447,6 +638,7 @@ export default function App() {
               setPatternGroups={setPatternGroups}
               selectedGroupId={selectedGroupId}
               setSelectedGroupId={setSelectedGroupId}
+              onAddTrack={openAddTrackModal}
             />
           )}
           <div

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -15,7 +15,6 @@ import { packs } from "./packs";
 import { StepModal } from "./StepModal";
 import type { PatternGroup } from "./song";
 import { createPatternGroupId } from "./song";
-import { formatInstrumentLabel } from "./utils/instrument";
 
 const baseInstrumentColors: Record<string, string> = {
   kick: "#e74c3c",
@@ -37,9 +36,6 @@ const getTrackNumberLabel = (tracks: Track[], trackId: number) => {
   const number = index >= 0 ? index + 1 : trackId;
   return number.toString().padStart(2, "0");
 };
-
-const formatPitchDisplay = (value: number) =>
-  value > 0 ? `+${value}` : value.toString();
 
 const LABEL_WIDTH = 60;
 const ROW_HEIGHT = 40;
@@ -81,6 +77,8 @@ export interface LoopStripHandle {
   openSequenceLibrary: () => void;
   addTrack: () => void;
   addTrackWithOptions: (options: AddTrackRequest) => void;
+  updateTrackWithOptions: (trackId: number, options: AddTrackRequest) => void;
+  removeTrack: (trackId: number) => void;
 }
 
 interface LoopStripProps {
@@ -97,6 +95,7 @@ interface LoopStripProps {
   selectedGroupId: string | null;
   setSelectedGroupId: Dispatch<SetStateAction<string | null>>;
   onAddTrack: () => void;
+  onRequestTrackModal: (track: Track) => void;
 }
 
 /**
@@ -121,6 +120,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
       selectedGroupId,
       setSelectedGroupId,
       onAddTrack,
+      onRequestTrackModal,
     },
     ref
   ) {
@@ -129,15 +129,13 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
   const [stepEditing, setStepEditing] = useState<
     { trackId: number; index: number } | null
   >(null);
-  const [detailTrackId, setDetailTrackId] = useState<number | null>(null);
-  const [pendingTrackIds, setPendingTrackIds] = useState<number[]>([]);
   const [isSequenceLibraryOpen, setIsSequenceLibraryOpen] = useState(false);
   const swipeRef = useRef(0);
   const trackAreaRef = useRef<HTMLDivElement>(null);
   const pack = packs[packIndex];
   const instrumentOptions = Object.keys(pack.instruments);
   const canAddTrack = instrumentOptions.length > 0;
-  const addTrackEnabled = canAddTrack && detailTrackId === null;
+  const addTrackEnabled = canAddTrack;
   const selectedGroup = useMemo(() => {
     if (!selectedGroupId) return null;
     return patternGroups.find((group) => group.id === selectedGroupId) ?? null;
@@ -163,12 +161,10 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
     (group: PatternGroup | null) => {
       const cloned = group ? group.tracks.map((track) => cloneTrack(track)) : [];
       setTracks(cloned);
-      setPendingTrackIds([]);
       setEditing(null);
-      setDetailTrackId(null);
       setStepEditing(null);
     },
-    [setTracks, setPendingTrackIds, setEditing, setDetailTrackId, setStepEditing]
+    [setTracks, setEditing, setStepEditing]
   );
 
   const isCreatingGroup = groupEditor?.mode === "create";
@@ -214,21 +210,6 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
       }
     }
   }, [groupEditor, patternGroups]);
-
-  useEffect(() => {
-    if (detailTrackId === null) return;
-    if (!tracks.some((track) => track.id === detailTrackId)) {
-      setDetailTrackId(null);
-    }
-  }, [detailTrackId, tracks]);
-
-  useEffect(() => {
-    setPendingTrackIds((ids) => {
-      const activeIds = new Set(tracks.map((track) => track.id));
-      const filtered = ids.filter((id) => activeIds.has(id));
-      return filtered.length === ids.length ? ids : filtered;
-    });
-  }, [tracks]);
 
   // Schedule a step advance on each 16th note when audio has started.
   useEffect(() => {
@@ -295,17 +276,12 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
       ];
     });
     if (createdId !== null) {
-      const newId = createdId;
-      setPendingTrackIds((ids) => [...ids, newId]);
-      setEditing(newId);
-    setDetailTrackId(newId);
+      setEditing(createdId);
     }
   }, [
     addTrackEnabled,
     setTracks,
-    setPendingTrackIds,
     setEditing,
-    setDetailTrackId,
   ]);
 
   const handleAddTrackWithOptions = useCallback(
@@ -357,20 +333,79 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
         ];
       });
       if (createdId !== null) {
-        const newId = createdId;
-        setPendingTrackIds((ids) => [...ids, newId]);
-        setEditing(newId);
-        setDetailTrackId(newId);
+        setEditing(createdId);
       }
     },
     [
       addTrackEnabled,
       pack,
       setTracks,
-      setPendingTrackIds,
       setEditing,
-      setDetailTrackId,
     ]
+  );
+
+  const handleUpdateTrackWithOptions = useCallback(
+    (
+      trackId: number,
+      { packId, instrumentId, characterId, presetId }: AddTrackRequest
+    ) => {
+      if (!instrumentId) return;
+      const activePack = pack.id === packId ? pack : packs.find((p) => p.id === packId);
+      if (!activePack || activePack.id !== pack.id) {
+        return;
+      }
+      setTracks((ts) =>
+        ts.map((t) => {
+          if (t.id !== trackId) return t;
+          const preset = presetId
+            ? activePack.chunks.find((chunk) => chunk.id === presetId)
+            : null;
+          const nextPattern: Chunk | null = preset
+            ? {
+                ...cloneChunk(preset),
+                id: `${preset.id}-${Date.now()}`,
+                instrument: instrumentId,
+                name: preset.name,
+              }
+            : t.pattern
+            ? { ...t.pattern, instrument: instrumentId }
+            : {
+                id: `track-${trackId}-${Date.now()}`,
+                name: t.name,
+                instrument: instrumentId,
+                steps: Array(16).fill(0),
+                velocities: Array(16).fill(1),
+                pitches: Array(16).fill(0),
+              };
+          const nextName = preset ? preset.name : t.name;
+          return {
+            ...t,
+            name: nextName,
+            instrument: instrumentId as keyof TriggerMap,
+            pattern: nextPattern,
+            source: {
+              packId,
+              instrumentId,
+              characterId,
+              presetId: presetId ?? null,
+            },
+          };
+        })
+      );
+      setEditing(trackId);
+    },
+    [pack, setTracks, setEditing]
+  );
+
+  const removeTrack = useCallback(
+    (trackId: number) => {
+      setTracks((ts) => ts.filter((t) => t.id !== trackId));
+      setEditing((current) => (current === trackId ? null : current));
+      setStepEditing((current) =>
+        current && current.trackId === trackId ? null : current
+      );
+    },
+    [setTracks, setEditing, setStepEditing]
   );
 
   useImperativeHandle(
@@ -380,8 +415,16 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
       addTrack: () => handleAddTrack(),
       addTrackWithOptions: (options: AddTrackRequest) =>
         handleAddTrackWithOptions(options),
+      updateTrackWithOptions: (trackId: number, options: AddTrackRequest) =>
+        handleUpdateTrackWithOptions(trackId, options),
+      removeTrack: (trackId: number) => removeTrack(trackId),
     }),
-    [handleAddTrack, handleAddTrackWithOptions]
+    [
+      handleAddTrack,
+      handleAddTrackWithOptions,
+      handleUpdateTrackWithOptions,
+      removeTrack,
+    ]
   );
 
   const handleToggleMute = (trackId: number) => {
@@ -395,79 +438,6 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
           : t
       )
     );
-  };
-
-  const showTrackDetails = (trackId: number) => {
-    setDetailTrackId(trackId);
-    setEditing(trackId);
-  };
-
-  const handleInstrumentChange = (trackId: number, value: string) => {
-    setTracks((ts) =>
-      ts.map((t) => {
-        if (t.id !== trackId) return t;
-        if (!value) {
-          return {
-            ...t,
-            instrument: "",
-            pattern: t.pattern ? { ...t.pattern, instrument: "" } : t.pattern,
-            source: t.source
-              ? { ...t.source, instrumentId: "", presetId: null }
-              : t.source,
-          };
-        }
-        const instrument = value as keyof TriggerMap;
-        const pattern = t.pattern
-          ? { ...t.pattern, instrument }
-          : t.pattern;
-        return {
-          ...t,
-          instrument,
-          pattern,
-          source: t.source
-            ? { ...t.source, instrumentId: value, presetId: null }
-            : t.source,
-        };
-      })
-    );
-  };
-
-  const handlePresetLoad = (trackId: number, chunkId: string) => {
-    if (!chunkId) return;
-    const chunk = pack.chunks.find((c) => c.id === chunkId);
-    if (!chunk) return;
-    loadChunk(chunk, trackId);
-  };
-
-  const hideTrackDetails = () => setDetailTrackId(null);
-
-  const removeTrack = (trackId: number) => {
-    setTracks((ts) => ts.filter((t) => t.id !== trackId));
-    setPendingTrackIds((ids) => {
-      if (!ids.includes(trackId)) return ids;
-      return ids.filter((id) => id !== trackId);
-    });
-    setEditing((current) => (current === trackId ? null : current));
-    setDetailTrackId((current) => (current === trackId ? null : current));
-    setStepEditing((current) =>
-      current && current.trackId === trackId ? null : current
-    );
-  };
-
-  const handleCancelNewTrack = (trackId: number) => {
-    removeTrack(trackId);
-  };
-
-  const handleDeleteTrack = (trackId: number) => {
-    removeTrack(trackId);
-  };
-
-  const handleCompleteTrack = (trackId: number) => {
-    setPendingTrackIds((ids) => {
-      if (!ids.includes(trackId)) return ids;
-      return ids.filter((id) => id !== trackId);
-    });
-    hideTrackDetails();
   };
 
   const openCreateGroup = () => {
@@ -643,69 +613,6 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
     );
   };
 
-  const updatePatternControls = (
-    trackId: number,
-    props: { velocity?: number; pitch?: number }
-  ) => {
-    setTracks((ts) =>
-      ts.map((t) => {
-        if (t.id === trackId && t.pattern) {
-          const velocities = t.pattern.velocities
-            ? t.pattern.velocities.slice()
-            : Array(16).fill(1);
-          const pitches = t.pattern.pitches
-            ? t.pattern.pitches.slice()
-            : Array(16).fill(0);
-          if (props.velocity !== undefined)
-            velocities.fill(props.velocity);
-          if (props.pitch !== undefined) pitches.fill(props.pitch);
-          return {
-            ...t,
-            pattern: { ...t.pattern, velocities, pitches },
-          };
-        }
-        return t;
-      })
-    );
-  };
-
-
-  const loadChunk = (chunk: Chunk, targetTrackId: number) => {
-    setTracks((ts) => {
-      const exists = ts.some((t) => t.id === targetTrackId);
-      if (!exists) return ts;
-      return ts.map((t) => {
-        if (t.id !== targetTrackId) return t;
-        const pattern = {
-          ...cloneChunk(chunk),
-          id: `${chunk.id}-${Date.now()}`,
-          instrument: chunk.instrument,
-        };
-        const nextSource = t.source
-          ? {
-              ...t.source,
-              instrumentId: chunk.instrument,
-              presetId: chunk.id,
-            }
-          : {
-              packId: pack.id,
-              instrumentId: chunk.instrument,
-              characterId: `${chunk.instrument}-default`,
-              presetId: chunk.id,
-            };
-        return {
-          ...t,
-          name: chunk.name,
-          instrument: chunk.instrument as keyof TriggerMap,
-          pattern,
-          source: nextSource,
-        };
-      });
-    });
-    setEditing(targetTrackId);
-    setDetailTrackId(targetTrackId);
-  };
-
   return (
     <div
       style={{
@@ -832,10 +739,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
           const color = getInstrumentColor(t.instrument);
           const isMuted = t.muted;
           const isEditing = editing === t.id;
-          const isPending = pendingTrackIds.includes(t.id);
           const trackLabel = getTrackNumberLabel(tracks, t.id);
-          const velocityValue = t.pattern?.velocities?.[0] ?? 1;
-          const pitchValue = t.pattern?.pitches?.[0] ?? 0;
 
           const handleLabelPointerDown = (
             event: ReactPointerEvent<HTMLDivElement>
@@ -845,7 +749,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
             if (labelTimer) window.clearTimeout(labelTimer);
             labelTimer = window.setTimeout(() => {
               longPressTriggered = true;
-              showTrackDetails(t.id);
+              onRequestTrackModal(t);
             }, 500);
           };
 
@@ -1001,334 +905,8 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                       New Pattern
                     </button>
                   )}
-                  {detailTrackId === t.id && (
-                    <div
-                      style={{
-                        position: "absolute",
-                        inset: 0,
-                        zIndex: 1,
-                        display: "flex",
-                        flexDirection: "column",
-                        justifyContent: "center",
-                        padding: "8px 12px",
-                        gap: 12,
-                        background: "rgba(17, 24, 39, 0.95)",
-                        border: "1px solid #2a3344",
-                        borderRadius: 6,
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: "flex",
-                          gap: 12,
-                          width: "100%",
-                          flexWrap: "nowrap",
-                          alignItems: "center",
-                        }}
-                      >
-                        <select
-                          value={t.instrument}
-                          onChange={(event) =>
-                            handleInstrumentChange(t.id, event.target.value)
-                          }
-                          aria-label="Select instrument"
-                          style={{
-                            flex: "1 1 0%",
-                            minWidth: 0,
-                            padding: 6,
-                            borderRadius: 6,
-                            border: "1px solid #333",
-                            background: "#1f2532",
-                            color: t.instrument ? "#e6f2ff" : "#64748b",
-                          }}
-                        >
-                          <option value="" disabled>
-                            Select instrument
-                          </option>
-                          {instrumentOptions.map((instrument) => (
-                            <option key={instrument} value={instrument}>
-                              {formatInstrumentLabel(instrument)}
-                            </option>
-                          ))}
-                        </select>
-                        <select
-                          value=""
-                          onChange={(event) =>
-                            handlePresetLoad(t.id, event.target.value)
-                          }
-                          aria-label="Preset (optional)"
-                          disabled={!t.instrument}
-                          style={{
-                            flex: "1 1 0%",
-                            minWidth: 0,
-                            padding: 6,
-                            borderRadius: 6,
-                            border: "1px solid #333",
-                            background: "#1f2532",
-                            color: t.instrument ? "#e6f2ff" : "#475569",
-                            opacity: t.instrument ? 1 : 0.5,
-                          }}
-                        >
-                          <option value="">Preset (optional)</option>
-                          {pack.chunks
-                            .filter((chunk) => chunk.instrument === t.instrument)
-                            .map((chunk) => (
-                              <option key={chunk.id} value={chunk.id}>
-                                {chunk.name}
-                              </option>
-                            ))}
-                        </select>
-                        <div
-                          style={{
-                            display: "flex",
-                            gap: 8,
-                            flexShrink: 0,
-                          }}
-                        >
-                          {isPending ? (
-                            <>
-                              <button
-                                type="button"
-                                onClick={() => handleCancelNewTrack(t.id)}
-                                aria-label="Cancel new track"
-                                title="Cancel new track"
-                                style={{
-                                  width: 36,
-                                  height: 36,
-                                  borderRadius: 6,
-                                  border: "1px solid #333",
-                                  background: "#1f2532",
-                                  color: "#e6f2ff",
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  cursor: "pointer",
-                                }}
-                              >
-                                <span
-                                  className="material-symbols-outlined"
-                                  style={{ fontSize: 20 }}
-                                >
-                                  close
-                                </span>
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() => handleCompleteTrack(t.id)}
-                                disabled={!t.instrument}
-                                aria-label="Done editing track"
-                                title="Done editing track"
-                                style={{
-                                  width: 36,
-                                  height: 36,
-                                  borderRadius: 6,
-                                  border: "1px solid #333",
-                                  background: t.instrument ? "#27E0B0" : "#1f2532",
-                                  color: t.instrument ? "#0f1420" : "#475569",
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  cursor: t.instrument ? "pointer" : "not-allowed",
-                                }}
-                              >
-                                <span
-                                  className="material-symbols-outlined"
-                                  style={{ fontSize: 20 }}
-                                >
-                                  check
-                                </span>
-                              </button>
-                            </>
-                          ) : (
-                            <>
-                              <button
-                                type="button"
-                                onClick={() => handleCompleteTrack(t.id)}
-                                aria-label="Done editing track"
-                                title="Done editing track"
-                                style={{
-                                  width: 36,
-                                  height: 36,
-                                  borderRadius: 6,
-                                  border: "1px solid #333",
-                                  background: "#27E0B0",
-                                  color: "#0f1420",
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  cursor: "pointer",
-                                }}
-                              >
-                                <span
-                                  className="material-symbols-outlined"
-                                  style={{ fontSize: 20 }}
-                                >
-                                  check
-                                </span>
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() => handleDeleteTrack(t.id)}
-                                aria-label="Delete track"
-                                title="Delete track"
-                                style={{
-                                  width: 36,
-                                  height: 36,
-                                  borderRadius: 6,
-                                  border: "1px solid #333",
-                                  background: "#1f2532",
-                                  color: "#f87171",
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  cursor: "pointer",
-                                }}
-                              >
-                                <span
-                                  className="material-symbols-outlined"
-                                  style={{ fontSize: 20 }}
-                                >
-                                  delete
-                                </span>
-                              </button>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  )}
                 </div>
               </div>
-              {detailTrackId === t.id && (
-                <div
-                  style={{
-                    marginLeft: LABEL_WIDTH,
-                    marginTop: 6,
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 8,
-                  }}
-                >
-                  <div
-                    style={{
-                      padding: 12,
-                      background: "rgba(15, 21, 34, 0.95)",
-                      borderRadius: 8,
-                      border: "1px solid #333",
-                      boxShadow: "0 8px 18px rgba(8, 12, 20, 0.6)",
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 12,
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: "flex",
-                        flexWrap: "wrap",
-                        gap: 12,
-                        alignItems: "center",
-                      }}
-                    >
-                      <label
-                        style={{
-                          flex: "1 1 260px",
-                          minWidth: 0,
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 8,
-                          fontSize: 12,
-                          color: t.pattern ? "#94a3b8" : "#475569",
-                        }}
-                      >
-                        <span
-                          className="material-symbols-outlined"
-                          style={{ fontSize: 18 }}
-                          aria-hidden="true"
-                        >
-                          speed
-                        </span>
-                        <input
-                          type="range"
-                          min={0}
-                          max={1}
-                          step={0.01}
-                          value={velocityValue}
-                          onChange={(event) =>
-                            updatePatternControls(t.id, {
-                              velocity: Number(event.target.value),
-                            })
-                          }
-                          style={{
-                            flex: 1,
-                            opacity: t.pattern ? 1 : 0.4,
-                            cursor: t.pattern ? "pointer" : "not-allowed",
-                          }}
-                          aria-label="Velocity"
-                          title="Velocity"
-                          disabled={!t.pattern}
-                        />
-                        <span
-                          style={{
-                            width: 48,
-                            textAlign: "right",
-                            color: t.pattern ? "#94a3b8" : "#475569",
-                          }}
-                        >
-                          {velocityValue.toFixed(2)}
-                        </span>
-                      </label>
-                      <label
-                        style={{
-                          flex: "1 1 260px",
-                          minWidth: 0,
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 8,
-                          fontSize: 12,
-                          color: t.pattern ? "#94a3b8" : "#475569",
-                        }}
-                      >
-                        <span
-                          className="material-symbols-outlined"
-                          style={{ fontSize: 18 }}
-                          aria-hidden="true"
-                        >
-                          music_note
-                        </span>
-                        <input
-                          type="range"
-                          min={-12}
-                          max={12}
-                          step={1}
-                          value={pitchValue}
-                          onChange={(event) =>
-                            updatePatternControls(t.id, {
-                              pitch: Number(event.target.value),
-                            })
-                          }
-                          style={{
-                            flex: 1,
-                            opacity: t.pattern ? 1 : 0.4,
-                            cursor: t.pattern ? "pointer" : "not-allowed",
-                          }}
-                          aria-label="Pitch"
-                          title="Pitch"
-                          disabled={!t.pattern}
-                        />
-                        <span
-                          style={{
-                            width: 48,
-                            textAlign: "right",
-                            color: t.pattern ? "#94a3b8" : "#475569",
-                          }}
-                        >
-                          {formatPitchDisplay(pitchValue)}
-                        </span>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              )}
             </div>
           );
         })}

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -89,7 +89,6 @@ interface LoopStripProps {
   setEditing: Dispatch<SetStateAction<number | null>>;
   setTracks: Dispatch<SetStateAction<Track[]>>;
   packIndex: number;
-  setPackIndex: Dispatch<SetStateAction<number>>;
   patternGroups: PatternGroup[];
   setPatternGroups: Dispatch<SetStateAction<PatternGroup[]>>;
   selectedGroupId: string | null;
@@ -114,7 +113,6 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
       setEditing,
       setTracks,
       packIndex,
-      setPackIndex,
       patternGroups,
       setPatternGroups,
       selectedGroupId,
@@ -687,26 +685,6 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
         >
           + Track
         </button>
-      </div>
-      <div style={{ marginBottom: 4 }}>
-        <select
-          value={packIndex}
-          onChange={(event) => setPackIndex(Number(event.target.value))}
-          style={{
-            width: "100%",
-            padding: 4,
-            borderRadius: 4,
-            background: "#121827",
-            color: "white",
-            border: "1px solid #333",
-          }}
-        >
-          {packs.map((p, i) => (
-            <option key={p.id} value={i}>
-              {p.name}
-            </option>
-          ))}
-        </select>
       </div>
       <div
         ref={trackAreaRef}

--- a/src/addTrackOptions.ts
+++ b/src/addTrackOptions.ts
@@ -1,0 +1,91 @@
+import { formatInstrumentLabel } from "./utils/instrument";
+
+export interface CharacterOption {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+type PackCharacterMap = Record<string, Record<string, CharacterOption[]>>;
+
+const PACK_CHARACTER_MAP: PackCharacterMap = {
+  phonk: {
+    kick: [
+      { id: "classic-808", name: "Classic 808" },
+      { id: "saturated-boom", name: "Saturated Boom" },
+    ],
+    snare: [
+      { id: "tight-snap", name: "Tight Snap" },
+      { id: "vinyl-crack", name: "Vinyl Crack" },
+    ],
+    hat: [
+      { id: "shufflin", name: "Shufflin' Hat" },
+      { id: "spray", name: "Spray Cymbal" },
+    ],
+    cowbell: [{ id: "club-bell", name: "Club Bell" }],
+  },
+  edm2000s: {
+    kick: [
+      { id: "trance-thump", name: "Trance Thump" },
+      { id: "sidechain", name: "Sidechain Pump" },
+    ],
+    snare: [
+      { id: "digital-snap", name: "Digital Snap" },
+      { id: "reverb-clap", name: "Reverb Clap" },
+    ],
+    hat: [
+      { id: "sparkle", name: "Sparkle Tick" },
+      { id: "driver", name: "Driver Hat" },
+    ],
+    bass: [
+      { id: "saw-pluck", name: "Saw Pluck" },
+      { id: "rolling-sub", name: "Rolling Sub" },
+    ],
+  },
+  kraftwerk: {
+    kick: [
+      { id: "motor-kick", name: "Motor Kick" },
+      { id: "analog-punch", name: "Analog Punch" },
+    ],
+    snare: [
+      { id: "machine-snare", name: "Machine Snare" },
+      { id: "air-lock", name: "Air Lock" },
+    ],
+    hat: [
+      { id: "robot-hat", name: "Robot Hat" },
+      { id: "metronome", name: "Metronome Hat" },
+    ],
+    bass: [
+      { id: "square-robot", name: "Square Robot" },
+      { id: "pulse-drive", name: "Pulse Drive" },
+    ],
+    chord: [
+      { id: "organ-pad", name: "Organ Pad" },
+      { id: "glass-wave", name: "Glass Wave" },
+    ],
+  },
+};
+
+const createFallbackCharacters = (instrumentId: string): CharacterOption[] => {
+  if (!instrumentId) return [];
+  return [
+    {
+      id: `${instrumentId}-default`,
+      name: formatInstrumentLabel(instrumentId),
+    },
+  ];
+};
+
+export const getCharacterOptions = (
+  packId: string,
+  instrumentId: string
+): CharacterOption[] => {
+  const pack = PACK_CHARACTER_MAP[packId];
+  if (!pack) return createFallbackCharacters(instrumentId);
+  const characters = pack[instrumentId];
+  if (!characters || characters.length === 0) {
+    return createFallbackCharacters(instrumentId);
+  }
+  return characters;
+};
+

--- a/src/packs/phonk.json
+++ b/src/packs/phonk.json
@@ -1,6 +1,6 @@
 {
   "id": "phonk",
-  "name": "Phonk Starter Pack",
+  "name": "Hip Hop",
   "instruments": {
     "kick": {
       "type": "MembraneSynth",
@@ -61,7 +61,7 @@
     }
   },
   "chunks": [
-    { "id": "phonk-kick", "name": "Heavy Kick", "instrument": "kick", "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0] },
+    { "id": "phonk-kick", "name": "Four on the Floor", "instrument": "kick", "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0] },
     { "id": "phonk-snare", "name": "Sharp Snare", "instrument": "snare", "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0] },
     { "id": "phonk-hat", "name": "Fast Hat", "instrument": "hat", "steps": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] },
     { "id": "phonk-cowbell", "name": "Cowbell", "instrument": "cowbell", "steps": [0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0] }

--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -14,10 +14,18 @@ export type TriggerMap = Record<
 
 export type TrackInstrument = keyof TriggerMap | "";
 
+export interface TrackSource {
+  packId: string;
+  instrumentId: string;
+  characterId: string;
+  presetId?: string | null;
+}
+
 export interface Track {
   id: number;
   name: string;
   instrument: TrackInstrument;
   pattern: Chunk | null;
   muted: boolean;
+  source?: TrackSource;
 }

--- a/src/utils/instrument.ts
+++ b/src/utils/instrument.ts
@@ -1,0 +1,6 @@
+export const formatInstrumentLabel = (value: string) =>
+  value
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+


### PR DESCRIPTION
## Summary
- add an AddTrackModal with sound pack, instrument, character, and preset selectors
- connect the modal to App state and LoopStrip so confirmed selections create fully configured tracks
- introduce character metadata, shared instrument label helper, and refresh the Hip Hop pack defaults

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c9fea84c5c8328946a1f5fefdbf75f