### PR TITLE
Fix track controls scrolling and viewport height

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,25 @@ export default function App() {
   const pendingTransportStateRef = useRef<boolean | null>(null);
 
   useEffect(() => {
+    const updateAppHeight = () => {
+      const height = window.visualViewport?.height ?? window.innerHeight;
+      document.documentElement.style.setProperty(
+        "--app-height",
+        `${height}px`
+      );
+    };
+
+    updateAppHeight();
+    window.addEventListener("resize", updateAppHeight);
+    window.visualViewport?.addEventListener("resize", updateAppHeight);
+
+    return () => {
+      window.removeEventListener("resize", updateAppHeight);
+      window.visualViewport?.removeEventListener("resize", updateAppHeight);
+    };
+  }, []);
+
+  useEffect(() => {
     setIsRecording(false);
   }, [editing]);
 
@@ -1174,8 +1193,8 @@ export default function App() {
   return (
     <div
       style={{
-        height: "100dvh",
-        minHeight: "100dvh",
+        height: "var(--app-height)",
+        minHeight: "var(--app-height)",
         paddingBottom: "env(safe-area-inset-bottom)",
         boxSizing: "border-box",
         background: "#0f1420",

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -1316,13 +1316,21 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
         : "";
 
     return (
-      <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-        {presetControls}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {presetControls ? (
+          <div style={{ marginBottom: 12 }}>{presetControls}</div>
+        ) : null}
         <div
           style={{
             position: "sticky",
             top: 0,
             zIndex: 20,
+            paddingTop: presetControls ? 12 : 0,
             paddingBottom: 8,
             background:
               "linear-gradient(180deg, rgba(11, 18, 32, 0.96) 0%, rgba(11, 18, 32, 0.88) 65%, rgba(11, 18, 32, 0) 100%)",
@@ -1441,8 +1449,6 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
         </div>
         <div
           style={{
-            flex: 1,
-            overflowY: "auto",
             padding: "0 6px 12px 0",
           }}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,8 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --app-height: 100vh;
 }
 
 /* Disable text selection and callout menus globally */
@@ -46,6 +48,10 @@
 .scrollable,
 .scrollable * {
   touch-action: pan-x pan-y;
+}
+
+.scrollable {
+  -webkit-overflow-scrolling: touch;
 }
 
 html,
@@ -66,12 +72,14 @@ html,
 body,
 #root {
   margin: 0;
-  height: 100dvh;
   background: #0f1420;
+  min-height: var(--app-height);
+  height: var(--app-height);
 }
 
 body {
   min-width: 320px;
+  overflow: hidden;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- ensure the app height tracks the visual viewport so the interface fills mobile Safari
- prevent the page from scrolling while enabling momentum scrolling within scrollable panels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb30adba08328a500dd2a2b9275a6