### PR TITLE
Ensure Add Track modal content scrolls

### DIFF
--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -325,14 +325,6 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     ? combinedPresetItems.find((preset) => preset.id === selectedPresetId)?.name ?? "Custom"
     : "None";
 
-  const contentWrapperStyle: CSSProperties = {
-    display: "flex",
-    flexDirection: "column",
-    gap: 16,
-    flex: "1 1 auto",
-    minHeight: 0,
-  };
-
   const scrollContainerStyle: CSSProperties = {
     display: "flex",
     flexDirection: "column",
@@ -341,7 +333,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     minHeight: 0,
     overflowY: "auto",
     paddingRight: 4,
-    paddingBottom: 24,
+    paddingBottom: 32,
     WebkitOverflowScrolling: "touch",
   };
 
@@ -392,83 +384,82 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
         </div>
       }
     >
-      <div style={contentWrapperStyle}>
-        <div style={scrollContainerStyle}>
-          <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            <span style={{ fontSize: 13, color: "#cbd5f5" }}>Sound Pack</span>
-            <select
-              value={pack?.id ?? ""}
-              onChange={(event) => onSelectPack(event.target.value)}
-              style={{
-                padding: "10px 12px",
-                borderRadius: 12,
-                border: "1px solid #2f384a",
-                background: "#0f172a",
-                color: "#e6f2ff",
-              }}
-            >
-              {packs.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.name}
-                </option>
-              ))}
-            </select>
-          </label>
+      <div style={scrollContainerStyle}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: 13, color: "#cbd5f5" }}>Sound Pack</span>
+          <select
+            value={pack?.id ?? ""}
+            onChange={(event) => onSelectPack(event.target.value)}
+            style={{
+              padding: "10px 12px",
+              borderRadius: 12,
+              border: "1px solid #2f384a",
+              background: "#0f172a",
+              color: "#e6f2ff",
+            }}
+          >
+            {packs.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </label>
 
-          <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            <span style={{ fontSize: 13, color: "#cbd5f5" }}>Instrument</span>
-            <select
-              value={selectedInstrumentId}
-              onChange={(event) => onSelectInstrument(event.target.value)}
-              style={{
-                padding: "10px 12px",
-                borderRadius: 12,
-                border: "1px solid #2f384a",
-                background: "#0f172a",
-                color: selectedInstrumentId ? "#e6f2ff" : "#64748b",
-              }}
-            >
-              {instrumentOptions.length === 0 ? (
-                <option value="" disabled>
-                  No instruments available
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: 13, color: "#cbd5f5" }}>Instrument</span>
+          <select
+            value={selectedInstrumentId}
+            onChange={(event) => onSelectInstrument(event.target.value)}
+            style={{
+              padding: "10px 12px",
+              borderRadius: 12,
+              border: "1px solid #2f384a",
+              background: "#0f172a",
+              color: selectedInstrumentId ? "#e6f2ff" : "#64748b",
+            }}
+          >
+            {instrumentOptions.length === 0 ? (
+              <option value="" disabled>
+                No instruments available
+              </option>
+            ) : (
+              instrumentOptions.map((instrument) => (
+                <option key={instrument} value={instrument}>
+                  {formatInstrumentLabel(instrument)}
                 </option>
-              ) : (
-                instrumentOptions.map((instrument) => (
-                  <option key={instrument} value={instrument}>
-                    {formatInstrumentLabel(instrument)}
-                  </option>
-                ))
-              )}
-            </select>
-          </label>
+              ))
+            )}
+          </select>
+        </label>
 
-          <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            <span style={{ fontSize: 13, color: "#cbd5f5" }}>Character</span>
-            <select
-              value={selectedCharacterId}
-              onChange={(event) => onSelectCharacter(event.target.value)}
-              disabled={characterOptions.length === 0}
-              style={{
-                padding: "10px 12px",
-                borderRadius: 12,
-                border: "1px solid #2f384a",
-                background: "#0f172a",
-                color: characterOptions.length > 0 ? "#e6f2ff" : "#64748b",
-              }}
-            >
-              {characterOptions.length === 0 ? (
-                <option value="" disabled>
-                  No characters
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: 13, color: "#cbd5f5" }}>Character</span>
+          <select
+            value={selectedCharacterId}
+            onChange={(event) => onSelectCharacter(event.target.value)}
+            disabled={characterOptions.length === 0}
+            style={{
+              padding: "10px 12px",
+              borderRadius: 12,
+              border: "1px solid #2f384a",
+              background: "#0f172a",
+              color: characterOptions.length > 0 ? "#e6f2ff" : "#64748b",
+            }}
+          >
+            {characterOptions.length === 0 ? (
+              <option value="" disabled>
+                No characters
+              </option>
+            ) : (
+              characterOptions.map((character) => (
+                <option key={character.id} value={character.id}>
+                  {character.name}
                 </option>
-              ) : (
-                characterOptions.map((character) => (
-                  <option key={character.id} value={character.id}>
-                    {character.name}
-                  </option>
-                ))
-              )}
-            </select>
-          </label>
+              ))
+            )}
+          </select>
+        </label>
 
           <div
             style={{
@@ -564,17 +555,16 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             </div>
           </div>
 
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              fontSize: 12,
-              color: "#94a3b8",
-            }}
-          >
-            <span>Current preset: {currentPresetLabel}</span>
-          </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            fontSize: 12,
+            color: "#94a3b8",
+          }}
+        >
+          <span>Current preset: {currentPresetLabel}</span>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
## Summary
- rely on a single scroll container in the Add Track modal to fill the available space
- ensure the modal content scrolls vertically with extra bottom padding so the footer no longer obscures options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cca06cdf2c83289400f3add114fa62