### PR TITLE
Add local project storage with save/load UI

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,147 @@
+import type { Chunk } from "./chunks";
+import type { PatternGroup, SongRow } from "./song";
+import type { Track } from "./tracks";
+
+const STORAGE_KEY = "sequencer_projects";
+
+export interface StoredProjectData {
+  packIndex: number;
+  bpm: number;
+  subdivision?: string;
+  isPlaying: boolean;
+  tracks: Track[];
+  patternGroups: PatternGroup[];
+  songRows: SongRow[];
+  selectedGroupId: string | null;
+  currentSectionIndex?: number;
+}
+
+interface StoredProjectPayload {
+  version: number;
+  updatedAt: number;
+  data: StoredProjectData;
+}
+
+type StoredProjectMap = Record<string, StoredProjectPayload>;
+
+const PROJECT_VERSION = 1;
+
+const cloneChunk = (chunk: Chunk): Chunk => ({
+  ...chunk,
+  steps: chunk.steps.slice(),
+  velocities: chunk.velocities ? chunk.velocities.slice() : undefined,
+  pitches: chunk.pitches ? chunk.pitches.slice() : undefined,
+  notes: chunk.notes ? chunk.notes.slice() : undefined,
+  degrees: chunk.degrees ? chunk.degrees.slice() : undefined,
+  noteEvents: chunk.noteEvents
+    ? chunk.noteEvents.map((event) => ({ ...event }))
+    : undefined,
+});
+
+const cloneTrack = (track: Track): Track => ({
+  ...track,
+  pattern: track.pattern ? cloneChunk(track.pattern) : null,
+  source: track.source ? { ...track.source } : undefined,
+});
+
+const clonePatternGroup = (group: PatternGroup): PatternGroup => ({
+  ...group,
+  tracks: group.tracks.map((track) => cloneTrack(track)),
+});
+
+const cloneSongRow = (row: SongRow): SongRow => ({
+  ...row,
+  slots: row.slots.slice(),
+});
+
+const cloneProjectData = (project: StoredProjectData): StoredProjectData => ({
+  ...project,
+  tracks: project.tracks.map((track) => cloneTrack(track)),
+  patternGroups: project.patternGroups.map((group) => clonePatternGroup(group)),
+  songRows: project.songRows.map((row) => cloneSongRow(row)),
+});
+
+const getStorage = (): Storage | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.warn("Local storage unavailable", error);
+    return null;
+  }
+};
+
+const readAllProjects = (): StoredProjectMap => {
+  const storage = getStorage();
+  if (!storage) return {};
+  const raw = storage.getItem(STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as StoredProjectMap;
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed;
+  } catch (error) {
+    console.warn("Failed to parse stored projects", error);
+    return {};
+  }
+};
+
+const writeAllProjects = (projects: StoredProjectMap) => {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(projects));
+  } catch (error) {
+    console.warn("Failed to persist projects", error);
+  }
+};
+
+export const listProjects = (): string[] => {
+  const projects = readAllProjects();
+  return Object.keys(projects).sort((a, b) => a.localeCompare(b));
+};
+
+export const saveProject = (
+  name: string,
+  project?: StoredProjectData
+): void => {
+  if (!name) return;
+  if (!project) {
+    console.warn("No project data provided to save");
+    return;
+  }
+  const trimmedName = name.trim();
+  if (!trimmedName) return;
+  const projects = readAllProjects();
+  projects[trimmedName] = {
+    version: PROJECT_VERSION,
+    updatedAt: Date.now(),
+    data: cloneProjectData(project),
+  };
+  writeAllProjects(projects);
+};
+
+export const loadProject = (name: string): StoredProjectData | null => {
+  if (!name) return null;
+  const trimmedName = name.trim();
+  if (!trimmedName) return null;
+  const projects = readAllProjects();
+  const payload = projects[trimmedName];
+  if (!payload) return null;
+  if (payload.version !== PROJECT_VERSION) {
+    // Future compatibility: for now, return the stored data as-is
+    return cloneProjectData(payload.data);
+  }
+  return cloneProjectData(payload.data);
+};
+
+export const deleteProject = (name: string): void => {
+  if (!name) return;
+  const trimmedName = name.trim();
+  if (!trimmedName) return;
+  const projects = readAllProjects();
+  if (projects[trimmedName]) {
+    delete projects[trimmedName];
+    writeAllProjects(projects);
+  }
+};


### PR DESCRIPTION
## Summary
- add a storage utility that snapshots tracks, pattern groups, and songs into localStorage
- hook up project save/load controls and restoration logic in the app UI so Tone graphs rebuild correctly

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cb4b5bf6908328ac6d707bc3add307