### PR TITLE
feat: add Harmonia data models

### DIFF
--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -2303,7 +2303,8 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
+                gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+                gridTemplateRows: "repeat(3, 1fr)",
                 height: 200,
                 gap: 10,
               }}
@@ -2334,6 +2335,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                         : "none",
                       transition: "background 0.15s ease",
                       height: "100%",
+                      gridColumn: index === 0 ? "1 / -1" : undefined,
                       display: "flex",
                       flexDirection: "column",
                       justifyContent: "space-between",

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -2155,11 +2155,17 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
   if (isHarmonia) {
     stickySections.push(
       <Section key="harmonia" padding={14}>
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
+        <div
+          style={{
+            display: "flex",
+            gap: 16,
+            alignItems: "stretch",
+          }}
+        >
           <div
             style={{
-              flex: "1 1 240px",
-              minWidth: 220,
+              flex: "0 0 50%",
+              maxWidth: "50%",
               display: "flex",
               flexDirection: "column",
               gap: 10,
@@ -2284,8 +2290,8 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
           </div>
           <div
             style={{
-              flex: "1 1 320px",
-              minWidth: 240,
+              flex: "0 0 50%",
+              maxWidth: "50%",
               display: "flex",
               flexDirection: "column",
               gap: 12,

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -686,15 +686,6 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
     ]
   );
 
-  const harmoniaChord = useMemo(() => {
-    if (!isHarmonia) return null;
-    return computeHarmoniaResolution(harmoniaSelectedDegree);
-  }, [isHarmonia, computeHarmoniaResolution, harmoniaSelectedDegree]);
-
-  const harmoniaChordSummary = harmoniaChord
-    ? describeHarmoniaChord(harmoniaChord)
-    : "";
-
   const harmoniaComplexityIndex = Math.max(
     0,
     HARMONIA_COMPLEXITY_ORDER.indexOf(harmoniaControls.complexity)
@@ -2238,54 +2229,6 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                   boxShadow: "0 0 16px rgba(39, 224, 176, 0.4)",
                 }}
               />
-              <div
-                style={{
-                  position: "absolute",
-                  bottom: 8,
-                  left: 16,
-                  fontSize: 10,
-                  color: "#64748b",
-                  letterSpacing: 0.4,
-                }}
-              >
-                Warm
-              </div>
-              <div
-                style={{
-                  position: "absolute",
-                  bottom: 8,
-                  right: 16,
-                  fontSize: 10,
-                  color: "#64748b",
-                  letterSpacing: 0.4,
-                }}
-              >
-                Bright
-              </div>
-              <div
-                style={{
-                  position: "absolute",
-                  top: 16,
-                  right: 16,
-                  fontSize: 10,
-                  color: "#64748b",
-                  letterSpacing: 0.4,
-                }}
-              >
-                Crisp
-              </div>
-              <div
-                style={{
-                  position: "absolute",
-                  top: 16,
-                  left: 16,
-                  fontSize: 10,
-                  color: "#64748b",
-                  letterSpacing: 0.4,
-                }}
-              >
-                Gentle
-              </div>
             </div>
           </div>
           <div
@@ -2294,7 +2237,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
               maxWidth: "50%",
               display: "flex",
               flexDirection: "column",
-              gap: 12,
+              gap: 8,
             }}
           >
             <div style={{ fontSize: 12, fontWeight: 700, color: "#94a3b8" }}>
@@ -2306,22 +2249,22 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                 gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
                 gridTemplateRows: "repeat(3, 1fr)",
                 height: 200,
-                gap: 10,
+                gap: 4,
               }}
             >
               {harmoniaDegreeLabels.map((label, index) => {
                 const degree = index as HarmoniaScaleDegree;
                 const preview = computeHarmoniaResolution(degree);
                 const isActive = harmoniaSelectedDegree === degree;
-                const previewNotes = preview.notes.slice(0, 3).join(" • ");
                 const summary = describeHarmoniaChord(preview);
                 return (
                   <button
                     key={label}
                     type="button"
                     onClick={() => handleHarmoniaPadPress(degree)}
+                    aria-label={summary}
                     style={{
-                      padding: "12px 14px",
+                      padding: 0,
                       borderRadius: 12,
                       border: `1px solid ${isActive ? "#27E0B0" : "#1f2a3d"}`,
                       background: isActive
@@ -2337,45 +2280,26 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                       height: "100%",
                       gridColumn: index === 0 ? "1 / -1" : undefined,
                       display: "flex",
-                      flexDirection: "column",
-                      justifyContent: "space-between",
+                      alignItems: "center",
+                      justifyContent: "center",
                     }}
                     title={summary}
                   >
-                    <div style={{ fontSize: 13, fontWeight: 700 }}>{label}</div>
-                    <div
+                    <span
                       style={{
-                        fontSize: 11,
-                        color: "#94a3b8",
-                        marginTop: 2,
-                        textTransform: "uppercase",
-                        letterSpacing: 0.6,
+                        width: 10,
+                        height: 10,
+                        borderRadius: "50%",
+                        background: isActive ? "#27E0B0" : "#1f2a3d",
+                        boxShadow: isActive
+                          ? "0 0 12px rgba(39, 224, 176, 0.45)"
+                          : "none",
                       }}
-                    >
-                      {preview.voicingLabel}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: 11,
-                        color: "#cbd5f5",
-                        marginTop: 4,
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                      }}
-                    >
-                      {previewNotes}
-                      {preview.notes.length > 3 ? " …" : ""}
-                    </div>
+                    />
                   </button>
                 );
               })}
             </div>
-            {harmoniaChordSummary ? (
-              <div style={{ fontSize: 11, color: "#94a3b8" }}>
-                {harmoniaChordSummary}
-              </div>
-            ) : null}
           </div>
         </div>
       </Section>

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -62,6 +62,11 @@ interface InstrumentControlPanelProps {
     trackId: number,
     payload: { presetId: string | null; characterId?: string | null; name?: string }
   ) => void;
+  onHarmoniaRealtimeChange?: (payload: {
+    tone: number;
+    dynamics: number;
+    characterId?: string | null;
+  }) => void;
 }
 
 interface SliderProps {
@@ -284,6 +289,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
   isRecording = false,
   onRecordingChange,
   onPresetApplied,
+  onHarmoniaRealtimeChange,
 }) => {
   const pattern = track.pattern;
   const patternCharacterId = pattern?.characterId ?? null;
@@ -520,8 +526,19 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
         filter: tone,
         velocityFactor: dynamics,
       });
+      onHarmoniaRealtimeChange?.({
+        tone,
+        dynamics,
+        characterId: sourceCharacterId ?? patternCharacterId,
+      });
     },
-    [isHarmonia, updatePattern]
+    [
+      isHarmonia,
+      updatePattern,
+      onHarmoniaRealtimeChange,
+      sourceCharacterId,
+      patternCharacterId,
+    ]
   );
 
   const handleHarmoniaPadPointerDown = useCallback(

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -14,6 +14,13 @@ import { formatInstrumentLabel } from "./utils/instrument";
 import { ensureAudioContextRunning, filterValueToFrequency } from "./utils/audio";
 import { ARP_PRESETS } from "./arpPresets";
 import {
+  getScaleDegreeOffset,
+  isScaleName,
+  SCALE_INTERVALS,
+  SCALE_OPTIONS,
+  type ScaleName,
+} from "./music/scales";
+import {
   deleteInstrumentPreset,
   listInstrumentPresets,
   loadInstrumentPreset,
@@ -189,25 +196,6 @@ const createChordNotes = (rootNote: string, degrees: number[]) => {
 
 const DEGREE_LABELS = ["I", "II", "III", "IV", "V", "VI", "VII"] as const;
 
-const SCALE_INTERVALS = {
-  Major: [0, 2, 4, 5, 7, 9, 11],
-  Minor: [0, 2, 3, 5, 7, 8, 10],
-  Dorian: [0, 2, 3, 5, 7, 9, 10],
-  Phrygian: [0, 1, 3, 5, 7, 8, 10],
-  Lydian: [0, 2, 4, 6, 7, 9, 11],
-  Mixolydian: [0, 2, 4, 5, 7, 9, 10],
-  Locrian: [0, 1, 3, 5, 6, 8, 10],
-  HarmonicMinor: [0, 2, 3, 5, 7, 8, 11],
-  MelodicMinor: [0, 2, 3, 5, 7, 9, 11],
-} as const;
-
-type ScaleName = keyof typeof SCALE_INTERVALS;
-
-const SCALE_OPTIONS = Object.keys(SCALE_INTERVALS) as ScaleName[];
-
-const isScaleName = (value: string | undefined | null): value is ScaleName =>
-  value !== undefined && value !== null && SCALE_OPTIONS.includes(value as ScaleName);
-
 const SYNC_RATE_OPTIONS = [
   { value: "4n", label: "1/4" },
   { value: "8n", label: "1/8" },
@@ -248,15 +236,6 @@ const arraysEqual = <T,>(a?: T[] | null, b?: T[] | null) => {
     if (a[i] !== b[i]) return false;
   }
   return true;
-};
-
-const getScaleDegreeOffset = (intervals: readonly number[], degreeIndex: number) => {
-  if (!intervals.length) return 0;
-  const length = intervals.length;
-  const normalizedIndex = ((degreeIndex % length) + length) % length;
-  const base = intervals[normalizedIndex];
-  const octaves = Math.floor((degreeIndex - normalizedIndex) / length);
-  return base + octaves * 12;
 };
 
 const buildChordForDegree = (

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -2143,6 +2143,8 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
 
   const stickySections: ReactNode[] = [];
 
+  const HARMONIA_PAD_HEIGHT = 140;
+
   if (isHarmonia) {
     stickySections.push(
       <Section key="harmonia" padding={14}>
@@ -2150,7 +2152,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
           style={{
             display: "flex",
             gap: 16,
-            alignItems: "stretch",
+            alignItems: "center",
           }}
         >
           <div
@@ -2160,6 +2162,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
               display: "flex",
               flexDirection: "column",
               gap: 10,
+              justifyContent: "center",
             }}
           >
             <div
@@ -2170,6 +2173,8 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                 fontSize: 11,
                 color: "#94a3b8",
                 fontWeight: 600,
+                fontVariantNumeric: "tabular-nums",
+                whiteSpace: "nowrap",
               }}
             >
               <span>XY Pad</span>
@@ -2186,13 +2191,14 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
               style={{
                 position: "relative",
                 width: "100%",
-                height: 200,
+                height: HARMONIA_PAD_HEIGHT,
                 borderRadius: 14,
                 border: "1px solid #1f2a3d",
                 background: "linear-gradient(135deg, #17253a 0%, #0c1524 100%)",
                 cursor: updatePattern ? "pointer" : "default",
                 touchAction: "none",
                 overflow: "hidden",
+                userSelect: "none",
               }}
             >
               <div
@@ -2203,6 +2209,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                   right: 0,
                   height: 1,
                   background: "rgba(148, 163, 184, 0.25)",
+                  pointerEvents: "none",
                 }}
               />
               <div
@@ -2213,6 +2220,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                   bottom: 0,
                   width: 1,
                   background: "rgba(148, 163, 184, 0.25)",
+                  pointerEvents: "none",
                 }}
               />
               <div
@@ -2227,6 +2235,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                   border: "2px solid #27E0B0",
                   background: "rgba(39, 224, 176, 0.25)",
                   boxShadow: "0 0 16px rgba(39, 224, 176, 0.4)",
+                  pointerEvents: "none",
                 }}
               />
             </div>
@@ -2238,9 +2247,19 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
               display: "flex",
               flexDirection: "column",
               gap: 8,
+              justifyContent: "center",
             }}
           >
-            <div style={{ fontSize: 12, fontWeight: 700, color: "#94a3b8" }}>
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 700,
+                color: "#94a3b8",
+                display: "flex",
+                alignItems: "center",
+                minHeight: 18,
+              }}
+            >
               Chord Pads
             </div>
             <div
@@ -2248,7 +2267,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                 display: "grid",
                 gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
                 gridTemplateRows: "repeat(3, 1fr)",
-                height: 200,
+                height: HARMONIA_PAD_HEIGHT,
                 gap: 4,
               }}
             >

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -2303,7 +2303,8 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
+                gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
+                height: 200,
                 gap: 10,
               }}
             >
@@ -2332,7 +2333,10 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                         ? "0 0 16px rgba(39, 224, 176, 0.2)"
                         : "none",
                       transition: "background 0.15s ease",
-                      minHeight: 68,
+                      height: "100%",
+                      display: "flex",
+                      flexDirection: "column",
+                      justifyContent: "space-between",
                     }}
                     title={summary}
                   >

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -657,19 +657,18 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
               harmoniaBorrowedLabel: resolution.borrowed
                 ? resolution.voicingLabel
                 : undefined,
+              filter: harmoniaControls.tone,
             }
           : undefined;
-        resolution.notes.forEach((note) => {
-          trigger(
-            now,
-            harmoniaControls.dynamics,
-            0,
-            note,
-            pattern?.sustain ?? undefined,
-            chunkPayload,
-            sourceCharacterId ?? patternCharacterId ?? undefined
-          );
-        });
+        trigger(
+          now,
+          harmoniaControls.dynamics,
+          0,
+          resolution.root,
+          pattern?.sustain ?? undefined,
+          chunkPayload,
+          sourceCharacterId ?? patternCharacterId ?? undefined
+        );
       }
     },
     [

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -236,6 +236,39 @@
       "type": "number",
       "description": "Loop length in seconds for free-time note events",
       "minimum": 0
+    },
+    "harmoniaComplexity": {
+      "type": "string",
+      "description": "Selected Harmonia complexity tier",
+      "enum": ["simple", "extended", "lush"]
+    },
+    "harmoniaTone": {
+      "type": "number",
+      "description": "Normalized Harmonia filter cutoff value",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "harmoniaDynamics": {
+      "type": "number",
+      "description": "Normalized Harmonia velocity scaling",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "harmoniaBass": {
+      "type": "boolean",
+      "description": "Whether Harmonia bass reinforcement is enabled"
+    },
+    "harmoniaArp": {
+      "type": "boolean",
+      "description": "Whether Harmonia arpeggiation is enabled"
+    },
+    "harmoniaPatternId": {
+      "type": "string",
+      "description": "Active Harmonia pattern preset identifier"
+    },
+    "harmoniaBorrowedLabel": {
+      "type": "string",
+      "description": "Selected borrowed chord label for Harmonia"
     }
   }
 }

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -46,5 +46,12 @@ export interface Chunk {
   autopilot?: boolean;
   noteEvents?: NoteEvent[];
   noteLoopLength?: number;
+  harmoniaComplexity?: "simple" | "extended" | "lush";
+  harmoniaTone?: number;
+  harmoniaDynamics?: number;
+  harmoniaBass?: boolean;
+  harmoniaArp?: boolean;
+  harmoniaPatternId?: string;
+  harmoniaBorrowedLabel?: string;
 }
 

--- a/src/instruments/harmonia/audio.ts
+++ b/src/instruments/harmonia/audio.ts
@@ -104,6 +104,8 @@ const deriveResolution = (
   });
 };
 
+export const HARMONIA_BASE_VOLUME_DB = -8;
+
 export const createHarmoniaNodes = (
   tone: ToneLike = Tone as ToneLike
 ): HarmoniaNodes => {
@@ -121,7 +123,7 @@ export const createHarmoniaNodes = (
     frequency: filterValueToFrequency(HARMONIA_DEFAULT_CONTROLS.tone),
     Q: 0.8,
   });
-  const volume = new tone.Volume(-8);
+  const volume = new tone.Volume(HARMONIA_BASE_VOLUME_DB);
   synth.connect(filter);
   filter.connect(volume);
   return { synth, filter, volume };

--- a/src/instruments/harmonia/audio.ts
+++ b/src/instruments/harmonia/audio.ts
@@ -1,0 +1,174 @@
+import * as Tone from "tone";
+
+import type { Chunk } from "../../chunks";
+import { filterValueToFrequency } from "../../utils/audio";
+import { isScaleName, type ScaleName } from "../../music/scales";
+import {
+  HARMONIA_CHARACTER_PRESETS,
+  HARMONIA_DEFAULT_CONTROLS,
+} from "./constants";
+import {
+  clampControlValue,
+  normalizeControlState,
+  resolveHarmoniaChord,
+} from "./harmony";
+import type {
+  HarmoniaCharacterId,
+  HarmoniaComplexity,
+  HarmoniaControlState,
+  HarmoniaScaleDegree,
+} from "./types";
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+export interface HarmoniaNodes {
+  synth: Tone.PolySynth;
+  filter: Tone.Filter;
+  volume: Tone.Volume;
+}
+
+const resolveCharacterPreset = (characterId?: HarmoniaCharacterId | null) => {
+  if (!characterId) return undefined;
+  return HARMONIA_CHARACTER_PRESETS.find((preset) => preset.id === characterId);
+};
+
+const deriveControlState = (
+  chunk?: Chunk,
+  characterId?: HarmoniaCharacterId | null
+): HarmoniaControlState => {
+  const preset = resolveCharacterPreset(characterId);
+  const complexity =
+    (chunk?.harmoniaComplexity as HarmoniaComplexity | undefined) ??
+    preset?.complexity ??
+    HARMONIA_DEFAULT_CONTROLS.complexity;
+  return normalizeControlState({
+    complexity,
+    tone: chunk?.harmoniaTone ?? undefined,
+    dynamics: chunk?.harmoniaDynamics ?? undefined,
+    bassEnabled: chunk?.harmoniaBass ?? undefined,
+    arpEnabled: chunk?.harmoniaArp ?? undefined,
+    patternId: chunk?.harmoniaPatternId,
+  });
+};
+
+const deriveScaleName = (candidate?: string | null): ScaleName => {
+  if (candidate && isScaleName(candidate)) {
+    return candidate as ScaleName;
+  }
+  return "Major";
+};
+
+const deriveDegree = (value?: number | null): HarmoniaScaleDegree => {
+  const clamped = clamp(Math.round(value ?? 0), 0, 6);
+  return clamped as HarmoniaScaleDegree;
+};
+
+const deriveResolution = (
+  chunk?: Chunk,
+  controls?: HarmoniaControlState,
+  characterId?: HarmoniaCharacterId | null
+) => {
+  const tonalCenter = chunk?.tonalCenter ?? chunk?.note ?? "C4";
+  const scale = deriveScaleName(chunk?.scale);
+  const degree = deriveDegree(chunk?.degree);
+  const complexity = controls?.complexity ?? HARMONIA_DEFAULT_CONTROLS.complexity;
+  const preset = resolveCharacterPreset(characterId);
+  const allowBorrowed =
+    preset?.allowBorrowed ?? Boolean(chunk?.harmoniaBorrowedLabel);
+  const preferredVoicingLabel = chunk?.harmoniaBorrowedLabel ?? undefined;
+  return resolveHarmoniaChord({
+    tonalCenter,
+    scale,
+    degree,
+    complexity,
+    allowBorrowed,
+    preferredVoicingLabel,
+  });
+};
+
+export const createHarmoniaNodes = (tone: typeof Tone = Tone): HarmoniaNodes => {
+  const synth = new tone.PolySynth();
+  const settable = synth as unknown as {
+    set?: (values: Record<string, unknown>) => void;
+  };
+  settable.set?.({
+    maxPolyphony: 16,
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.15, decay: 0.4, sustain: 0.75, release: 1.8 },
+  });
+  const filter = new tone.Filter({
+    type: "lowpass",
+    frequency: filterValueToFrequency(HARMONIA_DEFAULT_CONTROLS.tone),
+    Q: 0.8,
+  });
+  const volume = new tone.Volume(-8);
+  synth.connect(filter);
+  filter.connect(volume);
+  return { synth, filter, volume };
+};
+
+export interface HarmoniaTriggerOptions {
+  nodes: HarmoniaNodes;
+  time: number;
+  velocity?: number;
+  sustain?: number;
+  chunk?: Chunk;
+  characterId?: string | null;
+}
+
+export const triggerHarmoniaChord = ({
+  nodes,
+  time,
+  velocity = 1,
+  sustain,
+  chunk,
+  characterId,
+}: HarmoniaTriggerOptions) => {
+  const controls = deriveControlState(chunk, characterId as HarmoniaCharacterId);
+  const resolution = deriveResolution(chunk, controls, characterId as HarmoniaCharacterId);
+
+  const chordNotes = chunk?.notes?.length
+    ? chunk.notes.slice()
+    : resolution.notes.slice();
+
+  if (chordNotes.length === 0 && resolution.root) {
+    chordNotes.push(resolution.root);
+  }
+
+  if (controls.bassEnabled && resolution.root) {
+    const bassNote = Tone.Frequency(resolution.root).transpose(-12).toNote();
+    chordNotes.unshift(bassNote);
+  }
+
+  const filterValue = clampControlValue(
+    chunk?.harmoniaTone ?? chunk?.filter ?? controls.tone
+  );
+  const targetFrequency = filterValueToFrequency(filterValue);
+  nodes.filter.frequency.rampTo(targetFrequency, 0.05);
+
+  const level = clamp(velocity, 0, 1);
+  const hold = Math.max(sustain ?? chunk?.sustain ?? 1.6, 0.1);
+
+  if (!controls.arpEnabled || chordNotes.length <= 1) {
+    nodes.synth.triggerAttackRelease(chordNotes, hold, time, level);
+    return;
+  }
+
+  const stepDuration = Math.min(
+    hold / Math.max(chordNotes.length, 1),
+    Tone.Time("16n").toSeconds()
+  );
+  const noteDuration = Math.max(stepDuration * 0.9, hold * 0.4);
+
+  chordNotes.forEach((note, index) => {
+    const start = time + index * stepDuration;
+    nodes.synth.triggerAttackRelease(note, noteDuration, start, level);
+  });
+};
+
+export const disposeHarmoniaNodes = (nodes: HarmoniaNodes) => {
+  nodes.synth.dispose();
+  nodes.filter.dispose();
+  nodes.volume.dispose();
+};

--- a/src/instruments/harmonia/audio.ts
+++ b/src/instruments/harmonia/audio.ts
@@ -6,6 +6,7 @@ import { isScaleName, type ScaleName } from "../../music/scales";
 import {
   HARMONIA_CHARACTER_PRESETS,
   HARMONIA_DEFAULT_CONTROLS,
+  HARMONIA_PATTERN_IDS,
 } from "./constants";
 import {
   clampControlValue,
@@ -16,8 +17,22 @@ import type {
   HarmoniaCharacterId,
   HarmoniaComplexity,
   HarmoniaControlState,
+  HarmoniaPatternId,
   HarmoniaScaleDegree,
 } from "./types";
+
+type ToneLike = Pick<
+  typeof Tone,
+  "PolySynth" | "Filter" | "Volume" | "Frequency" | "Time"
+>;
+
+const isHarmoniaPatternId = (
+  value: unknown
+): value is HarmoniaPatternId =>
+  typeof value === "string" &&
+  (HARMONIA_PATTERN_IDS as readonly string[]).includes(
+    value as HarmoniaPatternId
+  );
 
 const clamp = (value: number, min: number, max: number) =>
   Math.max(min, Math.min(max, value));
@@ -48,7 +63,9 @@ const deriveControlState = (
     dynamics: chunk?.harmoniaDynamics ?? undefined,
     bassEnabled: chunk?.harmoniaBass ?? undefined,
     arpEnabled: chunk?.harmoniaArp ?? undefined,
-    patternId: chunk?.harmoniaPatternId,
+    patternId: isHarmoniaPatternId(chunk?.harmoniaPatternId)
+      ? chunk?.harmoniaPatternId
+      : undefined,
   });
 };
 
@@ -87,7 +104,9 @@ const deriveResolution = (
   });
 };
 
-export const createHarmoniaNodes = (tone: typeof Tone = Tone): HarmoniaNodes => {
+export const createHarmoniaNodes = (
+  tone: ToneLike = Tone as ToneLike
+): HarmoniaNodes => {
   const synth = new tone.PolySynth();
   const settable = synth as unknown as {
     set?: (values: Record<string, unknown>) => void;

--- a/src/instruments/harmonia/constants.ts
+++ b/src/instruments/harmonia/constants.ts
@@ -83,6 +83,12 @@ export const HARMONIA_CHARACTER_PRESETS: HarmoniaCharacterPreset[] = [
   },
 ];
 
+export const HARMONIA_PATTERN_IDS = [
+  "basic-progression",
+  "descending-line",
+  "circle-of-fifths",
+] as const;
+
 export const HARMONIA_PATTERN_PRESETS: HarmoniaPatternPreset[] = [
   {
     id: "basic-progression",

--- a/src/instruments/harmonia/constants.ts
+++ b/src/instruments/harmonia/constants.ts
@@ -1,0 +1,288 @@
+import type {
+  HarmoniaCharacterPreset,
+  HarmoniaChordLibraryEntry,
+  HarmoniaChordVoicing,
+  HarmoniaComplexity,
+  HarmoniaControlState,
+  HarmoniaPatternPreset,
+} from "./types";
+
+const createVoicing = (
+  label: string,
+  intervals: number[],
+  description?: string,
+  borrowed = false,
+  source?: string,
+  rootOffset = 0
+): HarmoniaChordVoicing => ({
+  label,
+  intervals,
+  description,
+  borrowed,
+  source,
+  rootOffset,
+});
+
+const lushStack = (base: number[]) => {
+  const extended = base.slice();
+  if (!extended.includes(11)) {
+    extended.push(11);
+  }
+  extended.push(14, 17, 21);
+  return extended.sort((a, b) => a - b);
+};
+
+const createDiatonicSet = (
+  simpleIntervals: number[],
+  extendedIntervals: number[],
+  lushBase: number[],
+  labels: { simple: string; extended: string; lush: string },
+  descriptions?: { simple?: string; extended?: string; lush?: string }
+): Record<HarmoniaComplexity, HarmoniaChordVoicing> => ({
+  simple: createVoicing(labels.simple, simpleIntervals, descriptions?.simple),
+  extended: createVoicing(
+    labels.extended,
+    extendedIntervals,
+    descriptions?.extended
+  ),
+  lush: createVoicing(labels.lush, lushStack(lushBase), descriptions?.lush),
+});
+
+export const HARMONIA_CHARACTER_PRESETS: HarmoniaCharacterPreset[] = [
+  {
+    id: "simple",
+    name: "Simple",
+    description: "Triads only with warm pad tone.",
+    type: "Harmonia",
+    complexity: "simple",
+    allowBorrowed: false,
+  },
+  {
+    id: "extended",
+    name: "Extended",
+    description: "Adds seventh chords for richer harmony.",
+    type: "Harmonia",
+    complexity: "extended",
+    allowBorrowed: false,
+  },
+  {
+    id: "lush",
+    name: "Lush",
+    description: "Stacked extensions reaching 13ths for cinematic pads.",
+    type: "Harmonia",
+    complexity: "lush",
+    allowBorrowed: false,
+  },
+  {
+    id: "borrowed",
+    name: "Borrowed",
+    description: "Modal interchange options woven into lush voicings.",
+    type: "Harmonia",
+    complexity: "lush",
+    allowBorrowed: true,
+  },
+];
+
+export const HARMONIA_PATTERN_PRESETS: HarmoniaPatternPreset[] = [
+  {
+    id: "basic-progression",
+    name: "Basic Progression",
+    description: "Classic I–V–vi–IV pop sequence.",
+    degrees: [0, 4, 5, 3],
+  },
+  {
+    id: "descending-line",
+    name: "Descending Line",
+    description: "Falling bass line: vi–V–IV–iii.",
+    degrees: [5, 4, 3, 2],
+  },
+  {
+    id: "circle-of-fifths",
+    name: "Circle of Fifths",
+    description: "Full cycle through dominant motions.",
+    degrees: [0, 3, 6, 2, 5, 1, 4, 0],
+  },
+];
+
+export const HARMONIA_DEFAULT_CONTROLS: HarmoniaControlState = {
+  complexity: "simple",
+  tone: 0.7,
+  dynamics: 0.8,
+  bassEnabled: true,
+  arpEnabled: false,
+};
+
+const borrowedFromParallelMinor = (
+  label: string,
+  intervals: number[],
+  rootOffset = 0
+) =>
+  createVoicing(
+    label,
+    intervals,
+    "Borrowed from parallel minor mode.",
+    true,
+    "parallel-minor",
+    rootOffset
+  );
+
+const borrowedFromDorian = (label: string, intervals: number[], rootOffset = 0) =>
+  createVoicing(label, intervals, "Borrowed from Dorian mode.", true, "dorian", rootOffset);
+
+export const HARMONIA_CHORD_LIBRARY: HarmoniaChordLibraryEntry[] = [
+  {
+    degree: 0,
+    romanNumeral: "I",
+    diatonic: createDiatonicSet(
+      [0, 4, 7],
+      [0, 4, 7, 11],
+      [0, 4, 7, 11],
+      { simple: "I", extended: "IMaj7", lush: "IMaj13" },
+      {
+        simple: "Tonic major triad.",
+        extended: "Major seventh tonic chord.",
+        lush: "Rich major 13th voicing.",
+      }
+    ),
+    borrowed: [
+      borrowedFromParallelMinor("i", [0, 3, 7]),
+      createVoicing(
+        "Iadd9",
+        [0, 4, 7, 14],
+        "Adds ninth color for airy tonic.",
+        true,
+        "lydian"
+      ),
+    ],
+  },
+  {
+    degree: 1,
+    romanNumeral: "ii",
+    diatonic: createDiatonicSet(
+      [0, 3, 7],
+      [0, 3, 7, 10],
+      [0, 3, 7, 10],
+      { simple: "ii", extended: "ii7", lush: "ii11" },
+      {
+        simple: "Supertonic minor triad.",
+        extended: "Supertonic minor seventh.",
+        lush: "Suspended ii chord with 11th.",
+      }
+    ),
+    borrowed: [
+      borrowedFromParallelMinor("ii°", [0, 3, 6]),
+      borrowedFromDorian("II", [0, 4, 7]),
+    ],
+  },
+  {
+    degree: 2,
+    romanNumeral: "iii",
+    diatonic: createDiatonicSet(
+      [0, 3, 7],
+      [0, 3, 7, 10],
+      [0, 3, 7, 10],
+      { simple: "iii", extended: "iii7", lush: "iii9" },
+      {
+        simple: "Mediant minor triad.",
+        extended: "Mediant minor seventh chord.",
+        lush: "Mediant with added 9th color.",
+      }
+    ),
+    borrowed: [
+      borrowedFromParallelMinor("♭III", [0, 4, 7], -1),
+    ],
+  },
+  {
+    degree: 3,
+    romanNumeral: "IV",
+    diatonic: createDiatonicSet(
+      [0, 4, 7],
+      [0, 4, 7, 11],
+      [0, 4, 7, 11],
+      { simple: "IV", extended: "IVMaj7", lush: "IV13" },
+      {
+        simple: "Subdominant major triad.",
+        extended: "Subdominant major seventh.",
+        lush: "Expansive subdominant with 13th.",
+      }
+    ),
+    borrowed: [
+      borrowedFromParallelMinor("iv", [0, 3, 7]),
+      borrowedFromParallelMinor("iv7", [0, 3, 7, 10]),
+    ],
+  },
+  {
+    degree: 4,
+    romanNumeral: "V",
+    diatonic: createDiatonicSet(
+      [0, 4, 7],
+      [0, 4, 7, 10],
+      [0, 4, 7, 10],
+      { simple: "V", extended: "V7", lush: "V13" },
+      {
+        simple: "Dominant major triad.",
+        extended: "Dominant seventh chord.",
+        lush: "Dominant with full extensions.",
+      }
+    ),
+    borrowed: [
+      createVoicing(
+        "Vsus4",
+        [0, 5, 7, 10],
+        "Suspended dominant for tension.",
+        true,
+        "mixolydian"
+      ),
+      borrowedFromParallelMinor("♭VII", [0, 4, 7], 3),
+    ],
+  },
+  {
+    degree: 5,
+    romanNumeral: "vi",
+    diatonic: createDiatonicSet(
+      [0, 3, 7],
+      [0, 3, 7, 10],
+      [0, 3, 7, 10],
+      { simple: "vi", extended: "vi7", lush: "vi9" },
+      {
+        simple: "Submediant minor triad.",
+        extended: "Submediant minor seventh.",
+        lush: "Submediant with ninth.",
+      }
+    ),
+    borrowed: [
+      borrowedFromParallelMinor("♭VI", [0, 4, 7], -1),
+    ],
+  },
+  {
+    degree: 6,
+    romanNumeral: "vii°",
+    diatonic: createDiatonicSet(
+      [0, 3, 6],
+      [0, 3, 6, 10],
+      [0, 3, 6, 10],
+      { simple: "vii°", extended: "viiø7", lush: "viiø11" },
+      {
+        simple: "Leading-tone diminished triad.",
+        extended: "Half-diminished seventh.",
+        lush: "Half-diminished with 11th.",
+      }
+    ),
+    borrowed: [
+      borrowedFromParallelMinor("vii°7", [0, 3, 6, 9]),
+      createVoicing(
+        "♭VIIadd6",
+        [0, 4, 7, 9],
+        "Major flat-seven sonority for lift.",
+        true,
+        "mixolydian",
+        -1
+      ),
+    ],
+  },
+];
+
+export const HARMONIA_SCALE_DEGREE_LABELS = HARMONIA_CHORD_LIBRARY.map(
+  (entry) => entry.romanNumeral
+);
+

--- a/src/instruments/harmonia/harmony.ts
+++ b/src/instruments/harmonia/harmony.ts
@@ -1,0 +1,110 @@
+import * as Tone from "tone";
+
+import { getScaleDegreeOffset, SCALE_INTERVALS } from "../../music/scales";
+import {
+  HARMONIA_CHORD_LIBRARY,
+  HARMONIA_DEFAULT_CONTROLS,
+  HARMONIA_SCALE_DEGREE_LABELS,
+} from "./constants";
+import type {
+  HarmoniaChordLibraryEntry,
+  HarmoniaChordRequest,
+  HarmoniaChordResolution,
+  HarmoniaChordVoicing,
+  HarmoniaComplexity,
+  HarmoniaControlState,
+  HarmoniaScaleDegree,
+} from "./types";
+
+export const HARMONIA_COMPLEXITY_ORDER: HarmoniaComplexity[] = [
+  "simple",
+  "extended",
+  "lush",
+];
+
+export const clampControlValue = (value: number, min = 0, max = 1) =>
+  Math.max(min, Math.min(max, value));
+
+export const normalizeControlState = (
+  state?: Partial<HarmoniaControlState>
+): HarmoniaControlState => ({
+  complexity: state?.complexity ?? HARMONIA_DEFAULT_CONTROLS.complexity,
+  tone: clampControlValue(state?.tone ?? HARMONIA_DEFAULT_CONTROLS.tone),
+  dynamics: clampControlValue(
+    state?.dynamics ?? HARMONIA_DEFAULT_CONTROLS.dynamics
+  ),
+  bassEnabled: state?.bassEnabled ?? HARMONIA_DEFAULT_CONTROLS.bassEnabled,
+  arpEnabled: state?.arpEnabled ?? HARMONIA_DEFAULT_CONTROLS.arpEnabled,
+  patternId: state?.patternId,
+});
+
+const findLibraryEntry = (degree: HarmoniaScaleDegree): HarmoniaChordLibraryEntry => {
+  const entry = HARMONIA_CHORD_LIBRARY.find((candidate) => candidate.degree === degree);
+  if (entry) return entry;
+  return HARMONIA_CHORD_LIBRARY[0];
+};
+
+const selectVoicing = (
+  entry: HarmoniaChordLibraryEntry,
+  complexity: HarmoniaComplexity,
+  allowBorrowed?: boolean,
+  preferredLabel?: string
+): HarmoniaChordVoicing => {
+  const diatonic = entry.diatonic[complexity] ?? entry.diatonic.simple;
+  if (!allowBorrowed || !entry.borrowed?.length) {
+    return diatonic;
+  }
+  if (preferredLabel) {
+    const preferred = entry.borrowed.find(
+      (candidate) => candidate.label.toLowerCase() === preferredLabel.toLowerCase()
+    );
+    if (preferred) {
+      return preferred;
+    }
+  }
+  return entry.borrowed[0];
+};
+
+export const resolveHarmoniaChord = (
+  request: HarmoniaChordRequest
+): HarmoniaChordResolution => {
+  const entry = findLibraryEntry(request.degree);
+  const voicing = selectVoicing(
+    entry,
+    request.complexity,
+    request.allowBorrowed,
+    request.preferredVoicingLabel
+  );
+  const intervals = SCALE_INTERVALS[request.scale] ?? SCALE_INTERVALS.Major;
+  const rootOffset = getScaleDegreeOffset(intervals, entry.degree) + (voicing.rootOffset ?? 0);
+  const tonalCenterMidi = Tone.Frequency(request.tonalCenter).toMidi();
+  const chordRootMidi = tonalCenterMidi + rootOffset;
+  const chordMidiNotes = voicing.intervals.map((interval) => chordRootMidi + interval);
+  const chordNotes = chordMidiNotes.map((value) => Tone.Frequency(value, "midi").toNote());
+  return {
+    root: Tone.Frequency(chordRootMidi, "midi").toNote(),
+    notes: chordNotes,
+    intervals: voicing.intervals.slice(),
+    romanNumeral: entry.romanNumeral,
+    borrowed: Boolean(voicing.borrowed),
+    voicingLabel: voicing.label,
+  };
+};
+
+export const listHarmoniaDegreeLabels = () => HARMONIA_SCALE_DEGREE_LABELS.slice();
+
+export const listBorrowedOptions = (degree: HarmoniaScaleDegree) => {
+  const entry = findLibraryEntry(degree);
+  if (!entry.borrowed) return [];
+  return entry.borrowed.map((voicing) => ({
+    label: voicing.label,
+    description: voicing.description,
+    source: voicing.source,
+  }));
+};
+
+export const describeHarmoniaChord = (resolution: HarmoniaChordResolution) =>
+  `${resolution.romanNumeral} (${resolution.voicingLabel}) → ${resolution.notes.join(
+    " • "
+  )}`;
+

--- a/src/instruments/harmonia/index.ts
+++ b/src/instruments/harmonia/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./constants";
+export * from "./harmony";

--- a/src/instruments/harmonia/index.ts
+++ b/src/instruments/harmonia/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./constants";
 export * from "./harmony";
+export * from "./audio";

--- a/src/instruments/harmonia/types.ts
+++ b/src/instruments/harmonia/types.ts
@@ -1,0 +1,73 @@
+import type { InstrumentCharacter } from "../../packs";
+import type { ScaleName } from "../../music/scales";
+
+export type HarmoniaComplexity = "simple" | "extended" | "lush";
+
+export type HarmoniaCharacterId =
+  | "simple"
+  | "extended"
+  | "lush"
+  | "borrowed";
+
+export type HarmoniaPatternId =
+  | "basic-progression"
+  | "descending-line"
+  | "circle-of-fifths";
+
+export type HarmoniaScaleDegree = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface HarmoniaControlState {
+  complexity: HarmoniaComplexity;
+  tone: number;
+  dynamics: number;
+  bassEnabled: boolean;
+  arpEnabled: boolean;
+  patternId?: HarmoniaPatternId;
+}
+
+export interface HarmoniaChordVoicing {
+  label: string;
+  intervals: readonly number[];
+  description?: string;
+  borrowed?: boolean;
+  source?: string;
+  rootOffset?: number;
+}
+
+export interface HarmoniaChordLibraryEntry {
+  degree: HarmoniaScaleDegree;
+  romanNumeral: string;
+  diatonic: Record<HarmoniaComplexity, HarmoniaChordVoicing>;
+  borrowed?: readonly HarmoniaChordVoicing[];
+}
+
+export interface HarmoniaCharacterPreset extends InstrumentCharacter {
+  complexity: HarmoniaComplexity;
+  allowBorrowed: boolean;
+}
+
+export interface HarmoniaPatternPreset {
+  id: HarmoniaPatternId;
+  name: string;
+  description: string;
+  degrees: readonly HarmoniaScaleDegree[];
+}
+
+export interface HarmoniaChordResolution {
+  root: string;
+  notes: string[];
+  intervals: number[];
+  romanNumeral: string;
+  borrowed: boolean;
+  voicingLabel: string;
+}
+
+export interface HarmoniaChordRequest {
+  tonalCenter: string;
+  scale: ScaleName;
+  degree: HarmoniaScaleDegree;
+  complexity: HarmoniaComplexity;
+  allowBorrowed?: boolean;
+  preferredVoicingLabel?: string;
+}
+

--- a/src/music/scales.ts
+++ b/src/music/scales.ts
@@ -1,0 +1,33 @@
+export const SCALE_INTERVALS = {
+  Major: [0, 2, 4, 5, 7, 9, 11],
+  Minor: [0, 2, 3, 5, 7, 8, 10],
+  Dorian: [0, 2, 3, 5, 7, 9, 10],
+  Phrygian: [0, 1, 3, 5, 7, 8, 10],
+  Lydian: [0, 2, 4, 6, 7, 9, 11],
+  Mixolydian: [0, 2, 4, 5, 7, 9, 10],
+  Locrian: [0, 1, 3, 5, 6, 8, 10],
+  HarmonicMinor: [0, 2, 3, 5, 7, 8, 11],
+  MelodicMinor: [0, 2, 3, 5, 7, 9, 11],
+} as const;
+
+export type ScaleName = keyof typeof SCALE_INTERVALS;
+
+export const SCALE_OPTIONS = Object.keys(SCALE_INTERVALS) as ScaleName[];
+
+export const isScaleName = (
+  value: string | undefined | null
+): value is ScaleName =>
+  value !== undefined && value !== null && SCALE_OPTIONS.includes(value as ScaleName);
+
+export const getScaleDegreeOffset = (
+  intervals: readonly number[],
+  degreeIndex: number
+) => {
+  if (!intervals.length) return 0;
+  const length = intervals.length;
+  const normalizedIndex = ((degreeIndex % length) + length) % length;
+  const base = intervals[normalizedIndex];
+  const octaves = Math.floor((degreeIndex - normalizedIndex) / length);
+  return base + octaves * 12;
+};
+

--- a/src/packs.ts
+++ b/src/packs.ts
@@ -16,6 +16,15 @@ export interface InstrumentCharacter extends InstrumentSpec {
 export interface InstrumentDefinition {
   defaultCharacterId?: string;
   characters: InstrumentCharacter[];
+  defaultPatternId?: string;
+  patterns?: InstrumentPatternPreset[];
+}
+
+export interface InstrumentPatternPreset {
+  id: string;
+  name: string;
+  description?: string;
+  degrees: number[];
 }
 
 export interface EffectSpec {

--- a/src/packs/chiptune.json
+++ b/src/packs/chiptune.json
@@ -228,6 +228,56 @@
           ]
         }
       ]
+    },
+    "harmonia": {
+      "defaultCharacterId": "simple",
+      "defaultPatternId": "basic-progression",
+      "characters": [
+        {
+          "id": "simple",
+          "name": "Simple",
+          "description": "Triads only for easy pads.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "extended",
+          "name": "Extended",
+          "description": "Adds seventh chords for richer harmony.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "lush",
+          "name": "Lush",
+          "description": "Expansive 9th, 11th, and 13th chords.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "borrowed",
+          "name": "Borrowed",
+          "description": "Modal interchange colors for surprise turns.",
+          "type": "Harmonia"
+        }
+      ],
+      "patterns": [
+        {
+          "id": "basic-progression",
+          "name": "Basic Progression",
+          "description": "Classic I–V–vi–IV pop cadence.",
+          "degrees": [0, 4, 5, 3]
+        },
+        {
+          "id": "descending-line",
+          "name": "Descending Line",
+          "description": "Falling motion: vi–V–IV–iii.",
+          "degrees": [5, 4, 3, 2]
+        },
+        {
+          "id": "circle-of-fifths",
+          "name": "Circle of Fifths",
+          "description": "Extended dominant cycle back to tonic.",
+          "degrees": [0, 3, 6, 2, 5, 1, 4, 0]
+        }
+      ]
     }
   },
   "chunks": [

--- a/src/packs/early-2000s-edm.json
+++ b/src/packs/early-2000s-edm.json
@@ -362,6 +362,56 @@
           ]
         }
       ]
+    },
+    "harmonia": {
+      "defaultCharacterId": "simple",
+      "defaultPatternId": "basic-progression",
+      "characters": [
+        {
+          "id": "simple",
+          "name": "Simple",
+          "description": "Triads only for easy pads.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "extended",
+          "name": "Extended",
+          "description": "Adds seventh chords for richer harmony.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "lush",
+          "name": "Lush",
+          "description": "Expansive 9th, 11th, and 13th chords.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "borrowed",
+          "name": "Borrowed",
+          "description": "Modal interchange colors for surprise turns.",
+          "type": "Harmonia"
+        }
+      ],
+      "patterns": [
+        {
+          "id": "basic-progression",
+          "name": "Basic Progression",
+          "description": "Classic I–V–vi–IV pop cadence.",
+          "degrees": [0, 4, 5, 3]
+        },
+        {
+          "id": "descending-line",
+          "name": "Descending Line",
+          "description": "Falling motion: vi–V–IV–iii.",
+          "degrees": [5, 4, 3, 2]
+        },
+        {
+          "id": "circle-of-fifths",
+          "name": "Circle of Fifths",
+          "description": "Extended dominant cycle back to tonic.",
+          "degrees": [0, 3, 6, 2, 5, 1, 4, 0]
+        }
+      ]
     }
   },
   "chunks": [

--- a/src/packs/kraftwerk.json
+++ b/src/packs/kraftwerk.json
@@ -232,6 +232,56 @@
           ]
         }
       ]
+    },
+    "harmonia": {
+      "defaultCharacterId": "simple",
+      "defaultPatternId": "basic-progression",
+      "characters": [
+        {
+          "id": "simple",
+          "name": "Simple",
+          "description": "Triads only for easy pads.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "extended",
+          "name": "Extended",
+          "description": "Adds seventh chords for richer harmony.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "lush",
+          "name": "Lush",
+          "description": "Expansive 9th, 11th, and 13th chords.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "borrowed",
+          "name": "Borrowed",
+          "description": "Modal interchange colors for surprise turns.",
+          "type": "Harmonia"
+        }
+      ],
+      "patterns": [
+        {
+          "id": "basic-progression",
+          "name": "Basic Progression",
+          "description": "Classic I–V–vi–IV pop cadence.",
+          "degrees": [0, 4, 5, 3]
+        },
+        {
+          "id": "descending-line",
+          "name": "Descending Line",
+          "description": "Falling motion: vi–V–IV–iii.",
+          "degrees": [5, 4, 3, 2]
+        },
+        {
+          "id": "circle-of-fifths",
+          "name": "Circle of Fifths",
+          "description": "Extended dominant cycle back to tonic.",
+          "degrees": [0, 3, 6, 2, 5, 1, 4, 0]
+        }
+      ]
     }
   },
   "chunks": [

--- a/src/packs/phonk.json
+++ b/src/packs/phonk.json
@@ -271,6 +271,56 @@
           ]
         }
       ]
+    },
+    "harmonia": {
+      "defaultCharacterId": "simple",
+      "defaultPatternId": "basic-progression",
+      "characters": [
+        {
+          "id": "simple",
+          "name": "Simple",
+          "description": "Triads only for easy pads.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "extended",
+          "name": "Extended",
+          "description": "Adds seventh chords for richer harmony.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "lush",
+          "name": "Lush",
+          "description": "Expansive 9th, 11th, and 13th chords.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "borrowed",
+          "name": "Borrowed",
+          "description": "Modal interchange colors for surprise turns.",
+          "type": "Harmonia"
+        }
+      ],
+      "patterns": [
+        {
+          "id": "basic-progression",
+          "name": "Basic Progression",
+          "description": "Classic I–V–vi–IV pop cadence.",
+          "degrees": [0, 4, 5, 3]
+        },
+        {
+          "id": "descending-line",
+          "name": "Descending Line",
+          "description": "Falling motion: vi–V–IV–iii.",
+          "degrees": [5, 4, 3, 2]
+        },
+        {
+          "id": "circle-of-fifths",
+          "name": "Circle of Fifths",
+          "description": "Extended dominant cycle back to tonic.",
+          "degrees": [0, 3, 6, 2, 5, 1, 4, 0]
+        }
+      ]
     }
   },
   "chunks": [

--- a/src/packs/trap.json
+++ b/src/packs/trap.json
@@ -236,6 +236,56 @@
           ]
         }
       ]
+    },
+    "harmonia": {
+      "defaultCharacterId": "simple",
+      "defaultPatternId": "basic-progression",
+      "characters": [
+        {
+          "id": "simple",
+          "name": "Simple",
+          "description": "Triads only for easy pads.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "extended",
+          "name": "Extended",
+          "description": "Adds seventh chords for richer harmony.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "lush",
+          "name": "Lush",
+          "description": "Expansive 9th, 11th, and 13th chords.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "borrowed",
+          "name": "Borrowed",
+          "description": "Modal interchange colors for surprise turns.",
+          "type": "Harmonia"
+        }
+      ],
+      "patterns": [
+        {
+          "id": "basic-progression",
+          "name": "Basic Progression",
+          "description": "Classic I–V–vi–IV pop cadence.",
+          "degrees": [0, 4, 5, 3]
+        },
+        {
+          "id": "descending-line",
+          "name": "Descending Line",
+          "description": "Falling motion: vi–V–IV–iii.",
+          "degrees": [5, 4, 3, 2]
+        },
+        {
+          "id": "circle-of-fifths",
+          "name": "Circle of Fifths",
+          "description": "Extended dominant cycle back to tonic.",
+          "degrees": [0, 3, 6, 2, 5, 1, 4, 0]
+        }
+      ]
     }
   },
   "chunks": [

--- a/src/packs/triphop.json
+++ b/src/packs/triphop.json
@@ -253,6 +253,56 @@
           ]
         }
       ]
+    },
+    "harmonia": {
+      "defaultCharacterId": "simple",
+      "defaultPatternId": "basic-progression",
+      "characters": [
+        {
+          "id": "simple",
+          "name": "Simple",
+          "description": "Triads only for easy pads.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "extended",
+          "name": "Extended",
+          "description": "Adds seventh chords for richer harmony.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "lush",
+          "name": "Lush",
+          "description": "Expansive 9th, 11th, and 13th chords.",
+          "type": "Harmonia"
+        },
+        {
+          "id": "borrowed",
+          "name": "Borrowed",
+          "description": "Modal interchange colors for surprise turns.",
+          "type": "Harmonia"
+        }
+      ],
+      "patterns": [
+        {
+          "id": "basic-progression",
+          "name": "Basic Progression",
+          "description": "Classic I–V–vi–IV pop cadence.",
+          "degrees": [0, 4, 5, 3]
+        },
+        {
+          "id": "descending-line",
+          "name": "Descending Line",
+          "description": "Falling motion: vi–V–IV–iii.",
+          "degrees": [5, 4, 3, 2]
+        },
+        {
+          "id": "circle-of-fifths",
+          "name": "Circle of Fifths",
+          "description": "Extended dominant cycle back to tonic.",
+          "degrees": [0, 3, 6, 2, 5, 1, 4, 0]
+        }
+      ]
     }
   },
   "chunks": [


### PR DESCRIPTION
## Summary
- add Harmonia-specific types, control defaults, and chord library helpers
- extract shared scale interval utilities and expose Harmonia chord resolution helpers
- extend chunk schema and instrument definition types to cover Harmonia controls and patterns

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cccc64ce948328900ea63a6fe69be5