### PR TITLE
Revamp arp instrument with tonal-center generation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,6 +126,10 @@ export default function App() {
 
   const canClearSelectedTrack = Boolean(selectedTrack?.pattern);
 
+  const handleToggleRecording = useCallback(() => {
+    setIsRecording((prev) => !prev);
+  }, []);
+
   const openAddTrackModal = useCallback(() => {
     setAddTrackModalState(() => {
       const pack = packs[packIndex];
@@ -600,6 +604,14 @@ export default function App() {
     [updateTrackPattern]
   );
 
+  const handleClearSelectedTrack = useCallback(() => {
+    if (!selectedTrack || !canClearSelectedTrack) return;
+    if (!window.confirm("Clear all steps for this track?")) {
+      return;
+    }
+    clearTrackPattern(selectedTrack.id);
+  }, [selectedTrack, canClearSelectedTrack, clearTrackPattern]);
+
   const initAudioGraph = async () => {
     await Tone.start(); // iOS unlock
     const synth = new Tone.PolySynth(Tone.Synth, {
@@ -628,10 +640,11 @@ export default function App() {
     setCurrentSectionIndex(0);
   };
 
-  const handlePlayPause = () => {
+  const handlePlayStop = () => {
     if (isPlaying) {
-      Tone.Transport.pause();
+      Tone.Transport.stop();
       setIsPlaying(false);
+      setCurrentSectionIndex(0);
       return;
     }
     if (Tone.Transport.state === "stopped") {
@@ -639,12 +652,6 @@ export default function App() {
     }
     Tone.Transport.start();
     setIsPlaying(true);
-  };
-
-  const handleStop = () => {
-    Tone.Transport.stop();
-    setIsPlaying(false);
-    setCurrentSectionIndex(0);
   };
 
   const handleOpenSequenceLibrary = () => {
@@ -854,57 +861,68 @@ export default function App() {
                           gap: 10,
                         }}
                       >
-                        {selectedTrack && canRecordSelectedTrack ? (
-                          <button
-                            onClick={() =>
-                              setIsRecording((prev) => !prev)
-                            }
-                            style={{
-                              padding: "4px 12px",
-                              borderRadius: 4,
-                              border: "1px solid #2a3344",
-                              background: isRecording ? "#E02749" : "#27E0B0",
-                              color: isRecording ? "#ffe4e6" : "#1F2532",
-                              cursor: "pointer",
-                              fontWeight: 600,
-                              fontSize: 12,
-                              letterSpacing: 0.6,
-                              textTransform: "uppercase",
-                            }}
-                          >
-                            {isRecording ? "Recording" : "Record"}
-                          </button>
-                        ) : null}
                         <button
-                          onClick={() =>
-                            selectedTrack && clearTrackPattern(selectedTrack.id)
-                          }
-                          disabled={!canClearSelectedTrack}
-                          style={{
-                            padding: "4px 12px",
-                            borderRadius: 4,
-                            border: "1px solid #2a3344",
-                            background: canClearSelectedTrack
-                              ? "#111a2c"
-                              : "#0b121f",
-                            color: canClearSelectedTrack ? "#e2e8f0" : "#475569",
-                            cursor: canClearSelectedTrack ? "pointer" : "not-allowed",
-                          }}
-                        >
-                          Clear
-                        </button>
-                        <button
+                          aria-label="Done editing"
                           onClick={() => setEditing(null)}
                           style={{
-                            padding: "4px 12px",
-                            borderRadius: 4,
+                            width: 40,
+                            height: 40,
+                            borderRadius: 8,
                             border: "1px solid #333",
                             background: "#27E0B0",
                             color: "#1F2532",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
                             cursor: "pointer",
                           }}
                         >
-                          Done
+                          <span className="material-symbols-outlined">check</span>
+                        </button>
+                        {selectedTrack && canRecordSelectedTrack ? (
+                          <button
+                            aria-label={
+                              isRecording ? "Stop recording" : "Start recording"
+                            }
+                            onClick={handleToggleRecording}
+                            style={{
+                              width: 40,
+                              height: 40,
+                              borderRadius: 8,
+                              border: "1px solid #333",
+                              background: isRecording ? "#E02749" : "#1f2532",
+                              color: isRecording ? "#ffe4e6" : "#e6f2ff",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              cursor: "pointer",
+                            }}
+                          >
+                            <span className="material-symbols-outlined">
+                              fiber_manual_record
+                            </span>
+                          </button>
+                        ) : null}
+                        <button
+                          aria-label="Clear track"
+                          onClick={handleClearSelectedTrack}
+                          disabled={!canClearSelectedTrack}
+                          style={{
+                            width: 40,
+                            height: 40,
+                            borderRadius: 8,
+                            border: "1px solid #333",
+                            background: canClearSelectedTrack
+                              ? "#1f2532"
+                              : "#111827",
+                            color: canClearSelectedTrack ? "#e6f2ff" : "#475569",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            cursor: canClearSelectedTrack ? "pointer" : "not-allowed",
+                          }}
+                        >
+                          <span className="material-symbols-outlined">backspace</span>
                         </button>
                       </div>
                     ) : (
@@ -958,49 +976,24 @@ export default function App() {
                   />
                   <div style={{ display: "flex", gap: 12 }}>
                     <button
-                      aria-label={isPlaying ? "Pause" : "Play"}
-                      onPointerDown={handlePlayPause}
+                      aria-label={isPlaying ? "Stop" : "Play"}
+                      onPointerDown={handlePlayStop}
                       onPointerUp={(e) => e.currentTarget.blur()}
                       style={{
-                        width: 40,
-                        height: 40,
+                        width: 44,
+                        height: 44,
                         borderRadius: 8,
                         border: "1px solid #333",
-                        background: "#27E0B0",
-                        color: "#1F2532",
+                        background: isPlaying ? "#E02749" : "#27E0B0",
+                        color: isPlaying ? "#ffe4e6" : "#1F2532",
                         display: "flex",
                         alignItems: "center",
                         justifyContent: "center",
-                        fontSize: 20,
+                        fontSize: 24,
                       }}
                     >
                       <span className="material-symbols-outlined">
-                        {isPlaying ? "pause" : "play_arrow"}
-                      </span>
-                    </button>
-                    <button
-                      aria-label="Stop"
-                      onPointerDown={handleStop}
-                      onPointerUp={(e) => e.currentTarget.blur()}
-                      style={{
-                        width: 40,
-                        height: 40,
-                        borderRadius: 8,
-                        border: "1px solid #333",
-                        background: "#E02749",
-                        color: "#e6f2ff",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        fontSize: 40,
-                        padding: 0,
-                      }}
-                    >
-                      <span
-                        className="material-symbols-outlined"
-                        style={{ lineHeight: 1, width: "100%", height: "100%" }}
-                      >
-                        stop
+                        {isPlaying ? "stop" : "play_arrow"}
                       </span>
                     </button>
                   </div>
@@ -1060,8 +1053,7 @@ export default function App() {
                 isPlaying={isPlaying}
                 bpm={bpm}
                 setBpm={setBpm}
-                onPlayPause={handlePlayPause}
-                onStop={handleStop}
+                onToggleTransport={handlePlayStop}
                 selectedGroupId={selectedGroupId}
                 onOpenSequenceLibrary={handleOpenSequenceLibrary}
                 onAddTrack={handleAddTrackRequest}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -341,7 +341,14 @@ export default function App() {
     setSongRows([createSongRow()]);
     setCurrentSectionIndex(0);
     if (!started) return;
-    Object.values(instrumentRefs.current).forEach((inst) => inst.dispose?.());
+    const disposed = new Set<ToneInstrument>();
+    Object.values(instrumentRefs.current).forEach((inst) => {
+      if (!inst || inst === noteRef.current || disposed.has(inst)) {
+        return;
+      }
+      inst.dispose?.();
+      disposed.add(inst);
+    });
     instrumentRefs.current = {};
     const newTriggers: TriggerMap = {};
     Object.entries(pack.instruments).forEach(([name, spec]) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ const CONTROL_BUTTON_SIZE = 44;
 const controlButtonBaseStyle: CSSProperties = {
   width: CONTROL_BUTTON_SIZE,
   height: CONTROL_BUTTON_SIZE,
-  borderRadius: 8,
+  borderRadius: CONTROL_BUTTON_SIZE / 2,
   border: "1px solid #333",
   display: "flex",
   alignItems: "center",
@@ -937,7 +937,7 @@ export default function App() {
                             className="material-symbols-outlined"
                             style={controlIconStyle}
                           >
-                            delete
+                            cleaning_services
                           </span>
                         </button>
                       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import type { Chunk } from "./chunks";
 import { packs } from "./packs";
 import { SongView } from "./SongView";
 import { PatternPlaybackManager } from "./PatternPlaybackManager";
-import { filterValueToFrequency } from "./utils/audio";
+import { ensureAudioContextRunning, filterValueToFrequency } from "./utils/audio";
 import type { PatternGroup, SongRow } from "./song";
 import { createPatternGroupId, createSongRow } from "./song";
 import { AddTrackModal } from "./AddTrackModal";
@@ -382,6 +382,7 @@ export default function App() {
         sustainArg?: number,
         chunk?: Chunk
       ) => {
+        void ensureAudioContextRunning();
         void noteArg;
         void sustainArg;
         const settable = inst as unknown as {
@@ -420,6 +421,7 @@ export default function App() {
       sustain?: number,
       chunk?: Chunk
     ) => {
+      void ensureAudioContextRunning();
       const releaseOverride =
         sustain ?? (chunk?.sustain !== undefined ? chunk.sustain : undefined);
       const envelope: Record<string, number> = {};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as Tone from "tone";
 
@@ -21,6 +22,23 @@ const createInitialPatternGroup = (): PatternGroup => ({
 });
 
 type Subdivision = "16n" | "8n" | "4n";
+
+const CONTROL_BUTTON_SIZE = 44;
+
+const controlButtonBaseStyle: CSSProperties = {
+  width: CONTROL_BUTTON_SIZE,
+  height: CONTROL_BUTTON_SIZE,
+  borderRadius: 8,
+  border: "1px solid #333",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  cursor: "pointer",
+};
+
+const controlIconStyle: CSSProperties = {
+  fontSize: 24,
+};
 
 interface AddTrackModalState {
   isOpen: boolean;
@@ -865,19 +883,17 @@ export default function App() {
                           aria-label="Done editing"
                           onClick={() => setEditing(null)}
                           style={{
-                            width: 40,
-                            height: 40,
-                            borderRadius: 8,
-                            border: "1px solid #333",
+                            ...controlButtonBaseStyle,
                             background: "#27E0B0",
                             color: "#1F2532",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            cursor: "pointer",
                           }}
                         >
-                          <span className="material-symbols-outlined">check</span>
+                          <span
+                            className="material-symbols-outlined"
+                            style={controlIconStyle}
+                          >
+                            check
+                          </span>
                         </button>
                         {selectedTrack && canRecordSelectedTrack ? (
                           <button
@@ -885,20 +901,17 @@ export default function App() {
                               isRecording ? "Stop recording" : "Start recording"
                             }
                             onClick={handleToggleRecording}
-                            style={{
-                              width: 40,
-                              height: 40,
-                              borderRadius: 8,
-                              border: "1px solid #333",
-                              background: isRecording ? "#E02749" : "#1f2532",
-                              color: isRecording ? "#ffe4e6" : "#e6f2ff",
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                              cursor: "pointer",
+                          style={{
+                              ...controlButtonBaseStyle,
+                              background: isRecording ? "#E02749" : "#111827",
+                              border: `1px solid ${isRecording ? "#E02749" : "#333"}`,
+                              color: isRecording ? "#ffe4e6" : "#f43f5e",
                             }}
                           >
-                            <span className="material-symbols-outlined">
+                            <span
+                              className="material-symbols-outlined"
+                              style={controlIconStyle}
+                            >
                               fiber_manual_record
                             </span>
                           </button>
@@ -908,21 +921,24 @@ export default function App() {
                           onClick={handleClearSelectedTrack}
                           disabled={!canClearSelectedTrack}
                           style={{
-                            width: 40,
-                            height: 40,
-                            borderRadius: 8,
-                            border: "1px solid #333",
+                            ...controlButtonBaseStyle,
                             background: canClearSelectedTrack
                               ? "#1f2532"
                               : "#111827",
+                            border: `1px solid ${
+                              canClearSelectedTrack ? "#333" : "#1f2937"
+                            }`,
                             color: canClearSelectedTrack ? "#e6f2ff" : "#475569",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
                             cursor: canClearSelectedTrack ? "pointer" : "not-allowed",
+                            opacity: canClearSelectedTrack ? 1 : 0.6,
                           }}
                         >
-                          <span className="material-symbols-outlined">backspace</span>
+                          <span
+                            className="material-symbols-outlined"
+                            style={controlIconStyle}
+                          >
+                            delete
+                          </span>
                         </button>
                       </div>
                     ) : (
@@ -980,19 +996,16 @@ export default function App() {
                       onPointerDown={handlePlayStop}
                       onPointerUp={(e) => e.currentTarget.blur()}
                       style={{
-                        width: 44,
-                        height: 44,
-                        borderRadius: 8,
-                        border: "1px solid #333",
+                        ...controlButtonBaseStyle,
                         background: isPlaying ? "#E02749" : "#27E0B0",
                         color: isPlaying ? "#ffe4e6" : "#1F2532",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
                         fontSize: 24,
                       }}
                     >
-                      <span className="material-symbols-outlined">
+                      <span
+                        className="material-symbols-outlined"
+                        style={controlIconStyle}
+                      >
                         {isPlaying ? "stop" : "play_arrow"}
                       </span>
                     </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -928,6 +928,7 @@ export default function App() {
                   {selectedTrack ? (
                     <InstrumentControlPanel
                       track={selectedTrack}
+                      allTracks={tracks}
                       trigger={
                         selectedTrack.instrument
                           ? triggers[selectedTrack.instrument] ?? undefined

--- a/src/Arpeggiator.tsx
+++ b/src/Arpeggiator.tsx
@@ -11,7 +11,7 @@ import type { Track } from "./tracks";
 
 type Subdivision = "16n" | "8n" | "4n";
 
-type ArpStyle = "up" | "down" | "up-down" | "random";
+type ArpStyle = "up" | "down" | "up-down" | "random" | "unfold";
 
 function nextGridTime(subdivision: Subdivision): number {
   const now = Tone.now();
@@ -358,6 +358,7 @@ export function Arpeggiator({
           <option value="down">Down</option>
           <option value="up-down">Up-Down</option>
           <option value="random">Random</option>
+          <option value="unfold">Unfold</option>
         </select>
         <label>Playback</label>
         <select

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -197,7 +197,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
   const latchedDegreeRef = useRef<number | null>(null);
   const unfoldProgressRef = useRef(0);
   const autopMaskRef = useRef<boolean[]>(Array(16).fill(false));
-  const previousAutopilotRef = useRef(autopilotEnabled);
+  const previousAutopilotRef = useRef(pattern?.autopilot ?? false);
 
   const updatePattern = useMemo(() => {
     if (!onUpdatePattern || !pattern) {

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -1,4 +1,10 @@
-import type { FC, PropsWithChildren, ReactNode } from "react";
+import type {
+  Dispatch,
+  FC,
+  PropsWithChildren,
+  ReactNode,
+  SetStateAction,
+} from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as Tone from "tone";
 
@@ -21,7 +27,7 @@ interface InstrumentControlPanelProps {
     chunk?: Chunk
   ) => void;
   isRecording?: boolean;
-  onRecordingChange?: (recording: boolean) => void;
+  onRecordingChange?: Dispatch<SetStateAction<boolean>>;
 }
 
 interface SliderProps {
@@ -312,11 +318,9 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
   const canTrigger = Boolean(trigger && pattern);
   const updateRecording = useCallback(
     (next: boolean | ((prev: boolean) => boolean)) => {
-      if (!onRecordingChange) return;
-      const resolved = typeof next === "function" ? next(isRecording) : next;
-      onRecordingChange(resolved);
+      onRecordingChange?.(next);
     },
-    [isRecording, onRecordingChange]
+    [onRecordingChange]
   );
 
   const arpRoot = pattern?.note ?? "C4";
@@ -865,11 +869,11 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
   useEffect(() => () => stopArpPlayback(), [stopArpPlayback]);
 
   useEffect(() => {
-    updateRecording(false);
+    onRecordingChange?.(false);
     stopArpPlayback();
     setActiveDegree(null);
     setPressedKeyboardNotes(new Set());
-  }, [track.id, track.instrument, stopArpPlayback, updateRecording]);
+  }, [track.id, track.instrument, stopArpPlayback, onRecordingChange]);
 
   useEffect(() => {
     if (!pattern || !updatePattern) return;

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -11,7 +11,7 @@ import * as Tone from "tone";
 import type { Chunk, NoteEvent } from "./chunks";
 import type { Track } from "./tracks";
 import { formatInstrumentLabel } from "./utils/instrument";
-import { filterValueToFrequency } from "./utils/audio";
+import { ensureAudioContextRunning, filterValueToFrequency } from "./utils/audio";
 import { ARP_PRESETS } from "./arpPresets";
 
 interface InstrumentControlPanelProps {
@@ -699,6 +699,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
     (degreeIndex: number) => {
       stopArpPlayback({ preserveState: true });
       if (!trigger || !pattern) return;
+      void ensureAudioContextRunning();
       const octaves = Math.max(1, pattern.arpOctaves ?? 1);
       const style = pattern.style ?? "up";
       const mode = pattern.timingMode === "free" ? "free" : "sync";
@@ -844,6 +845,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
 
   const triggerKeyboardNote = (note: string) => {
     if (!trigger || !pattern) return;
+    void ensureAudioContextRunning();
     const bend = pattern.pitchBend ?? 0;
     const sustain = pattern.sustain ?? 0.8;
     const noteName = bend ? Tone.Frequency(note).transpose(bend).toNote() : note;

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -313,6 +313,48 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
     };
   }, [onUpdatePattern, pattern]);
 
+  useEffect(() => {
+    if (!pattern || !updatePattern) return;
+    if (!isKeyboard && !isArp) return;
+    const defaults: Partial<Chunk> = {};
+    if (pattern.note === undefined) {
+      defaults.note = "C4";
+    }
+    if (pattern.attack === undefined) {
+      defaults.attack = 0.05;
+    }
+    if (pattern.sustain === undefined) {
+      defaults.sustain = 0.8;
+    }
+    if (pattern.glide === undefined) {
+      defaults.glide = 0;
+    }
+    if (pattern.pan === undefined) {
+      defaults.pan = 0;
+    }
+    if (pattern.reverb === undefined) {
+      defaults.reverb = 0;
+    }
+    if (pattern.delay === undefined) {
+      defaults.delay = 0;
+    }
+    if (pattern.distortion === undefined) {
+      defaults.distortion = 0;
+    }
+    if (pattern.bitcrusher === undefined) {
+      defaults.bitcrusher = 0;
+    }
+    if (pattern.chorus === undefined) {
+      defaults.chorus = 0;
+    }
+    if (pattern.filter === undefined) {
+      defaults.filter = 1;
+    }
+    if (Object.keys(defaults).length > 0) {
+      updatePattern(defaults);
+    }
+  }, [isArp, isKeyboard, pattern, updatePattern]);
+
   const activeVelocity = pattern?.velocityFactor ?? 1;
   const manualVelocity = Math.max(0, Math.min(1, activeVelocity));
   const canTrigger = Boolean(trigger && pattern);

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -67,6 +67,7 @@ const cloneChunk = (chunk: Chunk): Chunk => ({
   pitches: chunk.pitches ? chunk.pitches.slice() : undefined,
   notes: chunk.notes ? chunk.notes.slice() : undefined,
   degrees: chunk.degrees ? chunk.degrees.slice() : undefined,
+  noteEvents: chunk.noteEvents ? chunk.noteEvents.map((event) => ({ ...event })) : undefined,
 });
 
 const cloneTrack = (track: Track): Track => ({

--- a/src/PatternPlaybackManager.tsx
+++ b/src/PatternPlaybackManager.tsx
@@ -204,11 +204,15 @@ function PatternPlayer({
             }
             holdSteps += 1;
           }
-          const baseRelease = pattern.sustain ?? stepDurationSeconds;
-          const sustainSeconds = Math.max(
-            baseRelease,
-            (holdSteps + 1) * stepDurationSeconds
-          );
+          const holdDurationSeconds = (holdSteps + 1) * stepDurationSeconds;
+          const releaseControl = pattern.sustain;
+          const sustainSeconds =
+            releaseControl === undefined
+              ? holdDurationSeconds
+              : Math.min(
+                  Math.max(releaseControl, 0),
+                  holdDurationSeconds
+                );
           trigger(
             scheduledTime,
             velocity,

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -16,8 +16,7 @@ interface SongViewProps {
   isPlaying: boolean;
   bpm: number;
   setBpm: Dispatch<SetStateAction<number>>;
-  onPlayPause: () => void;
-  onStop: () => void;
+  onToggleTransport: () => void;
   selectedGroupId: string | null;
   onOpenSequenceLibrary: () => void;
   onAddTrack: () => void;
@@ -38,8 +37,7 @@ export function SongView({
   isPlaying,
   bpm,
   setBpm,
-  onPlayPause,
-  onStop,
+  onToggleTransport,
   selectedGroupId,
   onOpenSequenceLibrary,
   onAddTrack,
@@ -630,49 +628,24 @@ export function SongView({
         <div style={{ flex: 1 }} />
         <div style={{ display: "flex", gap: 12 }}>
           <button
-            aria-label={isPlaying ? "Pause" : "Play"}
-            onPointerDown={onPlayPause}
+            aria-label={isPlaying ? "Stop" : "Play"}
+            onPointerDown={onToggleTransport}
             onPointerUp={(e) => e.currentTarget.blur()}
             style={{
-              width: 40,
-              height: 40,
+              width: 44,
+              height: 44,
               borderRadius: 8,
               border: "1px solid #333",
-              background: "#27E0B0",
-              color: "#1F2532",
+              background: isPlaying ? "#E02749" : "#27E0B0",
+              color: isPlaying ? "#ffe4e6" : "#1F2532",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              fontSize: 20,
+              fontSize: 24,
             }}
           >
             <span className="material-symbols-outlined">
-              {isPlaying ? "pause" : "play_arrow"}
-            </span>
-          </button>
-          <button
-            aria-label="Stop"
-            onPointerDown={onStop}
-            onPointerUp={(e) => e.currentTarget.blur()}
-            style={{
-              width: 40,
-              height: 40,
-              borderRadius: 8,
-              border: "1px solid #333",
-              background: "#E02749",
-              color: "#e6f2ff",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 40,
-              padding: 0,
-            }}
-          >
-            <span
-              className="material-symbols-outlined"
-              style={{ lineHeight: 1, width: "100%", height: "100%" }}
-            >
-              stop
+              {isPlaying ? "stop" : "play_arrow"}
             </span>
           </button>
         </div>

--- a/src/arpPresets.ts
+++ b/src/arpPresets.ts
@@ -1,0 +1,76 @@
+import type { Chunk } from "./chunks";
+
+type TimingMode = Exclude<Chunk["timingMode"], undefined>;
+
+export interface ArpPreset {
+  id: string;
+  name: string;
+  description?: string;
+  settings: Partial<
+    Pick<
+      Chunk,
+      | "style"
+      | "timingMode"
+      | "arpRate"
+      | "arpGate"
+      | "arpOctaves"
+      | "arpFreeRate"
+      | "useExtensions"
+      | "autopilot"
+      | "reverb"
+      | "distortion"
+      | "bitcrusher"
+    >
+  >;
+}
+
+export const ARP_PRESETS: ArpPreset[] = [
+  {
+    id: "sync-sparkle",
+    name: "Sync Sparkle",
+    description: "Snappy up/down arp with shimmer",
+    settings: {
+      timingMode: "sync" as TimingMode,
+      style: "up-down",
+      arpRate: "8n",
+      arpGate: 0.55,
+      arpOctaves: 2,
+      useExtensions: true,
+      reverb: 0.35,
+      distortion: 0.1,
+      bitcrusher: 0.05,
+    },
+  },
+  {
+    id: "free-glide",
+    name: "Free Glide",
+    description: "Loose random flow with long tails",
+    settings: {
+      timingMode: "free" as TimingMode,
+      style: "random",
+      arpFreeRate: 420,
+      arpGate: 0.8,
+      arpOctaves: 3,
+      useExtensions: true,
+      reverb: 0.6,
+      distortion: 0.05,
+      bitcrusher: 0.12,
+    },
+  },
+  {
+    id: "mono-pulse",
+    name: "Mono Pulse",
+    description: "Tight single-octave driver",
+    settings: {
+      timingMode: "sync" as TimingMode,
+      style: "up",
+      arpRate: "16n",
+      arpGate: 0.45,
+      arpOctaves: 1,
+      useExtensions: false,
+      reverb: 0.2,
+      distortion: 0.2,
+      bitcrusher: 0.08,
+    },
+  },
+];

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -110,6 +110,20 @@
       "minimum": 0,
       "maximum": 1
     },
+    "tonalCenter": {
+      "type": "string",
+      "description": "Arpeggiator tonal center"
+    },
+    "scale": {
+      "type": "string",
+      "description": "Scale or mode name"
+    },
+    "degree": {
+      "type": "integer",
+      "description": "Scale degree index",
+      "minimum": 0,
+      "maximum": 6
+    },
     "velocityFactor": {
       "type": "number",
       "description": "Global velocity multiplier",
@@ -155,7 +169,7 @@
     "style": {
       "type": "string",
       "description": "Arpeggiator style",
-      "enum": ["up", "down", "up-down", "random"]
+      "enum": ["up", "down", "up-down", "random", "unfold"]
     },
     "mode": {
       "type": "string",
@@ -181,6 +195,14 @@
       "description": "Number of octaves for arpeggiator playback",
       "minimum": 1,
       "maximum": 4
+    },
+    "useExtensions": {
+      "type": "boolean",
+      "description": "Whether to include extended chord tones"
+    },
+    "autopilot": {
+      "type": "boolean",
+      "description": "Automatically trigger arp alongside kick/snare"
     }
   }
 }

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -110,6 +110,11 @@
       "minimum": 0,
       "maximum": 1
     },
+    "timingMode": {
+      "type": "string",
+      "description": "Whether the pattern follows BPM sync or free timing",
+      "enum": ["sync", "free"]
+    },
     "tonalCenter": {
       "type": "string",
       "description": "Arpeggiator tonal center"
@@ -180,6 +185,11 @@
       "type": "string",
       "description": "Arpeggiator rate (e.g. 1/8, 1/16)"
     },
+    "arpFreeRate": {
+      "type": "number",
+      "description": "Arpeggiator interval in milliseconds when in free timing mode",
+      "minimum": 0
+    },
     "arpGate": {
       "type": "number",
       "description": "Arpeggiator gate length",
@@ -203,6 +213,29 @@
     "autopilot": {
       "type": "boolean",
       "description": "Automatically trigger arp alongside kick/snare"
+    },
+    "noteEvents": {
+      "type": "array",
+      "description": "Recorded free-time note events",
+      "items": {
+        "type": "object",
+        "required": ["time", "duration", "note", "velocity"],
+        "properties": {
+          "time": { "type": "number", "minimum": 0 },
+          "duration": { "type": "number", "minimum": 0 },
+          "note": { "type": "string" },
+          "velocity": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        }
+      }
+    },
+    "noteLoopLength": {
+      "type": "number",
+      "description": "Loop length in seconds for free-time note events",
+      "minimum": 0
     }
   }
 }

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -16,6 +16,9 @@ export interface Chunk {
   bitcrusher?: number;
   filter?: number;
   chorus?: number;
+  tonalCenter?: string;
+  scale?: string;
+  degree?: number;
   velocityFactor?: number;
   pitchOffset?: number;
   swing?: number;
@@ -29,5 +32,7 @@ export interface Chunk {
   arpGate?: number;
   arpLatch?: boolean;
   arpOctaves?: number;
+  useExtensions?: boolean;
+  autopilot?: boolean;
 }
 

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -1,3 +1,10 @@
+export interface NoteEvent {
+  time: number;
+  duration: number;
+  note: string;
+  velocity: number;
+}
+
 export interface Chunk {
   id: string;
   name: string;
@@ -16,6 +23,7 @@ export interface Chunk {
   bitcrusher?: number;
   filter?: number;
   chorus?: number;
+  timingMode?: "sync" | "free";
   tonalCenter?: string;
   scale?: string;
   degree?: number;
@@ -32,7 +40,10 @@ export interface Chunk {
   arpGate?: number;
   arpLatch?: boolean;
   arpOctaves?: number;
+  arpFreeRate?: number;
   useExtensions?: boolean;
   autopilot?: boolean;
+  noteEvents?: NoteEvent[];
+  noteLoopLength?: number;
 }
 

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -1,3 +1,5 @@
+import * as Tone from "tone";
+
 const MIN_FILTER_FREQUENCY = 80;
 const MAX_FILTER_FREQUENCY = 12000;
 
@@ -17,5 +19,17 @@ export const frequencyToFilterValue = (frequency: number) => {
   const clamped = clamp(frequency, MIN_FILTER_FREQUENCY, MAX_FILTER_FREQUENCY);
   const freqLog = Math.log(clamped);
   return (freqLog - minLog) / (maxLog - minLog);
+};
+
+export const ensureAudioContextRunning = () => {
+  const context = Tone.getContext();
+  if (context.state === "running") {
+    return Promise.resolve();
+  }
+  try {
+    return context.resume();
+  } catch {
+    return Promise.resolve();
+  }
 };
 


### PR DESCRIPTION
## Summary
- add tonal-center and scale aware chord building to the arp instrument UI, including degree pads, extension and autopilot controls
- persist arp metadata such as tonal center, scale degree, and extension toggles in chunk data and update the arpeggiator style options
- ensure recorded keyboard/arp notes capture the current note and effect settings when writing steps

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cac84b5838832886def4931a572db4