### PR TITLE
Add PWA support with manifest and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^24.5.1",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1325,6 +1326,16 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.1.tgz",
+      "integrity": "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.13",
@@ -3022,6 +3033,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^24.5.1",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Sequencer Instrument",
+  "short_name": "Sequencer",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "/icons/app-icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/app-icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,3 +8,25 @@ createRoot(document.getElementById('root')!).render(
     <App />
   </StrictMode>,
 )
+
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  let hasRefreshed = false
+
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (hasRefreshed) {
+      return
+    }
+    hasRefreshed = true
+    window.location.reload()
+  })
+
+  window.addEventListener('load', async () => {
+    try {
+      await navigator.serviceWorker.register('/service-worker.js', {
+        type: 'module',
+      })
+    } catch (error) {
+      console.error('Service worker registration failed:', error)
+    }
+  })
+}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,150 @@
+/// <reference lib="webworker" />
+
+declare const self: ServiceWorkerGlobalScope
+declare const __BUILD_TIME__: string
+
+const CACHE_NAME = `sequencer-cache-${__BUILD_TIME__}`
+const FALLBACK_HTML_URL = '/index.html'
+
+const buildAssetEntries = (self as unknown as {
+  __WB_MANIFEST?: Array<{ url: string } | string>
+}).__WB_MANIFEST
+
+const precacheUrls = [
+  '/',
+  FALLBACK_HTML_URL,
+  '/manifest.webmanifest',
+  ...(buildAssetEntries
+    ? buildAssetEntries.map((entry) =>
+        typeof entry === 'string' ? entry : entry.url,
+      )
+    : []),
+]
+
+function normalizeUrl(url: string): string {
+  const normalized = new URL(url, self.location.origin)
+  return normalized.pathname + normalized.search
+}
+
+const PRECACHE_URLS = Array.from(new Set(precacheUrls.map(normalizeUrl)))
+
+async function cacheAppShell() {
+  const cache = await caches.open(CACHE_NAME)
+  await Promise.all(
+    PRECACHE_URLS.map(async (url) => {
+      try {
+        await cache.add(url)
+      } catch (error) {
+        console.warn('Failed to precache resource', url, error)
+      }
+    }),
+  )
+}
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      await cacheAppShell()
+      await self.skipWaiting()
+    })(),
+  )
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys()
+      await Promise.all(
+        keys
+          .filter((key) => key.startsWith('sequencer-cache-') && key !== CACHE_NAME)
+          .map((key) => caches.delete(key)),
+      )
+      await self.clients.claim()
+    })(),
+  )
+})
+
+async function cachedFetch(request: Request): Promise<Response> {
+  const cache = await caches.open(CACHE_NAME)
+  const cached = await cache.match(request)
+  if (cached) {
+    return cached
+  }
+
+  try {
+    const response = await fetch(request)
+    if (response && response.ok) {
+      cache.put(request, response.clone())
+    }
+    return response
+  } catch (error) {
+    if (request.mode === 'navigate') {
+      const fallbackResponse = await cache.match(FALLBACK_HTML_URL)
+      if (fallbackResponse) {
+        return fallbackResponse
+      }
+    }
+    throw error
+  }
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+
+  if (request.method !== 'GET') {
+    return
+  }
+
+  const url = new URL(request.url)
+  const isSameOrigin = url.origin === self.location.origin
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      (async () => {
+        try {
+          const response = await fetch(request)
+          const cache = await caches.open(CACHE_NAME)
+          cache.put(request, response.clone())
+          cache.put(FALLBACK_HTML_URL, response.clone())
+          return response
+        } catch {
+          const cache = await caches.open(CACHE_NAME)
+          const cached = await cache.match(request)
+          if (cached) {
+            return cached
+          }
+          const fallback = await cache.match(FALLBACK_HTML_URL)
+          if (fallback) {
+            return fallback
+          }
+          return new Response('Offline', {
+            status: 503,
+            headers: { 'Content-Type': 'text/plain' },
+          })
+        }
+      })(),
+    )
+    return
+  }
+
+  if (isSameOrigin) {
+    event.respondWith(cachedFetch(request))
+    return
+  }
+
+  event.respondWith(
+    (async () => {
+      try {
+        const response = await fetch(request)
+        return response
+      } catch {
+        const cache = await caches.open(CACHE_NAME)
+        const cached = await cache.match(request)
+        if (cached) {
+          return cached
+        }
+        throw new Error('Network request failed and no cached response available.')
+      }
+    })(),
+  )
+})

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __BUILD_TIME__: string

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,7 +19,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,31 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
+const buildTimestamp = new Date().toISOString()
+const rootDir = fileURLToPath(new URL('.', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __BUILD_TIME__: JSON.stringify(buildTimestamp),
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(rootDir, 'index.html'),
+        'service-worker': resolve(rootDir, 'src/service-worker.ts'),
+      },
+      output: {
+        entryFileNames: (chunk) => {
+          if (chunk.name === 'service-worker') {
+            return 'service-worker.js'
+          }
+          return 'assets/[name]-[hash].js'
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add a web app manifest and iOS status bar styling to support standalone installs
- register a new offline-capable service worker and preload essential assets for SPA routing
- configure Vite to emit the service worker, expose build metadata, and include Node types for the config file

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb458da5f083289f7827da24fca46f