### PR TITLE
feat: add expanded sound packs and dynamic characters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -436,12 +436,13 @@ export default function App() {
         const { voice, voiceOptions, ...polyOptions } = options;
         if (voice && voice in Tone) {
           const VoiceCtor = (
-            Tone as unknown as Record<
-              string,
-              new (opts?: Record<string, unknown>) => Tone.Synth
-            >
+            Tone as unknown as Record<string, new (opts?: Record<string, unknown>) => Tone.Synth>
           )[voice];
-          instrument = new Tone.PolySynth(VoiceCtor, voiceOptions ?? {}) as ToneInstrument;
+          const PolyCtor = Tone.PolySynth as unknown as new (
+            voice?: new (opts?: Record<string, unknown>) => Tone.Synth,
+            options?: Record<string, unknown>
+          ) => ToneInstrument;
+          instrument = new PolyCtor(VoiceCtor, voiceOptions ?? {});
           (instrument as unknown as { set?: (values: Record<string, unknown>) => void }).set?.(
             polyOptions
           );

--- a/src/Arpeggiator.tsx
+++ b/src/Arpeggiator.tsx
@@ -85,12 +85,12 @@ export function Arpeggiator({
         {
           id: nextId,
           name: label,
-          instrument: "arpeggiator",
+          instrument: "arp",
           muted: false,
           pattern: {
             id: `arp-${Date.now()}`,
             name: `Track ${label} Pattern`,
-            instrument: "arpeggiator",
+            instrument: "arp",
             steps,
             velocities,
             pitches,
@@ -181,12 +181,12 @@ export function Arpeggiator({
                 {
                   id: tid,
                   name: label,
-                  instrument: "arpeggiator",
+                  instrument: "arp",
                   muted: false,
                   pattern: {
                     id: `arp-${Date.now()}`,
                     name: `Track ${label} Pattern`,
-                    instrument: "arpeggiator",
+                    instrument: "arp",
                     steps,
                     velocities,
                     pitches,
@@ -214,7 +214,7 @@ export function Arpeggiator({
                 t.pattern ?? {
                   id: `arp-${Date.now()}`,
                   name: `Track ${label} Pattern`,
-                  instrument: "arpeggiator",
+                  instrument: "arp",
                   steps: Array(16).fill(0),
                   velocities: Array(16).fill(1),
                   pitches: Array(16).fill(0),

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -24,7 +24,8 @@ interface InstrumentControlPanelProps {
     pitch?: number,
     note?: string,
     sustain?: number,
-    chunk?: Chunk
+    chunk?: Chunk,
+    characterId?: string
   ) => void;
   isRecording?: boolean;
   onRecordingChange?: Dispatch<SetStateAction<boolean>>;
@@ -166,7 +167,7 @@ const CollapsibleSection: FC<
 };
 
 const isPercussiveInstrument = (instrument: string) =>
-  ["kick", "snare", "hat", "cowbell"].includes(instrument);
+  ["kick", "snare", "hihat"].includes(instrument);
 
 const createChordNotes = (rootNote: string, degrees: number[]) => {
   const rootMidi = Tone.Frequency(rootNote).toMidi();
@@ -282,8 +283,8 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
   const instrumentLabel = formatInstrumentLabel(track.instrument ?? "");
   const isPercussive = isPercussiveInstrument(track.instrument ?? "");
   const isBass = track.instrument === "bass";
-  const isArp = track.instrument === "arpeggiator";
-  const isKeyboard = track.instrument === "chord";
+  const isArp = track.instrument === "arp";
+  const isKeyboard = track.instrument === "keyboard";
   const [activeDegree, setActiveDegree] = useState<number | null>(null);
   const [pressedKeyboardNotes, setPressedKeyboardNotes] = useState<
     Set<string>

--- a/src/Keyboard.tsx
+++ b/src/Keyboard.tsx
@@ -354,7 +354,7 @@ export function Keyboard({
       const basePattern: Chunk = {
         id: `kb-${Date.now()}`,
         name: `Track ${label} Pattern`,
-        instrument: "chord",
+        instrument: "keyboard",
         steps,
         velocities,
         pitches,
@@ -365,7 +365,7 @@ export function Keyboard({
         {
           id: nextId,
           name: label,
-          instrument: "chord",
+          instrument: "keyboard",
           muted: false,
           pattern,
         },
@@ -408,7 +408,7 @@ export function Keyboard({
           const basePattern: Chunk = {
             id: `kb-${Date.now()}`,
             name: `Track ${label} Pattern`,
-            instrument: "chord",
+            instrument: "keyboard",
             steps,
             velocities,
             pitches,
@@ -419,7 +419,7 @@ export function Keyboard({
             {
               id: trackId,
               name: label,
-              instrument: "chord",
+              instrument: "keyboard",
               muted: false,
               pattern,
             },
@@ -442,7 +442,7 @@ export function Keyboard({
             {
               id: `kb-${Date.now()}`,
               name: `Track ${label} Pattern`,
-              instrument: "chord",
+              instrument: "keyboard",
               steps: Array(16).fill(0),
               velocities: Array(16).fill(1),
               pitches: Array(16).fill(0),

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -19,11 +19,10 @@ import { createPatternGroupId } from "./song";
 const baseInstrumentColors: Record<string, string> = {
   kick: "#e74c3c",
   snare: "#3498db",
-  hat: "#f1c40f",
+  hihat: "#f1c40f",
   bass: "#1abc9c",
-  cowbell: "#ff9f1c",
-  chord: "#2ecc71",
-  arpeggiator: "#9b59b6",
+  keyboard: "#2ecc71",
+  arp: "#9b59b6",
 };
 
 const FALLBACK_INSTRUMENT_COLOR = "#27E0B0";
@@ -319,7 +318,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
         const preset = presetId
           ? activePack.chunks.find((chunk) => chunk.id === presetId)
           : null;
-        const pattern: Chunk = preset
+        const basePattern: Chunk = preset
           ? {
               ...cloneChunk(preset),
               id: `${preset.id}-${Date.now()}`,
@@ -334,6 +333,14 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
               velocities: Array(16).fill(1),
               pitches: Array(16).fill(0),
             };
+        const instrumentDefinition = activePack.instruments[instrumentId];
+        const resolvedCharacterId =
+          characterId ||
+          basePattern.characterId ||
+          instrumentDefinition?.defaultCharacterId ||
+          instrumentDefinition?.characters?.[0]?.id ||
+          "";
+        const pattern: Chunk = { ...basePattern, characterId: resolvedCharacterId };
         createdId = nextId;
         return [
           ...ts,
@@ -346,7 +353,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
             source: {
               packId,
               instrumentId,
-              characterId,
+              characterId: resolvedCharacterId,
               presetId: presetId ?? null,
             },
           },
@@ -380,7 +387,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
           const preset = presetId
             ? activePack.chunks.find((chunk) => chunk.id === presetId)
             : null;
-          const nextPattern: Chunk | null = preset
+          const basePattern: Chunk | null = preset
             ? {
                 ...cloneChunk(preset),
                 id: `${preset.id}-${Date.now()}`,
@@ -388,7 +395,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 name: preset.name,
               }
             : t.pattern
-            ? { ...t.pattern, instrument: instrumentId }
+            ? { ...cloneChunk(t.pattern), instrument: instrumentId }
             : {
                 id: `track-${trackId}-${Date.now()}`,
                 name: t.name,
@@ -397,6 +404,16 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 velocities: Array(16).fill(1),
                 pitches: Array(16).fill(0),
               };
+          const instrumentDefinition = activePack.instruments[instrumentId];
+          const resolvedCharacterId =
+            characterId ||
+            basePattern?.characterId ||
+            instrumentDefinition?.defaultCharacterId ||
+            instrumentDefinition?.characters?.[0]?.id ||
+            "";
+          const nextPattern = basePattern
+            ? { ...basePattern, characterId: resolvedCharacterId }
+            : null;
           const nextName = preset ? preset.name : t.name;
           return {
             ...t,
@@ -406,7 +423,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
             source: {
               packId,
               instrumentId,
-              characterId,
+              characterId: resolvedCharacterId,
               presetId: presetId ?? null,
             },
           };

--- a/src/PatternPlaybackManager.tsx
+++ b/src/PatternPlaybackManager.tsx
@@ -58,7 +58,15 @@ export function PatternPlaybackManager({
             0,
             Math.min(1, velocity * velocityFactor)
           );
-          trigger(time, combinedVelocity, pitch, note, sustain, chunk);
+          trigger(
+            time,
+            combinedVelocity,
+            pitch,
+            note,
+            sustain,
+            chunk,
+            track.source?.characterId
+          );
         };
         const isTrackActive = () => !row.muted && !track.muted;
         players.push(
@@ -89,7 +97,17 @@ export function PatternPlaybackManager({
           <PatternPlayer
             key={track.id}
             pattern={track.pattern}
-            trigger={trigger}
+            trigger={(time, velocity, pitch, note, sustain, chunk) =>
+              trigger(
+                time,
+                velocity,
+                pitch,
+                note,
+                sustain,
+                chunk,
+                track.source?.characterId
+              )
+            }
             started={started}
             isTrackActive={isTrackActive}
           />

--- a/src/addTrackOptions.ts
+++ b/src/addTrackOptions.ts
@@ -1,3 +1,4 @@
+import { packs } from "./packs";
 import { formatInstrumentLabel } from "./utils/instrument";
 
 export interface CharacterOption {
@@ -5,86 +6,6 @@ export interface CharacterOption {
   name: string;
   description?: string;
 }
-
-type PackCharacterMap = Record<string, Record<string, CharacterOption[]>>;
-
-const PACK_CHARACTER_MAP: PackCharacterMap = {
-  phonk: {
-    kick: [
-      { id: "classic-808", name: "Classic 808" },
-      { id: "saturated-boom", name: "Saturated Boom" },
-    ],
-    snare: [
-      { id: "tight-snap", name: "Tight Snap" },
-      { id: "vinyl-crack", name: "Vinyl Crack" },
-    ],
-    hat: [
-      { id: "shufflin", name: "Shufflin' Hat" },
-      { id: "spray", name: "Spray Cymbal" },
-    ],
-    cowbell: [{ id: "club-bell", name: "Club Bell" }],
-    chord: [
-      { id: "dusty-keys", name: "Dusty Keys" },
-      { id: "lofi-pad", name: "Lo-fi Pad" },
-    ],
-    arpeggiator: [
-      { id: "midnight-arp", name: "Midnight Arp" },
-      { id: "drift-lights", name: "Drift Lights" },
-    ],
-  },
-  edm2000s: {
-    kick: [
-      { id: "trance-thump", name: "Trance Thump" },
-      { id: "sidechain", name: "Sidechain Pump" },
-    ],
-    snare: [
-      { id: "digital-snap", name: "Digital Snap" },
-      { id: "reverb-clap", name: "Reverb Clap" },
-    ],
-    hat: [
-      { id: "sparkle", name: "Sparkle Tick" },
-      { id: "driver", name: "Driver Hat" },
-    ],
-    bass: [
-      { id: "saw-pluck", name: "Saw Pluck" },
-      { id: "rolling-sub", name: "Rolling Sub" },
-    ],
-    chord: [
-      { id: "saw-pad", name: "Saw Pad" },
-      { id: "airwash", name: "Airwash Layer" },
-    ],
-    arpeggiator: [
-      { id: "stutter-stars", name: "Stutter Stars" },
-      { id: "laser-chase", name: "Laser Chase" },
-    ],
-  },
-  kraftwerk: {
-    kick: [
-      { id: "motor-kick", name: "Motor Kick" },
-      { id: "analog-punch", name: "Analog Punch" },
-    ],
-    snare: [
-      { id: "machine-snare", name: "Machine Snare" },
-      { id: "air-lock", name: "Air Lock" },
-    ],
-    hat: [
-      { id: "robot-hat", name: "Robot Hat" },
-      { id: "metronome", name: "Metronome Hat" },
-    ],
-    bass: [
-      { id: "square-robot", name: "Square Robot" },
-      { id: "pulse-drive", name: "Pulse Drive" },
-    ],
-    chord: [
-      { id: "organ-pad", name: "Organ Pad" },
-      { id: "glass-wave", name: "Glass Wave" },
-    ],
-    arpeggiator: [
-      { id: "neon-steps", name: "Neon Steps" },
-      { id: "data-stream", name: "Data Stream" },
-    ],
-  },
-};
 
 const createFallbackCharacters = (instrumentId: string): CharacterOption[] => {
   if (!instrumentId) return [];
@@ -100,12 +21,20 @@ export const getCharacterOptions = (
   packId: string,
   instrumentId: string
 ): CharacterOption[] => {
-  const pack = PACK_CHARACTER_MAP[packId];
-  if (!pack) return createFallbackCharacters(instrumentId);
-  const characters = pack[instrumentId];
-  if (!characters || characters.length === 0) {
+  if (!packId || !instrumentId) {
     return createFallbackCharacters(instrumentId);
   }
-  return characters;
+  const pack = packs.find((candidate) => candidate.id === packId);
+  if (!pack) return createFallbackCharacters(instrumentId);
+  const instrument = pack.instruments[instrumentId];
+  if (!instrument) return createFallbackCharacters(instrumentId);
+  if (!instrument.characters || instrument.characters.length === 0) {
+    return createFallbackCharacters(instrumentId);
+  }
+  return instrument.characters.map((character) => ({
+    id: character.id,
+    name: character.name,
+    description: character.description,
+  }));
 };
 

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -9,6 +9,7 @@ export interface Chunk {
   id: string;
   name: string;
   instrument: string;
+  characterId?: string;
   steps: number[];
   velocities?: number[];
   pitches?: number[];

--- a/src/packs.ts
+++ b/src/packs.ts
@@ -7,6 +7,17 @@ export interface InstrumentSpec {
   effects?: EffectSpec[];
 }
 
+export interface InstrumentCharacter extends InstrumentSpec {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface InstrumentDefinition {
+  defaultCharacterId?: string;
+  characters: InstrumentCharacter[];
+}
+
 export interface EffectSpec {
   type: string;
   options?: Record<string, unknown>;
@@ -15,7 +26,7 @@ export interface EffectSpec {
 export interface Pack {
   id: string;
   name: string;
-  instruments: Record<string, InstrumentSpec>;
+  instruments: Record<string, InstrumentDefinition>;
   chunks: Chunk[];
 }
 

--- a/src/packs/chiptune.json
+++ b/src/packs/chiptune.json
@@ -1,0 +1,398 @@
+{
+  "id": "chiptune",
+  "name": "Chip Tune",
+  "instruments": {
+    "kick": {
+      "defaultCharacterId": "tri-kick",
+      "characters": [
+        {
+          "id": "tri-kick",
+          "name": "Tri Kick",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "triangle" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.1,
+              "sustain": 0.01,
+              "release": 0.15
+            }
+          }
+        },
+        {
+          "id": "square-thump",
+          "name": "Square Thump",
+          "type": "MonoSynth",
+          "note": "C1",
+          "options": {
+            "oscillator": { "type": "square" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.2,
+              "sustain": 0.01,
+              "release": 0.25
+            }
+          }
+        }
+      ]
+    },
+    "snare": {
+      "defaultCharacterId": "noise-crack",
+      "characters": [
+        {
+          "id": "noise-crack",
+          "name": "Noise Crack",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.1,
+              "sustain": 0,
+              "release": 0.08
+            }
+          }
+        },
+        {
+          "id": "retro-pop",
+          "name": "Retro Pop",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.15,
+              "sustain": 0,
+              "release": 0.12
+            }
+          },
+          "effects": [
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.12, "feedback": 0.2, "wet": 0.18 } }
+          ]
+        }
+      ]
+    },
+    "hihat": {
+      "defaultCharacterId": "noise-hat",
+      "characters": [
+        {
+          "id": "noise-hat",
+          "name": "Noise Hat",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.05,
+              "sustain": 0,
+              "release": 0.04
+            }
+          }
+        },
+        {
+          "id": "click-hat",
+          "name": "Click Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 2000,
+            "harmonicity": 2,
+            "resonance": 4500,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.05,
+              "sustain": 0,
+              "release": 0.05
+            }
+          }
+        }
+      ]
+    },
+    "bass": {
+      "defaultCharacterId": "square-bass",
+      "characters": [
+        {
+          "id": "square-bass",
+          "name": "Square Bass",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "square" },
+            "filter": { "type": "lowpass", "frequency": 200, "Q": 1 },
+            "envelope": {
+              "attack": 0.005,
+              "decay": 0.3,
+              "sustain": 0.4,
+              "release": 0.4
+            }
+          }
+        },
+        {
+          "id": "pulse-bass",
+          "name": "Pulse Bass",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "pulse", "width": 0.25 },
+            "filter": { "type": "lowpass", "frequency": 220, "Q": 1.1 },
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.25,
+              "sustain": 0.3,
+              "release": 0.35
+            }
+          }
+        }
+      ]
+    },
+    "arp": {
+      "defaultCharacterId": "tri-arp",
+      "characters": [
+        {
+          "id": "tri-arp",
+          "name": "Tri Arp",
+          "type": "Synth",
+          "note": "C4",
+          "options": {
+            "oscillator": { "type": "triangle" },
+            "envelope": {
+              "attack": 0.005,
+              "decay": 0.2,
+              "sustain": 0.2,
+              "release": 0.3
+            }
+          }
+        },
+        {
+          "id": "square-arp",
+          "name": "Square Arp",
+          "type": "Synth",
+          "note": "C4",
+          "options": {
+            "oscillator": { "type": "square" },
+            "envelope": {
+              "attack": 0.005,
+              "decay": 0.15,
+              "sustain": 0.15,
+              "release": 0.25
+            }
+          }
+        }
+      ]
+    },
+    "keyboard": {
+      "defaultCharacterId": "pulse-keys",
+      "characters": [
+        {
+          "id": "pulse-keys",
+          "name": "Pulse Keys",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "pulse", "width": 0.5 },
+              "envelope": {
+                "attack": 0.02,
+                "decay": 0.2,
+                "sustain": 0.5,
+                "release": 0.4
+              }
+            }
+          }
+        },
+        {
+          "id": "game-pad",
+          "name": "Game Pad",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "triangle" },
+              "envelope": {
+                "attack": 0.1,
+                "decay": 0.3,
+                "sustain": 0.6,
+                "release": 1.2
+              }
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.8, "wet": 0.3 } }
+          ]
+        }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "id": "chip-kick-sparse",
+      "name": "Sparse Kick",
+      "instrument": "kick",
+      "characterId": "tri-kick",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [1,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0]
+    },
+    {
+      "id": "chip-kick-drive",
+      "name": "Drive Kick",
+      "instrument": "kick",
+      "characterId": "square-thump",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [0.95,0,0,0,0.9,0,0,0,0.92,0,0,0,0.88,0,0,0]
+    },
+    {
+      "id": "chip-kick-sync",
+      "name": "Pulse Kick",
+      "instrument": "kick",
+      "characterId": "tri-kick",
+      "steps": [1,0,0,0,1,0,1,0,1,0,0,0,1,0,1,0],
+      "velocities": [0.95,0,0,0,0.9,0,0.82,0,0.9,0,0,0,0.88,0,0.8,0]
+    },
+    {
+      "id": "chip-snare-backbeat",
+      "name": "Backbeat",
+      "instrument": "snare",
+      "characterId": "noise-crack",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0]
+    },
+    {
+      "id": "chip-snare-sparse",
+      "name": "Sparse Pop",
+      "instrument": "snare",
+      "characterId": "retro-pop",
+      "steps": [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0,0,0,0,0,0,0,0,0.8,0,0,0,0,0,0,0]
+    },
+    {
+      "id": "chip-snare-ghost",
+      "name": "Ghost Snare",
+      "instrument": "snare",
+      "characterId": "retro-pop",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0,0,0,0,0.9,0,0,0,0,0,0,0,0.7,0,0,0],
+      "humanize": 0.03
+    },
+    {
+      "id": "chip-hat-8ths",
+      "name": "8-bit 8ths",
+      "instrument": "hihat",
+      "characterId": "noise-hat",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+      "velocities": [0.8,0,0.7,0,0.78,0,0.7,0,0.8,0,0.7,0,0.78,0,0.7,0]
+    },
+    {
+      "id": "chip-hat-chop",
+      "name": "Chop Hat",
+      "instrument": "hihat",
+      "characterId": "click-hat",
+      "steps": [1,1,1,1,0,0,0,0,1,1,1,1,0,0,0,0],
+      "velocities": [0.7,0.6,0.7,0.6,0,0,0,0,0.7,0.6,0.7,0.6,0,0,0,0]
+    },
+    {
+      "id": "chip-hat-rolls",
+      "name": "Trap Rolls",
+      "instrument": "hihat",
+      "characterId": "click-hat",
+      "steps": [1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1],
+      "velocities": [0.8,0,0,0.7,0.65,0,0,0.68,0.75,0,0,0.7,0.65,0,0,0.68],
+      "swing": 0.06
+    },
+    {
+      "id": "chip-bass-drive",
+      "name": "Drive Bass",
+      "instrument": "bass",
+      "characterId": "square-bass",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [0.9,0,0,0,0.82,0,0,0,0.86,0,0,0,0.8,0,0,0],
+      "note": "C3"
+    },
+    {
+      "id": "chip-bass-skip",
+      "name": "Skip Bass",
+      "instrument": "bass",
+      "characterId": "pulse-bass",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.88,0,0,0,0,0,0,0,0.82,0,0,0,0,0,0,0],
+      "note": "C3"
+    },
+    {
+      "id": "chip-bass-galop",
+      "name": "Galop Bass",
+      "instrument": "bass",
+      "characterId": "pulse-bass",
+      "steps": [1,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0],
+      "velocities": [0.85,0,0.75,0,0,0.8,0,0,0.85,0,0.75,0,0,0.8,0,0],
+      "pitches": [0,0,7,0,0,5,0,0,0,0,7,0,0,5,0,0],
+      "note": "C3"
+    },
+    {
+      "id": "chip-arp-fast",
+      "name": "Fast Sweep",
+      "instrument": "arp",
+      "characterId": "tri-arp",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+      "velocities": [0.85,0,0.78,0,0.82,0,0.76,0,0.84,0,0.78,0,0.82,0,0.76,0],
+      "pitches": [0,4,7,12,7,4,0,7,12,16,12,7,0,4,7,12],
+      "note": "C4"
+    },
+    {
+      "id": "chip-arp-nest",
+      "name": "NES Cascade",
+      "instrument": "arp",
+      "characterId": "square-arp",
+      "steps": [1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0],
+      "velocities": [0.8,0,0,0.75,0,0,0.78,0,0.82,0,0,0.76,0,0,0.78,0],
+      "pitches": [0,0,0,5,0,0,7,0,12,0,0,17,0,0,19,0],
+      "note": "C4"
+    },
+    {
+      "id": "chip-arp-loop",
+      "name": "Looping 3-Step",
+      "instrument": "arp",
+      "characterId": "tri-arp",
+      "steps": [1,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0],
+      "velocities": [0.82,0,0.72,0,0,0.7,0,0,0.8,0,0.7,0,0,0.68,0,0],
+      "pitches": [0,7,12,0,0,4,0,0,7,12,19,0,0,4,0,0],
+      "note": "C4"
+    },
+    {
+      "id": "chip-key-block",
+      "name": "Block Chords",
+      "instrument": "keyboard",
+      "characterId": "pulse-keys",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.9,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "sustain": 0.8,
+      "note": "C4"
+    },
+    {
+      "id": "chip-key-sync",
+      "name": "Sync Stabs",
+      "instrument": "keyboard",
+      "characterId": "pulse-keys",
+      "steps": [0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0],
+      "velocities": [0,0.85,0,0,0,0.82,0,0,0,0.8,0,0,0,0.82,0,0],
+      "sustain": 0.3,
+      "pan": -0.05,
+      "note": "E4"
+    },
+    {
+      "id": "chip-key-pad",
+      "name": "Pad Sweep",
+      "instrument": "keyboard",
+      "characterId": "game-pad",
+      "steps": [1,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0.8,0,0,0,0,0,0,0,0,0,0,0,0.78,0,0,0],
+      "sustain": 1.2,
+      "reverb": 0.3,
+      "note": "G3"
+    }
+  ]
+}

--- a/src/packs/early-2000s-edm.json
+++ b/src/packs/early-2000s-edm.json
@@ -1,112 +1,538 @@
 {
   "id": "edm2000s",
-  "name": "Early 2000s EDM",
+  "name": "EDM 2000s",
   "instruments": {
     "kick": {
-      "type": "MembraneSynth",
-      "note": "C2",
-      "options": {
-        "pitchDecay": 0.02,
-        "octaves": 3,
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.5,
-          "sustain": 0,
-          "release": 0.5
+      "defaultCharacterId": "trance-thump",
+      "characters": [
+        {
+          "id": "trance-thump",
+          "name": "Trance Thump",
+          "type": "MembraneSynth",
+          "note": "C2",
+          "options": {
+            "pitchDecay": 0.03,
+            "octaves": 3,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.55,
+              "sustain": 0.01,
+              "release": 0.6
+            }
+          }
+        },
+        {
+          "id": "sidechain-pump",
+          "name": "Sidechain Pump",
+          "type": "MembraneSynth",
+          "note": "C2",
+          "options": {
+            "pitchDecay": 0.025,
+            "octaves": 3,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.45,
+              "sustain": 0.01,
+              "release": 0.5
+            }
+          },
+          "effects": [
+            { "type": "Compressor", "options": { "threshold": -22, "ratio": 6 } }
+          ]
+        },
+        {
+          "id": "hardstyle-kick",
+          "name": "Hardstyle Kick",
+          "type": "MembraneSynth",
+          "note": "C2",
+          "options": {
+            "pitchDecay": 0.05,
+            "octaves": 4,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.8,
+              "sustain": 0.02,
+              "release": 0.9
+            }
+          },
+          "effects": [
+            { "type": "Distortion", "options": { "distortion": 0.3, "wet": 0.3 } }
+          ]
         }
-      }
+      ]
     },
     "snare": {
-      "type": "NoiseSynth",
-      "note": "8n",
-      "options": {
-        "noise": { "type": "white" },
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.3,
-          "sustain": 0.01
+      "defaultCharacterId": "digital-snap",
+      "characters": [
+        {
+          "id": "digital-snap",
+          "name": "Digital Snap",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.2,
+              "sustain": 0,
+              "release": 0.1
+            },
+            "filter": { "type": "highpass", "frequency": 2600, "Q": 1.2 }
+          }
+        },
+        {
+          "id": "reverb-clap",
+          "name": "Reverb Clap",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "pink" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.35,
+              "sustain": 0,
+              "release": 0.18
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 2, "wet": 0.25 } }
+          ]
+        },
+        {
+          "id": "reverb-snare",
+          "name": "Reverb Snare",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.45,
+              "sustain": 0,
+              "release": 0.4
+            },
+            "filter": { "type": "bandpass", "frequency": 3200, "Q": 0.8 }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 3, "wet": 0.3 } }
+          ]
         }
-      },
-      "effects": [
-        { "type": "Reverb", "options": { "decay": 2, "wet": 0.2 } }
       ]
     },
-    "hat": {
-      "type": "MetalSynth",
-      "options": {
-        "frequency": 250,
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.3,
-          "sustain": 0
+    "hihat": {
+      "defaultCharacterId": "sparkle-tick",
+      "characters": [
+        {
+          "id": "sparkle-tick",
+          "name": "Sparkle Tick",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 250,
+            "harmonicity": 5,
+            "resonance": 6000,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.08,
+              "sustain": 0.01,
+              "release": 0.08
+            }
+          }
         },
-        "harmonicity": 5
-      }
+        {
+          "id": "driver-hat",
+          "name": "Driver Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 320,
+            "harmonicity": 6,
+            "resonance": 6500,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.06,
+              "sustain": 0.01,
+              "release": 0.06
+            }
+          }
+        },
+        {
+          "id": "bright-hat",
+          "name": "Bright Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 1500,
+            "harmonicity": 4,
+            "resonance": 5000,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.08,
+              "sustain": 0,
+              "release": 0.08
+            }
+          },
+          "effects": [
+            { "type": "EQ3", "options": { "high": 3 } }
+          ]
+        }
+      ]
     },
     "bass": {
-      "type": "MonoSynth",
-      "note": "C2",
-      "options": {
-        "oscillator": { "type": "sawtooth" },
-        "filter": { "type": "lowpass", "rolloff": -24 },
-        "envelope": {
-          "attack": 0.01,
-          "decay": 0.3,
-          "sustain": 0.2,
-          "release": 0.1
-        },
-        "filterEnvelope": {
-          "attack": 0.01,
-          "decay": 0.2,
-          "sustain": 0.2,
-          "release": 0.1,
-          "baseFrequency": 100,
-          "octaves": 2.5
-        }
-      },
-      "effects": [
+      "defaultCharacterId": "saw-pluck",
+      "characters": [
         {
-          "type": "Chorus",
-          "options": { "frequency": 4, "delayTime": 2.5, "depth": 0.5, "wet": 0.3 }
+          "id": "saw-pluck",
+          "name": "Saw Pluck",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "sawtooth" },
+            "filter": { "type": "lowpass", "frequency": 200, "Q": 1.1 },
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.4,
+              "sustain": 0.3,
+              "release": 0.5
+            },
+            "filterEnvelope": {
+              "attack": 0.01,
+              "decay": 0.3,
+              "sustain": 0.5,
+              "release": 0.6,
+              "baseFrequency": 80,
+              "octaves": 2
+            }
+          }
+        },
+        {
+          "id": "rolling-sub",
+          "name": "Rolling Sub",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "sine" },
+            "portamento": 0.05,
+            "filter": { "type": "lowpass", "frequency": 140, "Q": 1.2 },
+            "envelope": {
+              "attack": 0.02,
+              "decay": 0.6,
+              "sustain": 0.7,
+              "release": 1.1
+            }
+          }
+        },
+        {
+          "id": "rolling-bass",
+          "name": "Rolling Bass",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "sawtooth" },
+            "filter": { "type": "lowpass", "frequency": 220, "Q": 1.3 },
+            "envelope": {
+              "attack": 0.005,
+              "decay": 0.35,
+              "sustain": 0.4,
+              "release": 0.45
+            },
+            "filterEnvelope": {
+              "attack": 0.005,
+              "decay": 0.2,
+              "sustain": 0.3,
+              "release": 0.4,
+              "baseFrequency": 90,
+              "octaves": 1.5
+            }
+          },
+          "effects": [
+            { "type": "Chorus", "options": { "frequency": 4, "delayTime": 2.5, "depth": 0.5, "wet": 0.3 } }
+          ]
         }
       ]
     },
-    "chord": {
-      "type": "Synth",
-      "note": "C4",
-      "options": {
-        "oscillator": { "type": "sawtooth" },
-        "envelope": {
-          "attack": 0.02,
-          "decay": 0.5,
-          "sustain": 0.7,
-          "release": 1.2
+    "arp": {
+      "defaultCharacterId": "stutter-stars",
+      "characters": [
+        {
+          "id": "stutter-stars",
+          "name": "Stutter Stars",
+          "type": "Synth",
+          "note": "C4",
+          "options": {
+            "oscillator": { "type": "square" },
+            "envelope": {
+              "attack": 0.005,
+              "decay": 0.25,
+              "sustain": 0.3,
+              "release": 0.4
+            }
+          },
+          "effects": [
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.25, "feedback": 0.35, "wet": 0.25 } }
+          ]
+        },
+        {
+          "id": "laser-chase",
+          "name": "Laser Arp",
+          "type": "FMSynth",
+          "note": "C5",
+          "options": {
+            "harmonicity": 2,
+            "modulationIndex": 6,
+            "oscillator": { "type": "square" },
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.2,
+              "sustain": 0.4,
+              "release": 0.6
+            }
+          },
+          "effects": [
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.2, "feedback": 0.4, "wet": 0.4 } }
+          ]
         }
-      },
-      "effects": [
-        { "type": "Chorus", "options": { "frequency": 3, "delayTime": 2, "depth": 0.4, "wet": 0.35 } },
-        { "type": "Reverb", "options": { "decay": 2.8, "wet": 0.3 } }
       ]
     },
-    "arpeggiator": {
-      "type": "Synth",
-      "note": "C4",
-      "options": {
-        "oscillator": { "type": "square" },
-        "envelope": {
-          "attack": 0.005,
-          "decay": 0.2,
-          "sustain": 0.5,
-          "release": 0.6
+    "keyboard": {
+      "defaultCharacterId": "saw-pad",
+      "characters": [
+        {
+          "id": "saw-pad",
+          "name": "Saw Pad",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 8,
+            "voiceOptions": {
+              "oscillator": { "type": "sawtooth" },
+              "envelope": {
+                "attack": 0.1,
+                "decay": 0.5,
+                "sustain": 0.7,
+                "release": 1.8
+              }
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 2.5, "wet": 0.35 } }
+          ]
+        },
+        {
+          "id": "airwash",
+          "name": "Airwash Layer",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "AMSynth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "envelope": {
+                "attack": 0.12,
+                "decay": 0.4,
+                "sustain": 0.6,
+                "release": 1.6
+              }
+            }
+          },
+          "effects": [
+            { "type": "Chorus", "options": { "frequency": 1.2, "delayTime": 4, "depth": 0.45, "wet": 0.3 } },
+            { "type": "Reverb", "options": { "decay": 2.8, "wet": 0.28 } }
+          ]
+        },
+        {
+          "id": "supersaw-pad",
+          "name": "Supersaw Pad",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 10,
+            "voiceOptions": {
+              "oscillator": { "type": "sawtooth" },
+              "envelope": {
+                "attack": 0.15,
+                "decay": 0.6,
+                "sustain": 0.8,
+                "release": 2.5
+              }
+            }
+          },
+          "effects": [
+            { "type": "Chorus", "options": { "frequency": 0.8, "delayTime": 3.2, "depth": 0.6, "wet": 0.5 } },
+            { "type": "Reverb", "options": { "decay": 3.2, "wet": 0.35 } }
+          ]
         }
-      }
+      ]
     }
   },
   "chunks": [
-    { "id": "edm-kick", "name": "Four on the Floor", "instrument": "kick", "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0] },
-    { "id": "edm-snare", "name": "Offbeat Snare", "instrument": "snare", "steps": [0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1] },
-    { "id": "edm-hat", "name": "Trance Hat", "instrument": "hat", "steps": [0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1] },
-    { "id": "edm-bass", "name": "Saw Bass", "instrument": "bass", "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0] },
-    { "id": "edm-chord", "name": "Supersaw Pad", "instrument": "chord", "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0], "sustain": 1.2, "reverb": 0.4, "chorus": 0.3 }
+    {
+      "id": "edm-kick-4onfloor",
+      "name": "Four on the Floor",
+      "instrument": "kick",
+      "characterId": "trance-thump",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [1,0,0,0,0.95,0,0,0,0.98,0,0,0,0.95,0,0,0]
+    },
+    {
+      "id": "edm-kick-drop",
+      "name": "Festival Drop",
+      "instrument": "kick",
+      "characterId": "hardstyle-kick",
+      "steps": [1,0,0,0,1,0,1,0,1,0,0,0,1,0,1,0],
+      "velocities": [1,0,0,0,0.95,0,0.85,0,0.92,0,0,0,0.96,0,0.82,0]
+    },
+    {
+      "id": "edm-kick-sync",
+      "name": "Sync Pump",
+      "instrument": "kick",
+      "characterId": "sidechain-pump",
+      "steps": [1,0,0,0,1,0,0,1,1,0,0,0,1,0,0,1],
+      "velocities": [1,0,0,0,0.95,0,0,0.75,0.9,0,0,0,0.92,0,0,0.78]
+    },
+    {
+      "id": "edm-snare-offbeat",
+      "name": "Offbeat Snare",
+      "instrument": "snare",
+      "characterId": "digital-snap",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0,0,0,0,0.95,0,0,0,0,0,0,0,0.95,0,0,0]
+    },
+    {
+      "id": "edm-snare-build",
+      "name": "Build Clap",
+      "instrument": "snare",
+      "characterId": "reverb-clap",
+      "steps": [0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1],
+      "velocities": [0,0,0,0.7,0,0,0,0.8,0,0,0,0.85,0,0,0,0.9],
+      "humanize": 0.02
+    },
+    {
+      "id": "edm-snare-dropswell",
+      "name": "Drop Swell",
+      "instrument": "snare",
+      "characterId": "reverb-snare",
+      "steps": [0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1],
+      "velocities": [0,0,0,0,0,0,0,0,0.6,0.65,0.7,0.75,0.8,0.85,0.9,1]
+    },
+    {
+      "id": "edm-hat-16ths",
+      "name": "Trance 16ths",
+      "instrument": "hihat",
+      "characterId": "sparkle-tick",
+      "steps": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      "velocities": [0.8,0.5,0.75,0.5,0.82,0.5,0.76,0.5,0.8,0.5,0.75,0.5,0.82,0.5,0.76,0.5]
+    },
+    {
+      "id": "edm-hat-open",
+      "name": "Open Pulse",
+      "instrument": "hihat",
+      "characterId": "bright-hat",
+      "steps": [1,0,0,0,0,0,1,0,1,0,0,0,0,0,1,0],
+      "velocities": [0.9,0,0,0,0,0,0.85,0,0.88,0,0,0,0,0,0.84,0]
+    },
+    {
+      "id": "edm-hat-drive",
+      "name": "Driver Shuffle",
+      "instrument": "hihat",
+      "characterId": "driver-hat",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+      "velocities": [0.85,0,0.7,0,0.82,0,0.68,0,0.84,0,0.7,0,0.82,0,0.68,0],
+      "swing": 0.08
+    },
+    {
+      "id": "edm-bass-drive",
+      "name": "Drive Bass",
+      "instrument": "bass",
+      "characterId": "rolling-bass",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+      "velocities": [0.95,0,0.8,0,0.9,0,0.78,0,0.9,0,0.8,0,0.88,0,0.78,0],
+      "note": "C2"
+    },
+    {
+      "id": "edm-bass-offbeat",
+      "name": "Offbeat Bass",
+      "instrument": "bass",
+      "characterId": "saw-pluck",
+      "steps": [0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0],
+      "velocities": [0,0.85,0,0,0,0.8,0,0,0,0.75,0,0,0,0.8,0,0],
+      "note": "C2"
+    },
+    {
+      "id": "edm-bass-roll",
+      "name": "Rolling Sub",
+      "instrument": "bass",
+      "characterId": "rolling-sub",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,1,1,0,0,0],
+      "velocities": [0.9,0,0,0,0.85,0,0,0,0.88,0,0,0.8,0.82,0,0,0],
+      "pitches": [0,0,0,0,0,0,0,0,0,0,0,7,5,0,0,0],
+      "note": "C2"
+    },
+    {
+      "id": "edm-arp-rise",
+      "name": "Rising Arp",
+      "instrument": "arp",
+      "characterId": "laser-chase",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+      "velocities": [0.85,0,0.78,0,0.8,0,0.76,0,0.83,0,0.78,0,0.8,0,0.76,0],
+      "pitches": [0,4,7,11,12,16,19,23,24,28,31,35,36,40,43,47],
+      "note": "C4"
+    },
+    {
+      "id": "edm-arp-stutter",
+      "name": "Stutter Bounce",
+      "instrument": "arp",
+      "characterId": "stutter-stars",
+      "steps": [1,1,0,1,1,0,1,1,0,1,1,0,1,1,0,1],
+      "velocities": [0.8,0.6,0,0.78,0.6,0,0.82,0.6,0,0.8,0.6,0,0.78,0.6,0,0.82],
+      "pitches": [0,7,0,12,0,7,0,12,0,7,0,12,0,7,0,12],
+      "note": "C4"
+    },
+    {
+      "id": "edm-arp-laser",
+      "name": "Laser Sweep",
+      "instrument": "arp",
+      "characterId": "laser-chase",
+      "steps": [1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0],
+      "velocities": [0.85,0,0,0.78,0,0,0.82,0,0.84,0,0,0.8,0,0,0.82,0],
+      "pitches": [0,0,0,7,0,0,12,0,19,0,0,24,0,0,31,0],
+      "note": "C4"
+    },
+    {
+      "id": "edm-key-pad",
+      "name": "Pad Wash",
+      "instrument": "keyboard",
+      "characterId": "supersaw-pad",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.9,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "sustain": 1.8,
+      "reverb": 0.45,
+      "chorus": 0.4,
+      "note": "C4"
+    },
+    {
+      "id": "edm-key-chords",
+      "name": "Big Chords",
+      "instrument": "keyboard",
+      "characterId": "saw-pad",
+      "steps": [1,0,0,0,0,0,1,0,1,0,0,0,0,0,1,0],
+      "velocities": [0.88,0,0,0,0,0,0.8,0,0.82,0,0,0,0,0,0.78,0],
+      "sustain": 0.9,
+      "reverb": 0.35,
+      "delay": 0.2,
+      "note": "G4"
+    },
+    {
+      "id": "edm-key-break",
+      "name": "Break Wash",
+      "instrument": "keyboard",
+      "characterId": "airwash",
+      "steps": [1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0],
+      "velocities": [0.8,0,0,0,0,0,0,0,0,0.82,0,0,0,0,0,0],
+      "sustain": 1.4,
+      "reverb": 0.4,
+      "delay": 0.24,
+      "pan": 0.1,
+      "note": "A3"
+    }
   ]
 }

--- a/src/packs/kraftwerk.json
+++ b/src/packs/kraftwerk.json
@@ -1,102 +1,382 @@
 {
   "id": "kraftwerk",
-  "name": "Kraftwerk Style",
+  "name": "Kraftwerk",
   "instruments": {
     "kick": {
-      "type": "MembraneSynth",
-      "note": "C2",
-      "options": {
-        "pitchDecay": 0.01,
-        "octaves": 2,
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.4,
-          "sustain": 0,
-          "release": 0.4
-        }
-      }
-    },
-    "snare": {
-      "type": "NoiseSynth",
-      "note": "8n",
-      "options": {
-        "noise": { "type": "white" },
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.1,
-          "sustain": 0
-        }
-      }
-    },
-    "hat": {
-      "type": "MetalSynth",
-      "options": {
-        "frequency": 180,
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.05,
-          "sustain": 0
+      "defaultCharacterId": "motor-kick",
+      "characters": [
+        {
+          "id": "motor-kick",
+          "name": "Motor Kick",
+          "type": "MembraneSynth",
+          "note": "C2",
+          "options": {
+            "pitchDecay": 0.03,
+            "octaves": 3,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.7,
+              "sustain": 0.02,
+              "release": 0.8
+            }
+          }
         },
-        "harmonicity": 4
-      }
-    },
-    "bass": {
-      "type": "MonoSynth",
-      "note": "C2",
-      "options": {
-        "oscillator": { "type": "square" },
-        "filter": { "type": "lowpass", "rolloff": -24 },
-        "envelope": {
-          "attack": 0.01,
-          "decay": 0.2,
-          "sustain": 0.3,
-          "release": 0.2
-        },
-        "filterEnvelope": {
-          "attack": 0.01,
-          "decay": 0.2,
-          "sustain": 0.2,
-          "release": 0.2,
-          "baseFrequency": 120,
-          "octaves": 2
+        {
+          "id": "analog-punch",
+          "name": "Analog Punch",
+          "type": "MembraneSynth",
+          "note": "C2",
+          "options": {
+            "pitchDecay": 0.025,
+            "octaves": 2.5,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.5,
+              "sustain": 0.02,
+              "release": 0.6
+            }
+          }
         }
-      }
-    },
-    "chord": {
-      "type": "Synth",
-      "note": "C4",
-      "options": {
-        "oscillator": { "type": "sine" },
-        "envelope": {
-          "attack": 0.02,
-          "decay": 0.3,
-          "sustain": 0.9,
-          "release": 0.8
-        }
-      },
-      "effects": [
-        { "type": "Reverb", "options": { "decay": 1.5, "wet": 0.3 } }
       ]
     },
-    "arpeggiator": {
-      "type": "Synth",
-      "note": "C4",
-      "options": {
-        "oscillator": { "type": "triangle" },
-        "envelope": {
-          "attack": 0.01,
-          "decay": 0.25,
-          "sustain": 0.6,
-          "release": 0.5
+    "snare": {
+      "defaultCharacterId": "machine-snare",
+      "characters": [
+        {
+          "id": "machine-snare",
+          "name": "Machine Snare",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.18,
+              "sustain": 0,
+              "release": 0.12
+            }
+          }
+        },
+        {
+          "id": "air-lock",
+          "name": "Air Lock",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "pink" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.22,
+              "sustain": 0,
+              "release": 0.16
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.2, "wet": 0.2 } }
+          ]
         }
-      }
+      ]
+    },
+    "hihat": {
+      "defaultCharacterId": "robot-hat",
+      "characters": [
+        {
+          "id": "robot-hat",
+          "name": "Robot Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 180,
+            "harmonicity": 5,
+            "resonance": 4000,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.05,
+              "sustain": 0,
+              "release": 0.05
+            }
+          }
+        },
+        {
+          "id": "metronome-hat",
+          "name": "Metronome Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 260,
+            "harmonicity": 4,
+            "resonance": 4500,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.06,
+              "sustain": 0,
+              "release": 0.06
+            }
+          }
+        }
+      ]
+    },
+    "bass": {
+      "defaultCharacterId": "square-robot",
+      "characters": [
+        {
+          "id": "square-robot",
+          "name": "Square Robot",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "square" },
+            "filter": { "type": "lowpass", "frequency": 160, "Q": 1.2 },
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.4,
+              "sustain": 0.5,
+              "release": 0.6
+            }
+          }
+        },
+        {
+          "id": "pulse-drive",
+          "name": "Pulse Drive",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "pulse", "width": 0.3 },
+            "filter": { "type": "lowpass", "frequency": 180, "Q": 1.1 },
+            "envelope": {
+              "attack": 0.02,
+              "decay": 0.35,
+              "sustain": 0.4,
+              "release": 0.5
+            }
+          }
+        }
+      ]
+    },
+    "arp": {
+      "defaultCharacterId": "neon-steps",
+      "characters": [
+        {
+          "id": "neon-steps",
+          "name": "Neon Steps",
+          "type": "Synth",
+          "note": "C4",
+          "options": {
+            "oscillator": { "type": "sawtooth" },
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.25,
+              "sustain": 0.3,
+              "release": 0.4
+            }
+          }
+        },
+        {
+          "id": "data-stream",
+          "name": "Data Stream",
+          "type": "FMSynth",
+          "note": "C4",
+          "options": {
+            "harmonicity": 2,
+            "modulationIndex": 3,
+            "envelope": {
+              "attack": 0.02,
+              "decay": 0.3,
+              "sustain": 0.4,
+              "release": 0.5
+            }
+          }
+        }
+      ]
+    },
+    "keyboard": {
+      "defaultCharacterId": "organ-pad",
+      "characters": [
+        {
+          "id": "organ-pad",
+          "name": "Organ Pad",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "square" },
+              "envelope": {
+                "attack": 0.05,
+                "decay": 0.4,
+                "sustain": 0.6,
+                "release": 1.5
+              }
+            }
+          }
+        },
+        {
+          "id": "glass-wave",
+          "name": "Glass Wave",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "triangle" },
+              "envelope": {
+                "attack": 0.1,
+                "decay": 0.5,
+                "sustain": 0.5,
+                "release": 1.8
+              }
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.5, "wet": 0.3 } }
+          ]
+        }
+      ]
     }
   },
   "chunks": [
-    { "id": "kw-kick", "name": "Motor Kick", "instrument": "kick", "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0] },
-    { "id": "kw-snare", "name": "Machine Snare", "instrument": "snare", "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0] },
-    { "id": "kw-hat", "name": "Robot Hat", "instrument": "hat", "steps": [1,1,0,1,1,0,1,1,0,1,1,0,1,1,0,1] },
-    { "id": "kw-bass", "name": "Square Bass", "instrument": "bass", "steps": [1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1] },
-    { "id": "kw-chord", "name": "Organ Chord", "instrument": "chord", "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0] }
+    {
+      "id": "kw-kick-motor",
+      "name": "Motor Kick",
+      "instrument": "kick",
+      "characterId": "motor-kick",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0]
+    },
+    {
+      "id": "kw-kick-stutter",
+      "name": "Stutter Kick",
+      "instrument": "kick",
+      "characterId": "analog-punch",
+      "steps": [1,0,0,0,1,0,1,0,1,0,0,0,1,0,1,0],
+      "velocities": [0.95,0,0,0,0.9,0,0.8,0,0.88,0,0,0,0.86,0,0.78,0]
+    },
+    {
+      "id": "kw-kick-break",
+      "name": "Break Kick",
+      "instrument": "kick",
+      "characterId": "motor-kick",
+      "steps": [1,0,0,0,0,0,1,0,1,0,0,0,0,0,1,0]
+    },
+    {
+      "id": "kw-snare-backbeat",
+      "name": "Machine Snare",
+      "instrument": "snare",
+      "characterId": "machine-snare",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0]
+    },
+    {
+      "id": "kw-snare-sync",
+      "name": "Sync Snare",
+      "instrument": "snare",
+      "characterId": "air-lock",
+      "steps": [0,0,0,0,1,0,0,1,0,0,1,0,1,0,0,1],
+      "velocities": [0,0,0,0,0.9,0,0,0.7,0,0,0.75,0,0.85,0,0,0.7]
+    },
+    {
+      "id": "kw-snare-fill",
+      "name": "Fill",
+      "instrument": "snare",
+      "characterId": "air-lock",
+      "steps": [0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1]
+    },
+    {
+      "id": "kw-hat-robot",
+      "name": "Robot Hat",
+      "instrument": "hihat",
+      "characterId": "robot-hat",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0]
+    },
+    {
+      "id": "kw-hat-metronome",
+      "name": "Metronome",
+      "instrument": "hihat",
+      "characterId": "metronome-hat",
+      "steps": [1,1,0,1,1,1,0,1,1,1,0,1,1,1,0,1],
+      "velocities": [0.8,0.6,0,0.7,0.6,0.5,0,0.7,0.6,0.5,0,0.7,0.6,0.5,0,0.7]
+    },
+    {
+      "id": "kw-hat-offbeat",
+      "name": "Offbeat Tick",
+      "instrument": "hihat",
+      "characterId": "robot-hat",
+      "steps": [0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0]
+    },
+    {
+      "id": "kw-bass-square",
+      "name": "Square Bass",
+      "instrument": "bass",
+      "characterId": "square-robot",
+      "steps": [1,0,0,0,0,0,1,0,1,0,0,0,0,0,1,0],
+      "note": "C2"
+    },
+    {
+      "id": "kw-bass-pulse",
+      "name": "Pulse Drive",
+      "instrument": "bass",
+      "characterId": "pulse-drive",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+      "velocities": [0.85,0,0.7,0,0.8,0,0.7,0,0.85,0,0.7,0,0.8,0,0.7,0]
+    },
+    {
+      "id": "kw-bass-sync",
+      "name": "Sync Bass",
+      "instrument": "bass",
+      "characterId": "square-robot",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,1,0,0,0,0],
+      "note": "C2"
+    },
+    {
+      "id": "kw-arp-neon",
+      "name": "Neon Steps",
+      "instrument": "arp",
+      "characterId": "neon-steps",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "note": "C4"
+    },
+    {
+      "id": "kw-arp-stream",
+      "name": "Data Stream",
+      "instrument": "arp",
+      "characterId": "data-stream",
+      "steps": [1,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0],
+      "pitches": [0,0,7,0,0,5,0,0,12,0,7,0,0,5,0,0],
+      "note": "C4"
+    },
+    {
+      "id": "kw-arp-sync",
+      "name": "Sync Lead",
+      "instrument": "arp",
+      "characterId": "neon-steps",
+      "steps": [1,1,0,1,1,0,1,1,0,1,1,0,1,1,0,1]
+    },
+    {
+      "id": "kw-key-organ",
+      "name": "Organ Chord",
+      "instrument": "keyboard",
+      "characterId": "organ-pad",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "sustain": 1,
+      "note": "C4"
+    },
+    {
+      "id": "kw-key-stabs",
+      "name": "Glass Stabs",
+      "instrument": "keyboard",
+      "characterId": "glass-wave",
+      "steps": [0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0],
+      "sustain": 0.4,
+      "reverb": 0.2,
+      "note": "E4"
+    },
+    {
+      "id": "kw-key-pad",
+      "name": "Pad Sweep",
+      "instrument": "keyboard",
+      "characterId": "glass-wave",
+      "steps": [1,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0],
+      "sustain": 1.6,
+      "reverb": 0.3,
+      "note": "G4"
+    }
   ]
 }

--- a/src/packs/phonk.json
+++ b/src/packs/phonk.json
@@ -1,99 +1,453 @@
 {
   "id": "phonk",
-  "name": "Hip Hop",
+  "name": "Phonk",
   "instruments": {
     "kick": {
-      "type": "MembraneSynth",
-      "note": "C1",
-      "options": {
-        "pitchDecay": 0.05,
-        "octaves": 4,
-        "envelope": {
-          "attack": 0.001,
-          "decay": 1.0,
-          "sustain": 0.01,
-          "release": 1.4
+      "defaultCharacterId": "classic-808",
+      "characters": [
+        {
+          "id": "classic-808",
+          "name": "Classic 808",
+          "type": "MembraneSynth",
+          "note": "C1",
+          "options": {
+            "pitchDecay": 0.05,
+            "octaves": 4,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 1.2,
+              "sustain": 0.01,
+              "release": 1.6
+            }
+          }
+        },
+        {
+          "id": "distorted-808",
+          "name": "Distorted 808",
+          "type": "MembraneSynth",
+          "note": "C1",
+          "options": {
+            "pitchDecay": 0.04,
+            "octaves": 4,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 1.0,
+              "sustain": 0.02,
+              "release": 1.4
+            }
+          },
+          "effects": [
+            { "type": "Distortion", "options": { "distortion": 0.4, "wet": 0.4 } },
+            { "type": "EQ3", "options": { "low": 4, "high": -6 } }
+          ]
         }
-      }
+      ]
     },
     "snare": {
-      "type": "NoiseSynth",
-      "note": "16n",
-      "options": {
-        "noise": { "type": "white" },
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.2,
-          "sustain": 0
-        }
-      },
-      "effects": [
-        { "type": "Distortion", "options": { "distortion": 0.4 } }
-      ]
-    },
-    "hat": {
-      "type": "MetalSynth",
-      "options": {
-        "frequency": 400,
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.1,
-          "sustain": 0.01
+      "defaultCharacterId": "tight-snap",
+      "characters": [
+        {
+          "id": "tight-snap",
+          "name": "Tight Snap",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.18,
+              "sustain": 0,
+              "release": 0.12
+            },
+            "filter": { "type": "bandpass", "frequency": 4600, "Q": 1.1 }
+          }
         },
-        "harmonicity": 5
-      },
-      "effects": [
-        { "type": "Reverb", "options": { "decay": 1.2, "wet": 0.3 } }
+        {
+          "id": "dusty-crack",
+          "name": "Dusty Crack",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "pink" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.24,
+              "sustain": 0,
+              "release": 0.18
+            },
+            "filter": { "type": "bandpass", "frequency": 3000, "Q": 0.9 }
+          },
+          "effects": [
+            { "type": "BitCrusher", "options": { "bits": 6, "wet": 0.3 } },
+            { "type": "Reverb", "options": { "decay": 1.2, "wet": 0.25 } }
+          ]
+        }
       ]
     },
-    "cowbell": {
-      "type": "MetalSynth",
-      "options": {
-        "frequency": 600,
-        "harmonicity": 3,
-        "resonance": 7000,
-        "envelope": {
-          "attack": 0.001,
-          "decay": 0.25,
-          "sustain": 0
+    "hihat": {
+      "defaultCharacterId": "shufflin",
+      "characters": [
+        {
+          "id": "shufflin",
+          "name": "Shufflin' Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 420,
+            "harmonicity": 5,
+            "resonance": 7000,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.08,
+              "sustain": 0.01,
+              "release": 0.08
+            }
+          }
+        },
+        {
+          "id": "spray-hat",
+          "name": "Spray Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 620,
+            "harmonicity": 4.5,
+            "resonance": 8000,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.12,
+              "sustain": 0.02,
+              "release": 0.12
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.4, "wet": 0.3 } }
+          ]
         }
-      }
-    },
-    "chord": {
-      "type": "Synth",
-      "note": "C4",
-      "options": {
-        "oscillator": { "type": "triangle" },
-        "envelope": {
-          "attack": 0.03,
-          "decay": 0.4,
-          "sustain": 0.8,
-          "release": 0.9
-        }
-      },
-      "effects": [
-        { "type": "Reverb", "options": { "decay": 2.2, "wet": 0.25 } }
       ]
     },
-    "arpeggiator": {
-      "type": "Synth",
-      "note": "C4",
-      "options": {
-        "oscillator": { "type": "sawtooth" },
-        "envelope": {
-          "attack": 0.01,
-          "decay": 0.2,
-          "sustain": 0.4,
-          "release": 0.6
+    "bass": {
+      "defaultCharacterId": "808-sub",
+      "characters": [
+        {
+          "id": "808-sub",
+          "name": "808 Sub",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "sine" },
+            "filter": { "type": "lowpass", "frequency": 120, "Q": 1.1 },
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.8,
+              "sustain": 0.7,
+              "release": 1.5
+            },
+            "filterEnvelope": {
+              "attack": 0.01,
+              "decay": 0.3,
+              "sustain": 0.5,
+              "release": 0.8,
+              "baseFrequency": 120,
+              "octaves": 1
+            }
+          }
+        },
+        {
+          "id": "lofi-sub",
+          "name": "Lo-Fi Sub",
+          "type": "MonoSynth",
+          "note": "C2",
+          "options": {
+            "oscillator": { "type": "triangle" },
+            "portamento": 0.1,
+            "filter": { "type": "lowpass", "frequency": 80, "Q": 1.4 },
+            "envelope": {
+              "attack": 0.02,
+              "decay": 0.7,
+              "sustain": 0.6,
+              "release": 1.8
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.6, "wet": 0.2 } }
+          ]
         }
-      }
+      ]
+    },
+    "arp": {
+      "defaultCharacterId": "midnight-arp",
+      "characters": [
+        {
+          "id": "midnight-arp",
+          "name": "Midnight Arp",
+          "type": "Synth",
+          "note": "C4",
+          "options": {
+            "oscillator": { "type": "sawtooth" },
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.25,
+              "sustain": 0.4,
+              "release": 0.6
+            }
+          },
+          "effects": [
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.25, "feedback": 0.3, "wet": 0.25 } }
+          ]
+        },
+        {
+          "id": "midnight-bells",
+          "name": "Midnight Bells",
+          "type": "FMSynth",
+          "note": "C5",
+          "options": {
+            "harmonicity": 2.4,
+            "modulationIndex": 4,
+            "envelope": {
+              "attack": 0.02,
+              "decay": 0.4,
+              "sustain": 0.5,
+              "release": 1.2
+            },
+            "modulationEnvelope": {
+              "attack": 0.01,
+              "decay": 0.3,
+              "sustain": 0.2,
+              "release": 0.8
+            }
+          },
+          "effects": [
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.33, "feedback": 0.35, "wet": 0.3 } },
+            { "type": "Reverb", "options": { "decay": 2.1, "wet": 0.25 } }
+          ]
+        }
+      ]
+    },
+    "keyboard": {
+      "defaultCharacterId": "dusty-keys",
+      "characters": [
+        {
+          "id": "dusty-keys",
+          "name": "Dusty Keys",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "triangle" },
+              "envelope": {
+                "attack": 0.05,
+                "decay": 0.4,
+                "sustain": 0.7,
+                "release": 0.9
+              }
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 2.2, "wet": 0.25 } }
+          ]
+        },
+        {
+          "id": "rhodes-pad",
+          "name": "Rhodes Pad",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 8,
+            "voiceOptions": {
+              "oscillator": { "type": "sine" },
+              "envelope": {
+                "attack": 0.18,
+                "decay": 0.6,
+                "sustain": 0.8,
+                "release": 2.4
+              }
+            }
+          },
+          "effects": [
+            { "type": "Chorus", "options": { "frequency": 1.5, "delayTime": 3.2, "depth": 0.4, "wet": 0.35 } },
+            { "type": "Reverb", "options": { "decay": 2.8, "wet": 0.32 } }
+          ]
+        }
+      ]
     }
   },
   "chunks": [
-    { "id": "phonk-kick", "name": "Four on the Floor", "instrument": "kick", "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0] },
-    { "id": "phonk-snare", "name": "Sharp Snare", "instrument": "snare", "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0] },
-    { "id": "phonk-hat", "name": "Fast Hat", "instrument": "hat", "steps": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] },
-    { "id": "phonk-cowbell", "name": "Cowbell", "instrument": "cowbell", "steps": [0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0] },
-    { "id": "phonk-chord", "name": "Dusty Keys", "instrument": "chord", "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0], "velocities": [1,0,0,0,0,0,0,0,0.8,0,0,0,0,0,0,0], "sustain": 0.8, "reverb": 0.3 }
+    {
+      "id": "phonk-kick-deep",
+      "name": "Deep Pulse",
+      "instrument": "kick",
+      "characterId": "classic-808",
+      "steps": [1,0,0,0,0,1,0,0,1,0,0,1,0,0,0,0],
+      "velocities": [1,0,0,0,0,0.85,0,0,0.95,0,0,0.9,0,0,0,0.8]
+    },
+    {
+      "id": "phonk-kick-stutter",
+      "name": "Stuttered Boom",
+      "instrument": "kick",
+      "characterId": "distorted-808",
+      "steps": [1,0,0,1,0,0,0,0,1,0,1,0,0,0,1,0],
+      "velocities": [1,0,0,0.7,0,0,0,0,0.95,0,0.75,0,0,0,0.85,0],
+      "swing": 0.08
+    },
+    {
+      "id": "phonk-kick-spill",
+      "name": "Slide Accents",
+      "instrument": "kick",
+      "characterId": "classic-808",
+      "steps": [1,0,0,0,0,0,1,1,0,0,0,1,0,1,0,0],
+      "velocities": [1,0,0,0,0,0,0.9,0.6,0,0,0,0.85,0,0.7,0,0.6],
+      "humanize": 0.03
+    },
+    {
+      "id": "phonk-snare-backbeat",
+      "name": "Dusty Backbeat",
+      "instrument": "snare",
+      "characterId": "tight-snap",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0,0,0,0,1,0,0,0,0,0,0,0,0.92,0,0,0]
+    },
+    {
+      "id": "phonk-snare-sparse",
+      "name": "Sparse Crack",
+      "instrument": "snare",
+      "characterId": "dusty-crack",
+      "steps": [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "humanize": 0.05
+    },
+    {
+      "id": "phonk-snare-ghosts",
+      "name": "Trap Ghosts",
+      "instrument": "snare",
+      "characterId": "dusty-crack",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0,0,0,0,1,0,0,0,0,0,0,0,0.8,0,0,0],
+      "note": "16n",
+      "humanize": 0.06
+    },
+    {
+      "id": "phonk-hat-swing",
+      "name": "Swung Hats",
+      "instrument": "hihat",
+      "characterId": "shufflin",
+      "steps": [1,0,1,0,0,1,1,0,1,0,1,0,0,1,1,0],
+      "velocities": [0.9,0,0.7,0,0,0.85,0.6,0,0.88,0,0.7,0,0,0.82,0.6,0],
+      "swing": 0.18
+    },
+    {
+      "id": "phonk-hat-ride",
+      "name": "Straight 16ths",
+      "instrument": "hihat",
+      "characterId": "shufflin",
+      "steps": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      "velocities": [0.8,0.6,0.75,0.6,0.8,0.6,0.75,0.6,0.8,0.6,0.75,0.6,0.8,0.6,0.75,0.6]
+    },
+    {
+      "id": "phonk-hat-spray",
+      "name": "Spray Rolls",
+      "instrument": "hihat",
+      "characterId": "spray-hat",
+      "steps": [1,1,0,1,1,1,0,1,1,1,0,1,1,1,0,1],
+      "velocities": [0.7,0.6,0,0.55,0.7,0.6,0,0.5,0.7,0.6,0,0.55,0.7,0.6,0,0.5],
+      "humanize": 0.04
+    },
+    {
+      "id": "phonk-bass-bounce",
+      "name": "Bounce Line",
+      "instrument": "bass",
+      "characterId": "808-sub",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [0.95,0,0,0,0.85,0,0,0,0.9,0,0,0,0.8,0,0,0],
+      "note": "C2"
+    },
+    {
+      "id": "phonk-bass-slide",
+      "name": "Slide Down",
+      "instrument": "bass",
+      "characterId": "lofi-sub",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,1,0,0,1,0],
+      "velocities": [0.9,0,0,0,0,0,0,0,0.85,0,0,0.8,0,0,0.75,0],
+      "pitches": [0,0,0,0,0,0,0,0,-2,0,0,3,0,0,5,0],
+      "glide": 0.18
+    },
+    {
+      "id": "phonk-bass-sync",
+      "name": "Sync Pulse",
+      "instrument": "bass",
+      "characterId": "808-sub",
+      "steps": [1,0,0,0,1,0,0,0,1,0,1,0,1,0,0,0],
+      "velocities": [0.9,0,0,0,0.8,0,0,0,0.85,0,0.75,0,0.8,0,0,0],
+      "note": "C2"
+    },
+    {
+      "id": "phonk-arp-midnight",
+      "name": "Midnight Steps",
+      "instrument": "arp",
+      "characterId": "midnight-arp",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [0.85,0,0,0,0.75,0,0,0,0.8,0,0,0,0.7,0,0,0],
+      "note": "C4"
+    },
+    {
+      "id": "phonk-arp-glow",
+      "name": "Glow Cascade",
+      "instrument": "arp",
+      "characterId": "midnight-bells",
+      "steps": [1,0,1,0,0,0,1,0,1,0,0,1,0,0,1,0],
+      "velocities": [0.9,0,0.6,0,0,0,0.7,0,0.85,0,0,0.65,0,0,0.7,0],
+      "pitches": [0,0,7,0,0,0,5,0,12,0,0,7,0,0,5,0],
+      "note": "C4"
+    },
+    {
+      "id": "phonk-arp-echo",
+      "name": "Echo Shimmer",
+      "instrument": "arp",
+      "characterId": "midnight-bells",
+      "steps": [1,0,0,1,0,0,1,0,1,0,0,1,0,1,0,0],
+      "velocities": [0.85,0,0,0.7,0,0,0.65,0,0.8,0,0,0.75,0,0.7,0,0],
+      "pitches": [0,0,0,7,0,0,5,0,12,0,0,7,0,5,0,0],
+      "note": "C4"
+    },
+    {
+      "id": "phonk-key-dusty",
+      "name": "Dusty Chords",
+      "instrument": "keyboard",
+      "characterId": "dusty-keys",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.95,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "sustain": 1.1,
+      "reverb": 0.3,
+      "chorus": 0.18,
+      "note": "C4"
+    },
+    {
+      "id": "phonk-key-stabs",
+      "name": "Sync Stabs",
+      "instrument": "keyboard",
+      "characterId": "dusty-keys",
+      "steps": [0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0],
+      "velocities": [0,0.85,0,0,0,0.8,0,0,0,0.75,0,0,0,0.78,0,0],
+      "sustain": 0.45,
+      "reverb": 0.22,
+      "delay": 0.18,
+      "pan": -0.15,
+      "note": "E♭4"
+    },
+    {
+      "id": "phonk-key-pad",
+      "name": "Pad Wash",
+      "instrument": "keyboard",
+      "characterId": "rhodes-pad",
+      "steps": [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+      "velocities": [0.9,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+      "sustain": 2.4,
+      "reverb": 0.5,
+      "delay": 0.28,
+      "chorus": 0.35,
+      "pan": 0.1,
+      "note": "C4"
+    }
   ]
 }

--- a/src/packs/trap.json
+++ b/src/packs/trap.json
@@ -1,0 +1,416 @@
+{
+  "id": "trap",
+  "name": "Trap",
+  "instruments": {
+    "kick": {
+      "defaultCharacterId": "808-boom",
+      "characters": [
+        {
+          "id": "808-boom",
+          "name": "808 Boom",
+          "type": "MembraneSynth",
+          "note": "C1",
+          "options": {
+            "pitchDecay": 0.05,
+            "octaves": 4,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 1.2,
+              "sustain": 0.01,
+              "release": 1.8
+            }
+          }
+        },
+        {
+          "id": "punch-kick",
+          "name": "Punch Kick",
+          "type": "MembraneSynth",
+          "note": "C2",
+          "options": {
+            "pitchDecay": 0.02,
+            "octaves": 3,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.4,
+              "sustain": 0.01,
+              "release": 0.8
+            }
+          }
+        }
+      ]
+    },
+    "snare": {
+      "defaultCharacterId": "trap-snap",
+      "characters": [
+        {
+          "id": "trap-snap",
+          "name": "Trap Snap",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.2,
+              "sustain": 0,
+              "release": 0.2
+            },
+            "filter": { "type": "bandpass", "frequency": 5000, "Q": 1 }
+          }
+        },
+        {
+          "id": "clap-layer",
+          "name": "Clap Layer",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "pink" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.28,
+              "sustain": 0,
+              "release": 0.25
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.6, "wet": 0.25 } },
+            { "type": "Distortion", "options": { "distortion": 0.15, "wet": 0.2 } }
+          ]
+        }
+      ]
+    },
+    "hihat": {
+      "defaultCharacterId": "tick-hat",
+      "characters": [
+        {
+          "id": "tick-hat",
+          "name": "Tick Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 500,
+            "harmonicity": 3.5,
+            "resonance": 6000,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.05,
+              "sustain": 0.01,
+              "release": 0.05
+            }
+          }
+        },
+        {
+          "id": "roll-hat",
+          "name": "Roll Hat",
+          "type": "MetalSynth",
+          "options": {
+            "frequency": 600,
+            "harmonicity": 4,
+            "resonance": 6500,
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.1,
+              "sustain": 0.01,
+              "release": 0.1
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.1, "wet": 0.15 } }
+          ]
+        }
+      ]
+    },
+    "bass": {
+      "defaultCharacterId": "808-sub",
+      "characters": [
+        {
+          "id": "808-sub",
+          "name": "808 Sub",
+          "type": "MonoSynth",
+          "note": "C1",
+          "options": {
+            "oscillator": { "type": "sine" },
+            "filter": { "type": "lowpass", "frequency": 120, "Q": 1.1 },
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.8,
+              "sustain": 0.7,
+              "release": 1.5
+            }
+          }
+        },
+        {
+          "id": "glide-bass",
+          "name": "Glide Bass",
+          "type": "MonoSynth",
+          "note": "C1",
+          "options": {
+            "oscillator": { "type": "triangle" },
+            "portamento": 0.1,
+            "filter": { "type": "lowpass", "frequency": 100, "Q": 1.2 },
+            "envelope": {
+              "attack": 0.02,
+              "decay": 0.7,
+              "sustain": 0.6,
+              "release": 1.2
+            }
+          }
+        }
+      ]
+    },
+    "arp": {
+      "defaultCharacterId": "bell-arp",
+      "characters": [
+        {
+          "id": "bell-arp",
+          "name": "Bell Arp",
+          "type": "FMSynth",
+          "note": "C5",
+          "options": {
+            "harmonicity": 2,
+            "modulationIndex": 4,
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.3,
+              "sustain": 0.4,
+              "release": 0.8
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.8, "wet": 0.25 } }
+          ]
+        },
+        {
+          "id": "trap-lead",
+          "name": "Trap Lead",
+          "type": "Synth",
+          "note": "C5",
+          "options": {
+            "oscillator": { "type": "sawtooth" },
+            "envelope": {
+              "attack": 0.005,
+              "decay": 0.2,
+              "sustain": 0.3,
+              "release": 0.8
+            }
+          },
+          "effects": [
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.25, "feedback": 0.32, "wet": 0.25 } }
+          ]
+        }
+      ]
+    },
+    "keyboard": {
+      "defaultCharacterId": "pluck-keys",
+      "characters": [
+        {
+          "id": "pluck-keys",
+          "name": "Pluck Keys",
+          "type": "PluckSynth",
+          "note": "C4",
+          "options": {
+            "dampening": 2500,
+            "resonance": 0.9,
+            "attackNoise": 1
+          }
+        },
+        {
+          "id": "dark-pad",
+          "name": "Dark Pad",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 8,
+            "voiceOptions": {
+              "oscillator": { "type": "sawtooth" },
+              "envelope": {
+                "attack": 0.6,
+                "decay": 0.6,
+                "sustain": 0.7,
+                "release": 2.5
+              }
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 2.6, "wet": 0.4 } }
+          ]
+        }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "id": "trap-kick-four",
+      "name": "Club Stomp",
+      "instrument": "kick",
+      "characterId": "808-boom",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [1,0,0,0,0.9,0,0,0,0.95,0,0,0,0.9,0,0,0]
+    },
+    {
+      "id": "trap-kick-sparse",
+      "name": "Sparse Trap",
+      "instrument": "kick",
+      "characterId": "punch-kick",
+      "steps": [1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0],
+      "velocities": [1,0,0,0,0,0,0.85,0,0,0,0,0,0.9,0,0,0],
+      "humanize": 0.03
+    },
+    {
+      "id": "trap-kick-sync",
+      "name": "Syncopated 808s",
+      "instrument": "kick",
+      "characterId": "808-boom",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [1,0,0,0,0,0,0,0,0.85,0,0,0,0.8,0,0,0],
+      "swing": 0.06
+    },
+    {
+      "id": "trap-snare-backbeat",
+      "name": "Backbeat",
+      "instrument": "snare",
+      "characterId": "trap-snap",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0,0,0,0,1,0,0,0,0,0,0,0,0.95,0,0,0]
+    },
+    {
+      "id": "trap-snare-sparse",
+      "name": "Sparse Clap",
+      "instrument": "snare",
+      "characterId": "clap-layer",
+      "steps": [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "humanize": 0.04
+    },
+    {
+      "id": "trap-snare-ghost",
+      "name": "Trap Ghosts",
+      "instrument": "snare",
+      "characterId": "clap-layer",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0,0,0,0,1,0,0,0,0,0,0,0,0.7,0,0,0],
+      "humanize": 0.07
+    },
+    {
+      "id": "trap-hat-eighth",
+      "name": "8ths",
+      "instrument": "hihat",
+      "characterId": "tick-hat",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+      "velocities": [0.85,0,0.75,0,0.8,0,0.72,0,0.8,0,0.75,0,0.78,0,0.7,0]
+    },
+    {
+      "id": "trap-hat-sixteenth",
+      "name": "16ths",
+      "instrument": "hihat",
+      "characterId": "roll-hat",
+      "steps": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      "velocities": [0.75,0.6,0.72,0.6,0.74,0.6,0.72,0.6,0.75,0.6,0.72,0.6,0.74,0.6,0.72,0.6]
+    },
+    {
+      "id": "trap-hat-rolls",
+      "name": "Trap Rolls",
+      "instrument": "hihat",
+      "characterId": "roll-hat",
+      "steps": [1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1],
+      "velocities": [0.8,0,0,0.7,0.65,0,0,0.68,0.75,0,0,0.7,0.65,0,0,0.68],
+      "swing": 0.12
+    },
+    {
+      "id": "trap-bass-pulse",
+      "name": "Trap Pulse",
+      "instrument": "bass",
+      "characterId": "808-sub",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [0.9,0,0,0,0.85,0,0,0,0.88,0,0,0,0.82,0,0,0],
+      "note": "C1"
+    },
+    {
+      "id": "trap-bass-sparse",
+      "name": "Sub Drop",
+      "instrument": "bass",
+      "characterId": "glide-bass",
+      "steps": [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0],
+      "velocities": [0.92,0,0,0,0,0,0,0,0,0,0.85,0,0,0,0,0],
+      "pitches": [0,0,0,0,0,0,0,0,0,0,5,0,0,0,0,0],
+      "glide": 0.15,
+      "note": "C1"
+    },
+    {
+      "id": "trap-bass-drive",
+      "name": "Rolling Low",
+      "instrument": "bass",
+      "characterId": "glide-bass",
+      "steps": [1,0,0,0,1,0,0,0,1,0,1,0,0,0,1,0],
+      "velocities": [0.9,0,0,0,0.82,0,0,0,0.85,0,0.78,0,0,0,0.8,0],
+      "note": "C1"
+    },
+    {
+      "id": "trap-arp-bell",
+      "name": "Bell Drops",
+      "instrument": "arp",
+      "characterId": "bell-arp",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "velocities": [0.85,0,0,0,0.78,0,0,0,0.8,0,0,0,0.75,0,0,0],
+      "note": "C5"
+    },
+    {
+      "id": "trap-arp-pulse",
+      "name": "Lead Pulse",
+      "instrument": "arp",
+      "characterId": "trap-lead",
+      "steps": [1,0,1,0,0,0,1,0,1,0,0,1,0,0,1,0],
+      "velocities": [0.9,0,0.7,0,0,0,0.8,0,0.88,0,0,0.76,0,0,0.8,0],
+      "pitches": [0,0,7,0,0,0,5,0,12,0,0,7,0,0,5,0],
+      "note": "C5"
+    },
+    {
+      "id": "trap-arp-rush",
+      "name": "Hi Hat Rush",
+      "instrument": "arp",
+      "characterId": "trap-lead",
+      "steps": [1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0],
+      "velocities": [0.85,0,0,0.78,0,0,0.8,0,0.82,0,0,0.76,0,0,0.8,0],
+      "pitches": [0,0,0,5,0,0,7,0,10,0,0,12,0,0,14,0],
+      "note": "C5"
+    },
+    {
+      "id": "trap-key-sustain",
+      "name": "Downbeat Chords",
+      "instrument": "keyboard",
+      "characterId": "dark-pad",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.9,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "sustain": 1.2,
+      "reverb": 0.4,
+      "delay": 0.18,
+      "note": "A♭4"
+    },
+    {
+      "id": "trap-key-stab",
+      "name": "Offbeat Stabs",
+      "instrument": "keyboard",
+      "characterId": "pluck-keys",
+      "steps": [0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0],
+      "velocities": [0,0.85,0,0,0,0.8,0,0,0,0.75,0,0,0,0.8,0,0],
+      "sustain": 0.35,
+      "reverb": 0.2,
+      "delay": 0.22,
+      "pan": -0.1,
+      "note": "D♭5"
+    },
+    {
+      "id": "trap-key-pad",
+      "name": "Pad Wash",
+      "instrument": "keyboard",
+      "characterId": "dark-pad",
+      "steps": [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+      "velocities": [0.85,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+      "sustain": 2.5,
+      "reverb": 0.5,
+      "delay": 0.3,
+      "chorus": 0.25,
+      "note": "F4"
+    }
+  ]
+}

--- a/src/packs/triphop.json
+++ b/src/packs/triphop.json
@@ -1,0 +1,435 @@
+{
+  "id": "triphop",
+  "name": "Trip Hop",
+  "instruments": {
+    "kick": {
+      "defaultCharacterId": "deep-kick",
+      "characters": [
+        {
+          "id": "deep-kick",
+          "name": "Deep Kick",
+          "type": "MembraneSynth",
+          "note": "C1",
+          "options": {
+            "pitchDecay": 0.03,
+            "octaves": 3,
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.8,
+              "sustain": 0.05,
+              "release": 1.5
+            }
+          }
+        },
+        {
+          "id": "lofi-kick",
+          "name": "Lo-Fi Kick",
+          "type": "MembraneSynth",
+          "note": "C1",
+          "options": {
+            "pitchDecay": 0.02,
+            "octaves": 3,
+            "envelope": {
+              "attack": 0.01,
+              "decay": 0.6,
+              "sustain": 0.05,
+              "release": 1.2
+            }
+          },
+          "effects": [
+            { "type": "Distortion", "options": { "distortion": 0.2, "wet": 0.25 } }
+          ]
+        }
+      ]
+    },
+    "snare": {
+      "defaultCharacterId": "vinyl-snare",
+      "characters": [
+        {
+          "id": "vinyl-snare",
+          "name": "Vinyl Snare",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "pink" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.25,
+              "sustain": 0,
+              "release": 0.2
+            }
+          },
+          "effects": [
+            { "type": "BitCrusher", "options": { "bits": 6, "wet": 0.25 } }
+          ]
+        },
+        {
+          "id": "dark-clap",
+          "name": "Dark Clap",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.35,
+              "sustain": 0,
+              "release": 0.28
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 1.8, "wet": 0.4 } }
+          ]
+        }
+      ]
+    },
+    "hihat": {
+      "defaultCharacterId": "loose-hat",
+      "characters": [
+        {
+          "id": "loose-hat",
+          "name": "Loose Hat",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "white" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.2,
+              "sustain": 0,
+              "release": 0.18
+            }
+          }
+        },
+        {
+          "id": "tape-hat",
+          "name": "Tape Hat",
+          "type": "NoiseSynth",
+          "note": "16n",
+          "options": {
+            "noise": { "type": "pink" },
+            "envelope": {
+              "attack": 0.001,
+              "decay": 0.15,
+              "sustain": 0,
+              "release": 0.14
+            }
+          },
+          "effects": [
+            { "type": "Distortion", "options": { "distortion": 0.12, "wet": 0.2 } }
+          ]
+        }
+      ]
+    },
+    "bass": {
+      "defaultCharacterId": "moody-bass",
+      "characters": [
+        {
+          "id": "moody-bass",
+          "name": "Moody Bass",
+          "type": "MonoSynth",
+          "note": "C1",
+          "options": {
+            "oscillator": { "type": "sine" },
+            "filter": { "type": "lowpass", "frequency": 100, "Q": 1.2 },
+            "envelope": {
+              "attack": 0.05,
+              "decay": 0.8,
+              "sustain": 0.6,
+              "release": 2
+            }
+          }
+        },
+        {
+          "id": "trip-bass",
+          "name": "Trip Bass",
+          "type": "MonoSynth",
+          "note": "C1",
+          "options": {
+            "oscillator": { "type": "triangle" },
+            "filter": { "type": "lowpass", "frequency": 80, "Q": 1.3 },
+            "envelope": {
+              "attack": 0.03,
+              "decay": 0.7,
+              "sustain": 0.5,
+              "release": 1.8
+            }
+          },
+          "effects": [
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.3, "feedback": 0.25, "wet": 0.2 } }
+          ]
+        }
+      ]
+    },
+    "arp": {
+      "defaultCharacterId": "ghost-arp",
+      "characters": [
+        {
+          "id": "ghost-arp",
+          "name": "Ghost Arp",
+          "type": "FMSynth",
+          "note": "C4",
+          "options": {
+            "harmonicity": 3,
+            "modulationIndex": 5,
+            "envelope": {
+              "attack": 0.2,
+              "decay": 0.6,
+              "sustain": 0.5,
+              "release": 2
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 2.5, "wet": 0.35 } }
+          ]
+        },
+        {
+          "id": "eerie-lead",
+          "name": "Eerie Lead",
+          "type": "Synth",
+          "note": "C4",
+          "options": {
+            "oscillator": { "type": "sawtooth" },
+            "envelope": {
+              "attack": 0.05,
+              "decay": 0.3,
+              "sustain": 0.4,
+              "release": 1.2
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 2, "wet": 0.5 } },
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.35, "feedback": 0.3, "wet": 0.3 } }
+          ]
+        }
+      ]
+    },
+    "keyboard": {
+      "defaultCharacterId": "rhodes-keys",
+      "characters": [
+        {
+          "id": "rhodes-keys",
+          "name": "Rhodes Keys",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "sine" },
+              "envelope": {
+                "attack": 0.1,
+                "decay": 0.4,
+                "sustain": 0.7,
+                "release": 1.8
+              }
+            }
+          },
+          "effects": [
+            { "type": "Chorus", "options": { "frequency": 1.5, "delayTime": 4, "depth": 0.5, "wet": 0.3 } },
+            { "type": "Reverb", "options": { "decay": 2.4, "wet": 0.4 } }
+          ]
+        },
+        {
+          "id": "dusty-pad",
+          "name": "Dusty Pad",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "triangle" },
+              "envelope": {
+                "attack": 0.3,
+                "decay": 0.6,
+                "sustain": 0.6,
+                "release": 2.5
+              }
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 3, "wet": 0.5 } }
+          ]
+        }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "id": "trip-kick-sparse",
+      "name": "Sparse",
+      "instrument": "kick",
+      "characterId": "deep-kick",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.95,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "humanize": 0.04
+    },
+    {
+      "id": "trip-kick-bounce",
+      "name": "Trip Bounce",
+      "instrument": "kick",
+      "characterId": "lofi-kick",
+      "steps": [1,0,0,0,1,0,0,0,0,1,0,0,0,0,1,0],
+      "velocities": [0.9,0,0,0,0.82,0,0,0,0,0.78,0,0,0,0,0.75,0],
+      "swing": 0.12
+    },
+    {
+      "id": "trip-kick-sync",
+      "name": "Sync Drift",
+      "instrument": "kick",
+      "characterId": "deep-kick",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0],
+      "velocities": [0.92,0,0,0,0,0,0,0,0.8,0,0,0.76,0,0,0,0]
+    },
+    {
+      "id": "trip-snare-backbeat",
+      "name": "Dusty Backbeat",
+      "instrument": "snare",
+      "characterId": "vinyl-snare",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0,0,0,0,0.95,0,0,0,0,0,0,0,0.88,0,0,0],
+      "humanize": 0.05
+    },
+    {
+      "id": "trip-snare-ghost",
+      "name": "Ghost Notes",
+      "instrument": "snare",
+      "characterId": "dark-clap",
+      "steps": [0,0,0,0,1,0,0,0,0,0,0,0,1,0,1,0],
+      "velocities": [0,0,0,0,0.9,0,0,0,0,0,0,0,0.8,0,0.45,0],
+      "humanize": 0.08
+    },
+    {
+      "id": "trip-snare-sync",
+      "name": "Sync Fill",
+      "instrument": "snare",
+      "characterId": "dark-clap",
+      "steps": [0,0,0,0,1,0,0,1,0,0,1,0,1,0,0,1],
+      "velocities": [0,0,0,0,0.85,0,0,0.6,0,0,0.65,0,0.8,0,0,0.6]
+    },
+    {
+      "id": "trip-hat-swing",
+      "name": "Swung Hats",
+      "instrument": "hihat",
+      "characterId": "loose-hat",
+      "steps": [1,0,1,0,0,1,1,0,1,0,1,0,0,1,1,0],
+      "velocities": [0.8,0,0.7,0,0,0.75,0.6,0,0.78,0,0.7,0,0,0.72,0.58,0],
+      "swing": 0.2
+    },
+    {
+      "id": "trip-hat-pattern",
+      "name": "Loose Ride",
+      "instrument": "hihat",
+      "characterId": "tape-hat",
+      "steps": [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+      "velocities": [0.72,0,0.6,0,0.68,0,0.6,0,0.72,0,0.6,0,0.68,0,0.6,0],
+      "humanize": 0.05
+    },
+    {
+      "id": "trip-hat-wash",
+      "name": "Dusty Wash",
+      "instrument": "hihat",
+      "characterId": "loose-hat",
+      "steps": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      "velocities": [0.6,0.5,0.58,0.5,0.6,0.5,0.58,0.5,0.62,0.5,0.6,0.5,0.58,0.5,0.6,0.5]
+    },
+    {
+      "id": "trip-bass-sustain",
+      "name": "Long Tones",
+      "instrument": "bass",
+      "characterId": "moody-bass",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.9,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "sustain": 1.6,
+      "note": "C1"
+    },
+    {
+      "id": "trip-bass-pulse",
+      "name": "Pulsed Groove",
+      "instrument": "bass",
+      "characterId": "trip-bass",
+      "steps": [1,0,0,0,1,0,0,1,0,0,1,0,0,0,1,0],
+      "velocities": [0.85,0,0,0,0.78,0,0,0.72,0,0,0.7,0,0,0,0.68,0],
+      "note": "C1"
+    },
+    {
+      "id": "trip-bass-slide",
+      "name": "Sliding Low",
+      "instrument": "bass",
+      "characterId": "trip-bass",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0],
+      "velocities": [0.88,0,0,0,0,0,0,0,0.8,0,0,0.72,0,0,0,0],
+      "pitches": [0,0,0,0,0,0,0,0,-5,0,0,3,0,0,0,0],
+      "glide": 0.2,
+      "note": "C1"
+    },
+    {
+      "id": "trip-arp-rise",
+      "name": "Slow Rise",
+      "instrument": "arp",
+      "characterId": "ghost-arp",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.75,0,0,0,0,0,0,0,0.7,0,0,0,0,0,0,0],
+      "pitches": [0,0,0,0,0,0,0,0,7,0,0,0,0,0,0,0],
+      "sustain": 1.2,
+      "note": "C4"
+    },
+    {
+      "id": "trip-arp-echo",
+      "name": "Echo Steps",
+      "instrument": "arp",
+      "characterId": "eerie-lead",
+      "steps": [1,0,0,1,0,0,0,1,1,0,0,1,0,0,0,1],
+      "velocities": [0.78,0,0,0.7,0,0,0,0.65,0.72,0,0,0.68,0,0,0,0.6],
+      "pitches": [0,0,0,5,0,0,0,7,12,0,0,9,0,0,0,7],
+      "note": "C4"
+    },
+    {
+      "id": "trip-arp-haze",
+      "name": "Hazy Arp",
+      "instrument": "arp",
+      "characterId": "ghost-arp",
+      "steps": [1,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0],
+      "velocities": [0.7,0,0.6,0,0,0.62,0,0,0.68,0,0.6,0,0,0.64,0,0],
+      "sustain": 0.8,
+      "note": "C4"
+    },
+    {
+      "id": "trip-key-rhodes",
+      "name": "Rhodes Sustain",
+      "instrument": "keyboard",
+      "characterId": "rhodes-keys",
+      "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+      "velocities": [0.88,0,0,0,0,0,0,0,0.8,0,0,0,0,0,0,0],
+      "sustain": 1.6,
+      "reverb": 0.35,
+      "delay": 0.2,
+      "note": "F3"
+    },
+    {
+      "id": "trip-key-stabs",
+      "name": "Offbeat Stabs",
+      "instrument": "keyboard",
+      "characterId": "rhodes-keys",
+      "steps": [0,1,0,0,0,0,0,1,0,1,0,0,0,0,0,1],
+      "velocities": [0,0.75,0,0,0,0,0,0.7,0,0.74,0,0,0,0,0,0.68],
+      "sustain": 0.5,
+      "reverb": 0.28,
+      "pan": -0.12,
+      "note": "A♭3"
+    },
+    {
+      "id": "trip-key-pad",
+      "name": "Dusty Pad",
+      "instrument": "keyboard",
+      "characterId": "dusty-pad",
+      "steps": [1,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0],
+      "velocities": [0.7,0,0,0,0,0,0,0,0,0,0,0,0.68,0,0,0],
+      "sustain": 2.2,
+      "reverb": 0.5,
+      "delay": 0.26,
+      "note": "D♭4"
+    }
+  ]
+}

--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -8,7 +8,8 @@ export type TriggerMap = Record<
     pitch?: number,
     note?: string,
     sustain?: number,
-    chunk?: Chunk
+    chunk?: Chunk,
+    characterId?: string
   ) => void
 >;
 

--- a/src/utils/instrument.ts
+++ b/src/utils/instrument.ts
@@ -1,6 +1,7 @@
 const CUSTOM_LABELS: Record<string, string> = {
-  chord: "Keyboard",
-  arpeggiator: "Arp",
+  keyboard: "Keyboard",
+  arp: "Arp",
+  hihat: "Hi-Hat",
 };
 
 export const formatInstrumentLabel = (value: string) => {


### PR DESCRIPTION
## Summary
- refactor instrument loading to support character-specific Tone.js specs and reusable effect chains
- update playback, track management, and UI controls to propagate per-track character selections
- author new Trap, Chip Tune, and Trip Hop packs and refresh Phonk, EDM 2000s, and Kraftwerk data with multi-pattern character sets

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb0b0cca708328956820a3992cddfd