### PR TITLE
Add Kick Designer instrument with pack integrations

### DIFF
--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -32,6 +32,11 @@ import {
   normalizeControlState as normalizeHarmoniaControlState,
   resolveHarmoniaChord,
 } from "./instruments/harmonia";
+import {
+  DEFAULT_KICK_STATE,
+  mergeKickDesignerState,
+  normalizeKickDesignerState,
+} from "./instruments/kickDesigner";
 import type {
   HarmoniaComplexity,
   HarmoniaPatternId,
@@ -317,6 +322,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
   const patternCharacterId = pattern?.characterId ?? null;
   const instrumentLabel = formatInstrumentLabel(track.instrument ?? "");
   const isPercussive = isPercussiveInstrument(track.instrument ?? "");
+  const isKick = track.instrument === "kick";
   const isBass = track.instrument === "bass";
   const isArp = track.instrument === "arp";
   const isKeyboard = track.instrument === "keyboard";
@@ -376,6 +382,61 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
   );
 
   const packId = track.source?.packId ?? "";
+
+  const kickDefaults = useMemo(() => {
+    if (!isKick) return DEFAULT_KICK_STATE;
+    if (!packId) return DEFAULT_KICK_STATE;
+    const pack = packs.find((candidate) => candidate.id === packId);
+    const instrument = pack?.instruments?.kick;
+    if (!instrument) return DEFAULT_KICK_STATE;
+    const activeCharacterId =
+      patternCharacterId ??
+      sourceCharacterId ??
+      instrument.defaultCharacterId ??
+      instrument.characters[0]?.id ??
+      null;
+    const character = activeCharacterId
+      ? instrument.characters.find((candidate) => candidate.id === activeCharacterId) ?? null
+      : instrument.characters[0] ?? null;
+    return character
+      ? normalizeKickDesignerState(character.defaults)
+      : DEFAULT_KICK_STATE;
+  }, [
+    isKick,
+    packId,
+    patternCharacterId,
+    sourceCharacterId,
+  ]);
+
+  useEffect(() => {
+    if (!isKick || !pattern || !updatePattern) return;
+    const merged = mergeKickDesignerState(kickDefaults, {
+      punch: pattern.punch,
+      clean: pattern.clean,
+      tight: pattern.tight,
+    });
+    const needsUpdate =
+      pattern.punch !== merged.punch ||
+      pattern.clean !== merged.clean ||
+      pattern.tight !== merged.tight;
+    if (needsUpdate) {
+      updatePattern({
+        punch: merged.punch,
+        clean: merged.clean,
+        tight: merged.tight,
+      });
+    }
+  }, [isKick, pattern, updatePattern, kickDefaults]);
+
+  const kickState = useMemo(
+    () =>
+      mergeKickDesignerState(kickDefaults, {
+        punch: pattern?.punch,
+        clean: pattern?.clean,
+        tight: pattern?.tight,
+      }),
+    [kickDefaults, pattern?.punch, pattern?.clean, pattern?.tight]
+  );
 
   const harmoniaPatternPresets = useMemo(() => {
     if (!packId) {
@@ -3236,6 +3297,53 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
           }
         />
       </Section>
+
+      {isKick ? (
+        <Section>
+          <span style={{ color: "#94a3b8", fontSize: 12 }}>
+            Shape the transient, saturation, and tail of the Kick Designer layer blend.
+          </span>
+          <Slider
+            label="Punch ↔ Sub"
+            min={0}
+            max={1}
+            step={0.01}
+            value={kickState.punch}
+            formatValue={(value) =>
+              `${Math.round((1 - value) * 100)}% Punch / ${Math.round(value * 100)}% Sub`
+            }
+            onChange={
+              updatePattern ? (value) => updatePattern({ punch: value }) : undefined
+            }
+          />
+          <Slider
+            label="Clean ↔ Dirty"
+            min={0}
+            max={1}
+            step={0.01}
+            value={kickState.clean}
+            formatValue={(value) =>
+              `${Math.round((1 - value) * 100)}% Clean / ${Math.round(value * 100)}% Dirty`
+            }
+            onChange={
+              updatePattern ? (value) => updatePattern({ clean: value }) : undefined
+            }
+          />
+          <Slider
+            label="Tight ↔ Long"
+            min={0}
+            max={1}
+            step={0.01}
+            value={kickState.tight}
+            formatValue={(value) =>
+              `${Math.round((1 - value) * 100)}% Tight / ${Math.round(value * 100)}% Long`
+            }
+            onChange={
+              updatePattern ? (value) => updatePattern({ tight: value }) : undefined
+            }
+          />
+        </Section>
+      ) : null}
 
       {isPercussive ? (
         <Section>

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -278,6 +278,24 @@
         "minimum": 0,
         "maximum": 6
       }
+    },
+    "punch": {
+      "type": "number",
+      "description": "Kick Designer punch vs sub balance",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "clean": {
+      "type": "number",
+      "description": "Kick Designer clean vs dirty saturation",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "tight": {
+      "type": "number",
+      "description": "Kick Designer decay length",
+      "minimum": 0,
+      "maximum": 1
     }
   }
 }

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -54,5 +54,8 @@ export interface Chunk {
   harmoniaPatternId?: string;
   harmoniaBorrowedLabel?: string;
   harmoniaStepDegrees?: (number | null)[];
+  punch?: number;
+  clean?: number;
+  tight?: number;
 }
 

--- a/src/instruments/kickDesigner.ts
+++ b/src/instruments/kickDesigner.ts
@@ -1,0 +1,258 @@
+import * as Tone from "tone";
+
+import type { Chunk } from "../chunks";
+
+export interface KickDesignerState {
+  punch: number;
+  clean: number;
+  tight: number;
+}
+
+export const DEFAULT_KICK_STATE: KickDesignerState = {
+  punch: 0.5,
+  clean: 0.5,
+  tight: 0.5,
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+export const normalizeKickDesignerState = (
+  state?: Partial<KickDesignerState> | null
+): KickDesignerState => ({
+  punch: clamp(state?.punch ?? DEFAULT_KICK_STATE.punch, 0, 1),
+  clean: clamp(state?.clean ?? DEFAULT_KICK_STATE.clean, 0, 1),
+  tight: clamp(state?.tight ?? DEFAULT_KICK_STATE.tight, 0, 1),
+});
+
+export const mergeKickDesignerState = (
+  defaults: Partial<KickDesignerState> | null | undefined,
+  overrides: Partial<KickDesignerState> | null | undefined
+): KickDesignerState =>
+  normalizeKickDesignerState({
+    punch: overrides?.punch ?? defaults?.punch,
+    clean: overrides?.clean ?? defaults?.clean,
+    tight: overrides?.tight ?? defaults?.tight,
+  });
+
+export const applyKickDefaultsToChunk = (
+  chunk: Chunk,
+  defaults: Partial<KickDesignerState> | null | undefined
+): Chunk => {
+  const state = mergeKickDesignerState(defaults, {
+    punch: chunk.punch,
+    clean: chunk.clean,
+    tight: chunk.tight,
+  });
+  return {
+    ...chunk,
+    punch: state.punch,
+    clean: state.clean,
+    tight: state.tight,
+  };
+};
+
+export type KickDesignerInstrument = Tone.Gain & {
+  triggerAttackRelease: (
+    note?: Tone.Unit.Frequency,
+    duration?: Tone.Unit.Time,
+    time?: Tone.Unit.Time,
+    velocity?: number
+  ) => void;
+  setMacroState: (state: Partial<KickDesignerState>) => void;
+  getMacroState: () => KickDesignerState;
+};
+
+export const createKickDesigner = (
+  initialState?: Partial<KickDesignerState>
+): KickDesignerInstrument => {
+  const state = normalizeKickDesignerState(initialState);
+
+  const output = new Tone.Gain(1) as KickDesignerInstrument;
+
+  const transient = new Tone.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0, decay: 0.015, sustain: 0, release: 0.02 },
+  });
+  const transientFilter = new Tone.Filter({
+    type: "highpass",
+    frequency: 2000,
+    rolloff: -24,
+  });
+  const transientGain = new Tone.Gain(0.5);
+
+  const body = new Tone.MembraneSynth({
+    pitchDecay: 0.04,
+    octaves: 4,
+    envelope: { attack: 0.001, decay: 0.3, sustain: 0.01, release: 0.2 },
+    volume: -4,
+  });
+  const bodyFilter = new Tone.Filter({ type: "lowpass", frequency: 5000, rolloff: -24 });
+  const bodyGain = new Tone.Gain(0.75);
+
+  const sub = new Tone.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0, decay: 0.6, sustain: 0, release: 0.8 },
+    volume: -2,
+  });
+  const subFilter = new Tone.Filter({ type: "lowpass", frequency: 180, rolloff: -24 });
+  const subGain = new Tone.Gain(0.7);
+
+  const mix = new Tone.Gain(1);
+  const saturation = new Tone.Distortion({ distortion: 0.1, oversample: "4x", wet: 0.2 });
+  const eq = new Tone.EQ3({ low: 0, mid: 0, high: 0 });
+  const compressor = new Tone.Compressor({
+    threshold: -20,
+    ratio: 3,
+    attack: 0.01,
+    release: 0.25,
+  });
+  const limiter = new Tone.Limiter({ threshold: -6 });
+  const outputGain = new Tone.Gain(0.9);
+
+  transient.connect(transientFilter);
+  transientFilter.connect(transientGain);
+  transientGain.connect(mix);
+
+  body.connect(bodyFilter);
+  bodyFilter.connect(bodyGain);
+  bodyGain.connect(mix);
+
+  sub.connect(subFilter);
+  subFilter.connect(subGain);
+  subGain.connect(mix);
+
+  mix.connect(saturation);
+  saturation.connect(eq);
+  eq.connect(compressor);
+  compressor.connect(limiter);
+  limiter.connect(outputGain);
+  outputGain.connect(output);
+
+  const applyState = () => {
+    const punch = clamp(state.punch, 0, 1);
+    const clean = clamp(state.clean, 0, 1);
+    const tight = clamp(state.tight, 0, 1);
+
+    const transientLevel = Math.sqrt(1 - punch);
+    const subLevel = Math.sqrt(punch);
+    const bodyLevel = 0.8 + (1 - punch) * 0.15;
+
+    transientGain.gain.rampTo(0.75 * transientLevel, 0.05);
+    subGain.gain.rampTo(1.1 * subLevel, 0.05);
+    bodyGain.gain.rampTo(bodyLevel, 0.05);
+
+    const transientDecay = 0.01 + (1 - tight) * 0.02;
+    transient.set({
+      envelope: { attack: 0, decay: transientDecay, sustain: 0, release: 0.015 + (1 - tight) * 0.02 },
+    });
+    transientFilter.frequency.rampTo(1800 + (1 - punch) * 1800 + (1 - tight) * 600, 0.05);
+
+    const bodyDecay = 0.18 + tight * 0.45;
+    const bodyRelease = 0.12 + tight * 0.4;
+    const bodyPitchDecay = 0.018 + (1 - tight) * 0.05;
+    const bodyOctaves = 3.5 + (1 - tight) * 1.5;
+    body.set({
+      pitchDecay: bodyPitchDecay,
+      octaves: bodyOctaves,
+      envelope: { attack: 0.001, decay: bodyDecay, sustain: 0.01, release: bodyRelease },
+    });
+    bodyFilter.frequency.rampTo(3500 + punch * 1500, 0.05);
+
+    const subDecay = 0.35 + tight * 0.8;
+    const subRelease = 0.45 + tight * 1.1;
+    sub.set({
+      envelope: { attack: 0, decay: subDecay, sustain: 0, release: subRelease },
+    });
+    subFilter.frequency.rampTo(120 + tight * 80 + punch * 30, 0.05);
+
+    saturation.distortion = 0.08 + (1 - clean) * 0.75;
+    saturation.wet.value = 0.1 + (1 - clean) * 0.85;
+
+    eq.high.value = (1 - punch) * 5 - 2;
+    eq.mid.value = -1 - (1 - clean) * 2 + (0.5 - punch) * 1.2;
+    eq.low.value = punch * 6 - 1.5;
+
+    outputGain.gain.rampTo(0.85 + (1 - clean) * 0.12, 0.05);
+  };
+
+  applyState();
+
+  output.setMacroState = (partial) => {
+    const next = normalizeKickDesignerState({
+      punch: partial.punch ?? state.punch,
+      clean: partial.clean ?? state.clean,
+      tight: partial.tight ?? state.tight,
+    });
+    state.punch = next.punch;
+    state.clean = next.clean;
+    state.tight = next.tight;
+    applyState();
+  };
+
+  output.getMacroState = () => ({ ...state });
+
+  output.triggerAttackRelease = (
+    note = "C2",
+    duration: Tone.Unit.Time = "8n",
+    time?: Tone.Unit.Time,
+    velocity = 1
+  ) => {
+    const when = time ?? Tone.now();
+    const tight = state.tight;
+    const punch = state.punch;
+
+    const baseNote = typeof note === "number" ? note : note || "C2";
+    const baseFrequency = Tone.Frequency(baseNote).toFrequency();
+
+    const transientVelocity = Math.min(1, velocity * (0.85 + (1 - punch) * 0.3));
+    transient.triggerAttackRelease("32n", when, transientVelocity);
+
+    const bodyDuration = Math.max(0.15, 0.35 + tight * 0.4);
+    const bodyStart = baseFrequency * (1 + (1 - tight) * 1.4);
+    body.frequency.setValueAtTime(bodyStart, when);
+    body.frequency.exponentialRampToValueAtTime(
+      Math.max(30, baseFrequency),
+      when + 0.08 + (1 - tight) * 0.05
+    );
+    body.triggerAttackRelease(baseNote, bodyDuration, when, Math.min(1, velocity * 0.95));
+
+    const subNote = Tone.Frequency(baseNote).transpose(-12 + punch * -2).toNote();
+    const subDuration = Math.max(0.4, 0.6 + tight * 1.2);
+    sub.frequency.setValueAtTime(baseFrequency * 0.5, when);
+    sub.frequency.exponentialRampToValueAtTime(
+      Math.max(20, baseFrequency * 0.5),
+      when + 0.12 + tight * 0.2
+    );
+    sub.triggerAttackRelease(subNote, subDuration, when, Math.min(1, velocity * (0.7 + punch * 0.4)));
+
+    const releaseTime = Tone.Time(duration).toSeconds();
+    const totalRelease = when + releaseTime;
+    mix.gain.cancelAndHoldAtTime(totalRelease);
+    mix.gain.rampTo(0, 0.2, totalRelease);
+    mix.gain.rampTo(1, 0.001, when);
+  };
+
+  const originalDispose = output.dispose.bind(output);
+  output.dispose = () => {
+    transient.dispose();
+    transientFilter.dispose();
+    transientGain.dispose();
+    body.dispose();
+    bodyFilter.dispose();
+    bodyGain.dispose();
+    sub.dispose();
+    subFilter.dispose();
+    subGain.dispose();
+    mix.dispose();
+    saturation.dispose();
+    eq.dispose();
+    compressor.dispose();
+    limiter.dispose();
+    outputGain.dispose();
+    return originalDispose();
+  };
+
+  return output;
+};
+

--- a/src/packs.ts
+++ b/src/packs.ts
@@ -1,7 +1,8 @@
 import type { Chunk } from "./chunks";
+import type { KickDesignerState } from "./instruments/kickDesigner";
 
 export interface InstrumentSpec {
-  type: string;
+  type?: string;
   note?: string;
   options?: Record<string, unknown>;
   effects?: EffectSpec[];
@@ -11,9 +12,12 @@ export interface InstrumentCharacter extends InstrumentSpec {
   id: string;
   name: string;
   description?: string;
+  defaults?: Partial<KickDesignerState>;
 }
 
 export interface InstrumentDefinition {
+  id?: string;
+  name?: string;
   defaultCharacterId?: string;
   characters: InstrumentCharacter[];
   defaultPatternId?: string;
@@ -24,7 +28,12 @@ export interface InstrumentPatternPreset {
   id: string;
   name: string;
   description?: string;
-  degrees: number[];
+  degrees?: number[];
+  steps?: number[];
+  velocities?: number[];
+  punch?: number;
+  clean?: number;
+  tight?: number;
 }
 
 export interface EffectSpec {

--- a/src/packs/chiptune.json
+++ b/src/packs/chiptune.json
@@ -3,37 +3,39 @@
   "name": "Chip Tune",
   "instruments": {
     "kick": {
-      "defaultCharacterId": "tri-kick",
+      "id": "kick",
+      "name": "Kick Designer",
+      "defaultCharacterId": "chip_square_thump",
       "characters": [
         {
-          "id": "tri-kick",
-          "name": "Tri Kick",
-          "type": "MonoSynth",
-          "note": "C2",
-          "options": {
-            "oscillator": { "type": "triangle" },
-            "envelope": {
-              "attack": 0.001,
-              "decay": 0.1,
-              "sustain": 0.01,
-              "release": 0.15
-            }
-          }
+          "id": "chip_square_thump",
+          "name": "Square Thump",
+          "defaults": { "punch": 0.6, "clean": 0.8, "tight": 0.5 }
         },
         {
-          "id": "square-thump",
-          "name": "Square Thump",
-          "type": "MonoSynth",
-          "note": "C1",
-          "options": {
-            "oscillator": { "type": "square" },
-            "envelope": {
-              "attack": 0.001,
-              "decay": 0.2,
-              "sustain": 0.01,
-              "release": 0.25
-            }
-          }
+          "id": "chip_noise_pop",
+          "name": "Noise Pop",
+          "defaults": { "punch": 0.7, "clean": 0.9, "tight": 0.4 }
+        }
+      ],
+      "patterns": [
+        {
+          "id": "chip_steady_march",
+          "name": "Steady March",
+          "steps": [1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0],
+          "velocities": [1, 0, 0, 0, 0, 0.85, 0, 0, 0.9, 0, 0, 0, 0, 0.82, 0, 0]
+        },
+        {
+          "id": "chip_syncopate",
+          "name": "Syncopated Beat",
+          "steps": [1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1],
+          "velocities": [1, 0, 0.75, 0, 0, 0.8, 0, 0.7, 0.9, 0, 0.78, 0, 0, 0.82, 0, 0.75]
+        },
+        {
+          "id": "chip_arcade_fill",
+          "name": "Arcade Fill",
+          "steps": [1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0],
+          "velocities": [1, 0, 0, 0, 0.85, 0.7, 0, 0, 0.9, 0, 0.78, 0, 0.82, 0.75, 0.7, 0]
         }
       ]
     },
@@ -358,25 +360,34 @@
       "id": "chip-kick-sparse",
       "name": "Sparse Kick",
       "instrument": "kick",
-      "characterId": "tri-kick",
+      "characterId": "chip_square_thump",
       "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
-      "velocities": [1,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0]
+      "velocities": [1,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
+      "punch": 0.6,
+      "clean": 0.8,
+      "tight": 0.5
     },
     {
       "id": "chip-kick-drive",
       "name": "Drive Kick",
       "instrument": "kick",
-      "characterId": "square-thump",
+      "characterId": "chip_noise_pop",
       "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
-      "velocities": [0.95,0,0,0,0.9,0,0,0,0.92,0,0,0,0.88,0,0,0]
+      "velocities": [0.95,0,0,0,0.9,0,0,0,0.92,0,0,0,0.88,0,0,0],
+      "punch": 0.72,
+      "clean": 0.9,
+      "tight": 0.42
     },
     {
       "id": "chip-kick-sync",
       "name": "Pulse Kick",
       "instrument": "kick",
-      "characterId": "tri-kick",
+      "characterId": "chip_square_thump",
       "steps": [1,0,0,0,1,0,1,0,1,0,0,0,1,0,1,0],
-      "velocities": [0.95,0,0,0,0.9,0,0.82,0,0.9,0,0,0,0.88,0,0.8,0]
+      "velocities": [0.95,0,0,0,0.9,0,0.82,0,0.9,0,0,0,0.88,0,0.8,0],
+      "punch": 0.62,
+      "clean": 0.82,
+      "tight": 0.48
     },
     {
       "id": "chip-snare-backbeat",

--- a/src/packs/early-2000s-edm.json
+++ b/src/packs/early-2000s-edm.json
@@ -3,61 +3,39 @@
   "name": "EDM 2000s",
   "instruments": {
     "kick": {
-      "defaultCharacterId": "trance-thump",
+      "id": "kick",
+      "name": "Kick Designer",
+      "defaultCharacterId": "edm_club_punch",
       "characters": [
         {
-          "id": "trance-thump",
-          "name": "Trance Thump",
-          "type": "MembraneSynth",
-          "note": "C2",
-          "options": {
-            "pitchDecay": 0.03,
-            "octaves": 3,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 0.55,
-              "sustain": 0.01,
-              "release": 0.6
-            }
-          }
+          "id": "edm_club_punch",
+          "name": "Club Punch",
+          "defaults": { "punch": 0.7, "clean": 0.9, "tight": 0.4 }
         },
         {
-          "id": "sidechain-pump",
-          "name": "Sidechain Pump",
-          "type": "MembraneSynth",
-          "note": "C2",
-          "options": {
-            "pitchDecay": 0.025,
-            "octaves": 3,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 0.45,
-              "sustain": 0.01,
-              "release": 0.5
-            }
-          },
-          "effects": [
-            { "type": "Compressor", "options": { "threshold": -22, "ratio": 6 } }
-          ]
+          "id": "edm_trance_boom",
+          "name": "Trance Boom",
+          "defaults": { "punch": 0.5, "clean": 0.7, "tight": 0.5 }
+        }
+      ],
+      "patterns": [
+        {
+          "id": "edm_four_floor",
+          "name": "Four on the Floor",
+          "steps": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+          "velocities": [1, 0, 0, 0, 0.95, 0, 0, 0, 0.98, 0, 0, 0, 0.94, 0, 0, 0]
         },
         {
-          "id": "hardstyle-kick",
-          "name": "Hardstyle Kick",
-          "type": "MembraneSynth",
-          "note": "C2",
-          "options": {
-            "pitchDecay": 0.05,
-            "octaves": 4,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 0.8,
-              "sustain": 0.02,
-              "release": 0.9
-            }
-          },
-          "effects": [
-            { "type": "Distortion", "options": { "distortion": 0.3, "wet": 0.3 } }
-          ]
+          "id": "edm_offbeat_drive",
+          "name": "Offbeat Drive",
+          "steps": [1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0],
+          "velocities": [1, 0, 0, 0, 0.85, 0, 0.7, 0, 0.9, 0, 0, 0, 0.88, 0, 0.72, 0]
+        },
+        {
+          "id": "edm_build_roll",
+          "name": "Build-Up Roll",
+          "steps": [1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1],
+          "velocities": [1, 0, 0, 0, 0.9, 0, 0.75, 0, 0.85, 0, 0.8, 0, 0.78, 0.85, 0.9, 1]
         }
       ]
     },
@@ -505,25 +483,34 @@
       "id": "edm-kick-4onfloor",
       "name": "Four on the Floor",
       "instrument": "kick",
-      "characterId": "trance-thump",
+      "characterId": "edm_club_punch",
       "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
-      "velocities": [1,0,0,0,0.95,0,0,0,0.98,0,0,0,0.95,0,0,0]
+      "velocities": [1,0,0,0,0.95,0,0,0,0.98,0,0,0,0.95,0,0,0],
+      "punch": 0.7,
+      "clean": 0.9,
+      "tight": 0.4
     },
     {
       "id": "edm-kick-drop",
       "name": "Festival Drop",
       "instrument": "kick",
-      "characterId": "hardstyle-kick",
+      "characterId": "edm_trance_boom",
       "steps": [1,0,0,0,1,0,1,0,1,0,0,0,1,0,1,0],
-      "velocities": [1,0,0,0,0.95,0,0.85,0,0.92,0,0,0,0.96,0,0.82,0]
+      "velocities": [1,0,0,0,0.95,0,0.85,0,0.92,0,0,0,0.96,0,0.82,0],
+      "punch": 0.55,
+      "clean": 0.72,
+      "tight": 0.48
     },
     {
       "id": "edm-kick-sync",
       "name": "Sync Pump",
       "instrument": "kick",
-      "characterId": "sidechain-pump",
+      "characterId": "edm_club_punch",
       "steps": [1,0,0,0,1,0,0,1,1,0,0,0,1,0,0,1],
-      "velocities": [1,0,0,0,0.95,0,0,0.75,0.9,0,0,0,0.92,0,0,0.78]
+      "velocities": [1,0,0,0,0.95,0,0,0.75,0.9,0,0,0,0.92,0,0,0.78],
+      "punch": 0.68,
+      "clean": 0.85,
+      "tight": 0.42
     },
     {
       "id": "edm-snare-offbeat",

--- a/src/packs/kraftwerk.json
+++ b/src/packs/kraftwerk.json
@@ -3,39 +3,39 @@
   "name": "Kraftwerk",
   "instruments": {
     "kick": {
-      "defaultCharacterId": "motor-kick",
+      "id": "kick",
+      "name": "Kick Designer",
+      "defaultCharacterId": "kraftwerk_motor_drive",
       "characters": [
         {
-          "id": "motor-kick",
-          "name": "Motor Kick",
-          "type": "MembraneSynth",
-          "note": "C2",
-          "options": {
-            "pitchDecay": 0.03,
-            "octaves": 3,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 0.7,
-              "sustain": 0.02,
-              "release": 0.8
-            }
-          }
+          "id": "kraftwerk_motor_drive",
+          "name": "Motor Drive",
+          "defaults": { "punch": 0.5, "clean": 0.8, "tight": 0.55 }
         },
         {
-          "id": "analog-punch",
-          "name": "Analog Punch",
-          "type": "MembraneSynth",
-          "note": "C2",
-          "options": {
-            "pitchDecay": 0.025,
-            "octaves": 2.5,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 0.5,
-              "sustain": 0.02,
-              "release": 0.6
-            }
-          }
+          "id": "kraftwerk_robotic_snap",
+          "name": "Robotic Snap",
+          "defaults": { "punch": 0.35, "clean": 0.6, "tight": 0.45 }
+        }
+      ],
+      "patterns": [
+        {
+          "id": "kraftwerk_motorik",
+          "name": "Motorik Pulse",
+          "steps": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+          "velocities": [1, 0, 0, 0, 0.9, 0, 0, 0, 0.92, 0, 0, 0, 0.88, 0, 0, 0]
+        },
+        {
+          "id": "kraftwerk_sequencer",
+          "name": "Sequencer Sync",
+          "steps": [1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0],
+          "velocities": [1, 0, 0.7, 0, 0, 0.85, 0, 0, 0.9, 0, 0.75, 0, 0, 0.82, 0, 0]
+        },
+        {
+          "id": "kraftwerk_fill",
+          "name": "Robot Fill",
+          "steps": [1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1],
+          "velocities": [1, 0, 0, 0, 0.88, 0, 0.72, 0, 0.9, 0, 0.8, 0, 0.82, 0.9, 0, 0.85]
         }
       ]
     },
@@ -367,23 +367,32 @@
       "id": "kw-kick-motor",
       "name": "Motor Kick",
       "instrument": "kick",
-      "characterId": "motor-kick",
-      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0]
+      "characterId": "kraftwerk_motor_drive",
+      "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+      "punch": 0.5,
+      "clean": 0.8,
+      "tight": 0.55
     },
     {
       "id": "kw-kick-stutter",
       "name": "Stutter Kick",
       "instrument": "kick",
-      "characterId": "analog-punch",
+      "characterId": "kraftwerk_robotic_snap",
       "steps": [1,0,0,0,1,0,1,0,1,0,0,0,1,0,1,0],
-      "velocities": [0.95,0,0,0,0.9,0,0.8,0,0.88,0,0,0,0.86,0,0.78,0]
+      "velocities": [0.95,0,0,0,0.9,0,0.8,0,0.88,0,0,0,0.86,0,0.78,0],
+      "punch": 0.38,
+      "clean": 0.62,
+      "tight": 0.46
     },
     {
       "id": "kw-kick-break",
       "name": "Break Kick",
       "instrument": "kick",
-      "characterId": "motor-kick",
-      "steps": [1,0,0,0,0,0,1,0,1,0,0,0,0,0,1,0]
+      "characterId": "kraftwerk_motor_drive",
+      "steps": [1,0,0,0,0,0,1,0,1,0,0,0,0,0,1,0],
+      "punch": 0.46,
+      "clean": 0.75,
+      "tight": 0.52
     },
     {
       "id": "kw-snare-backbeat",

--- a/src/packs/phonk.json
+++ b/src/packs/phonk.json
@@ -3,43 +3,39 @@
   "name": "Phonk",
   "instruments": {
     "kick": {
-      "defaultCharacterId": "classic-808",
+      "id": "kick",
+      "name": "Kick Designer",
+      "defaultCharacterId": "phonk_memphis_distorted",
       "characters": [
         {
-          "id": "classic-808",
-          "name": "Classic 808",
-          "type": "MembraneSynth",
-          "note": "C1",
-          "options": {
-            "pitchDecay": 0.05,
-            "octaves": 4,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 1.2,
-              "sustain": 0.01,
-              "release": 1.6
-            }
-          }
+          "id": "phonk_memphis_distorted",
+          "name": "Memphis Distorted",
+          "defaults": { "punch": 0.5, "clean": 0.1, "tight": 0.6 }
         },
         {
-          "id": "distorted-808",
-          "name": "Distorted 808",
-          "type": "MembraneSynth",
-          "note": "C1",
-          "options": {
-            "pitchDecay": 0.04,
-            "octaves": 4,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 1.0,
-              "sustain": 0.02,
-              "release": 1.4
-            }
-          },
-          "effects": [
-            { "type": "Distortion", "options": { "distortion": 0.4, "wet": 0.4 } },
-            { "type": "EQ3", "options": { "low": 4, "high": -6 } }
-          ]
+          "id": "phonk_tape_slam",
+          "name": "Tape Slam",
+          "defaults": { "punch": 0.4, "clean": 0.3, "tight": 0.7 }
+        }
+      ],
+      "patterns": [
+        {
+          "id": "phonk_lofi_boom",
+          "name": "Lo-Fi Boom",
+          "steps": [1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0],
+          "velocities": [1, 0, 0, 0, 0, 0, 0.8, 0, 0.75, 0, 0, 0, 0, 0, 0.85, 0]
+        },
+        {
+          "id": "phonk_half_time",
+          "name": "Half-Time Stomp",
+          "steps": [1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+          "velocities": [0.95, 0, 0, 0, 0, 0, 0, 0, 0.88, 0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "id": "phonk_tape_roll",
+          "name": "Tape Machine Roll",
+          "steps": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0],
+          "velocities": [1, 0, 0, 0, 0.85, 0, 0, 0, 0.82, 0, 0.7, 0, 0.65, 0, 0, 0]
         }
       ]
     },
@@ -398,27 +394,36 @@
       "id": "phonk-kick-deep",
       "name": "Deep Pulse",
       "instrument": "kick",
-      "characterId": "classic-808",
+      "characterId": "phonk_memphis_distorted",
       "steps": [1,0,0,0,0,1,0,0,1,0,0,1,0,0,0,0],
-      "velocities": [1,0,0,0,0,0.85,0,0,0.95,0,0,0.9,0,0,0,0.8]
+      "velocities": [1,0,0,0,0,0.85,0,0,0.95,0,0,0.9,0,0,0,0.8],
+      "punch": 0.48,
+      "clean": 0.12,
+      "tight": 0.62
     },
     {
       "id": "phonk-kick-stutter",
       "name": "Stuttered Boom",
       "instrument": "kick",
-      "characterId": "distorted-808",
+      "characterId": "phonk_memphis_distorted",
       "steps": [1,0,0,1,0,0,0,0,1,0,1,0,0,0,1,0],
       "velocities": [1,0,0,0.7,0,0,0,0,0.95,0,0.75,0,0,0,0.85,0],
-      "swing": 0.08
+      "swing": 0.08,
+      "punch": 0.52,
+      "clean": 0.1,
+      "tight": 0.6
     },
     {
       "id": "phonk-kick-spill",
       "name": "Slide Accents",
       "instrument": "kick",
-      "characterId": "classic-808",
+      "characterId": "phonk_tape_slam",
       "steps": [1,0,0,0,0,0,1,1,0,0,0,1,0,1,0,0],
       "velocities": [1,0,0,0,0,0,0.9,0.6,0,0,0,0.85,0,0.7,0,0.6],
-      "humanize": 0.03
+      "humanize": 0.03,
+      "punch": 0.42,
+      "clean": 0.28,
+      "tight": 0.7
     },
     {
       "id": "phonk-snare-backbeat",

--- a/src/packs/trap.json
+++ b/src/packs/trap.json
@@ -3,39 +3,39 @@
   "name": "Trap",
   "instruments": {
     "kick": {
-      "defaultCharacterId": "808-boom",
+      "id": "kick",
+      "name": "Kick Designer",
+      "defaultCharacterId": "trap_808_boom",
       "characters": [
         {
-          "id": "808-boom",
+          "id": "trap_808_boom",
           "name": "808 Boom",
-          "type": "MembraneSynth",
-          "note": "C1",
-          "options": {
-            "pitchDecay": 0.05,
-            "octaves": 4,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 1.2,
-              "sustain": 0.01,
-              "release": 1.8
-            }
-          }
+          "defaults": { "punch": 0.2, "clean": 0.6, "tight": 0.7 }
         },
         {
-          "id": "punch-kick",
-          "name": "Punch Kick",
-          "type": "MembraneSynth",
-          "note": "C2",
-          "options": {
-            "pitchDecay": 0.02,
-            "octaves": 3,
-            "envelope": {
-              "attack": 0.001,
-              "decay": 0.4,
-              "sustain": 0.01,
-              "release": 0.8
-            }
-          }
+          "id": "trap_hard_clip",
+          "name": "Hard Clip",
+          "defaults": { "punch": 0.4, "clean": 0.2, "tight": 0.6 }
+        }
+      ],
+      "patterns": [
+        {
+          "id": "trap_basic_808",
+          "name": "Basic 808",
+          "steps": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+          "velocities": [1, 0, 0, 0, 0.9, 0, 0, 0, 0.95, 0, 0, 0, 0.88, 0, 0, 0]
+        },
+        {
+          "id": "trap_offbeat_sync",
+          "name": "Off-Beat Sync",
+          "steps": [1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+          "velocities": [1, 0, 0, 0, 0, 0, 0, 0, 0.85, 0, 0, 0, 0.8, 0, 0, 0]
+        },
+        {
+          "id": "trap_triplet_roll",
+          "name": "Triplet Roll",
+          "steps": [1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0],
+          "velocities": [1, 0, 0, 0, 0, 0, 0, 0, 0.9, 0, 0.75, 0, 0.7, 0, 0, 0]
         }
       ]
     },
@@ -362,27 +362,36 @@
       "id": "trap-kick-four",
       "name": "Club Stomp",
       "instrument": "kick",
-      "characterId": "808-boom",
+      "characterId": "trap_808_boom",
       "steps": [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
-      "velocities": [1,0,0,0,0.9,0,0,0,0.95,0,0,0,0.9,0,0,0]
+      "velocities": [1,0,0,0,0.9,0,0,0,0.95,0,0,0,0.9,0,0,0],
+      "punch": 0.2,
+      "clean": 0.6,
+      "tight": 0.7
     },
     {
       "id": "trap-kick-sparse",
       "name": "Sparse Trap",
       "instrument": "kick",
-      "characterId": "punch-kick",
+      "characterId": "trap_hard_clip",
       "steps": [1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0],
       "velocities": [1,0,0,0,0,0,0.85,0,0,0,0,0,0.9,0,0,0],
-      "humanize": 0.03
+      "humanize": 0.03,
+      "punch": 0.45,
+      "clean": 0.25,
+      "tight": 0.58
     },
     {
       "id": "trap-kick-sync",
       "name": "Syncopated 808s",
       "instrument": "kick",
-      "characterId": "808-boom",
+      "characterId": "trap_808_boom",
       "steps": [1,0,0,0,0,0,0,0,1,0,0,0,1,0,0,0],
       "velocities": [1,0,0,0,0,0,0,0,0.85,0,0,0,0.8,0,0,0],
-      "swing": 0.06
+      "swing": 0.06,
+      "punch": 0.25,
+      "clean": 0.55,
+      "tight": 0.68
     },
     {
       "id": "trap-snare-backbeat",

--- a/src/packs/triphop.json
+++ b/src/packs/triphop.json
@@ -3,42 +3,39 @@
   "name": "Trip Hop",
   "instruments": {
     "kick": {
-      "defaultCharacterId": "deep-kick",
+      "id": "kick",
+      "name": "Kick Designer",
+      "defaultCharacterId": "triphop_lofi_thump",
       "characters": [
         {
-          "id": "deep-kick",
-          "name": "Deep Kick",
-          "type": "MembraneSynth",
-          "note": "C1",
-          "options": {
-            "pitchDecay": 0.03,
-            "octaves": 3,
-            "envelope": {
-              "attack": 0.01,
-              "decay": 0.8,
-              "sustain": 0.05,
-              "release": 1.5
-            }
-          }
+          "id": "triphop_lofi_thump",
+          "name": "Lo-Fi Thump",
+          "defaults": { "punch": 0.3, "clean": 0.3, "tight": 0.8 }
         },
         {
-          "id": "lofi-kick",
-          "name": "Lo-Fi Kick",
-          "type": "MembraneSynth",
-          "note": "C1",
-          "options": {
-            "pitchDecay": 0.02,
-            "octaves": 3,
-            "envelope": {
-              "attack": 0.01,
-              "decay": 0.6,
-              "sustain": 0.05,
-              "release": 1.2
-            }
-          },
-          "effects": [
-            { "type": "Distortion", "options": { "distortion": 0.2, "wet": 0.25 } }
-          ]
+          "id": "triphop_vinyl_kick",
+          "name": "Vinyl Kick",
+          "defaults": { "punch": 0.4, "clean": 0.2, "tight": 0.7 }
+        }
+      ],
+      "patterns": [
+        {
+          "id": "triphop_laid_back",
+          "name": "Laid Back Boom",
+          "steps": [1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0],
+          "velocities": [1, 0, 0, 0, 0, 0, 0, 0.75, 0, 0, 0, 0, 0.9, 0, 0, 0]
+        },
+        {
+          "id": "triphop_dusty_half",
+          "name": "Dusty Half-Time",
+          "steps": [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+          "velocities": [0.95, 0, 0, 0, 0, 0, 0.65, 0, 0, 0, 0, 0, 0.85, 0, 0, 0]
+        },
+        {
+          "id": "triphop_tape_roll",
+          "name": "Tape Roll",
+          "steps": [1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0],
+          "velocities": [1, 0, 0, 0, 0, 0, 0, 0.7, 0, 0, 0.6, 0, 0, 0, 0.8, 0]
         }
       ]
     },
@@ -384,27 +381,36 @@
       "id": "trip-kick-sparse",
       "name": "Sparse",
       "instrument": "kick",
-      "characterId": "deep-kick",
+      "characterId": "triphop_lofi_thump",
       "steps": [1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
       "velocities": [0.95,0,0,0,0,0,0,0,0.85,0,0,0,0,0,0,0],
-      "humanize": 0.04
+      "humanize": 0.04,
+      "punch": 0.3,
+      "clean": 0.3,
+      "tight": 0.82
     },
     {
       "id": "trip-kick-bounce",
       "name": "Trip Bounce",
       "instrument": "kick",
-      "characterId": "lofi-kick",
+      "characterId": "triphop_vinyl_kick",
       "steps": [1,0,0,0,1,0,0,0,0,1,0,0,0,0,1,0],
       "velocities": [0.9,0,0,0,0.82,0,0,0,0,0.78,0,0,0,0,0.75,0],
-      "swing": 0.12
+      "swing": 0.12,
+      "punch": 0.42,
+      "clean": 0.22,
+      "tight": 0.72
     },
     {
       "id": "trip-kick-sync",
       "name": "Sync Drift",
       "instrument": "kick",
-      "characterId": "deep-kick",
+      "characterId": "triphop_lofi_thump",
       "steps": [1,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0],
-      "velocities": [0.92,0,0,0,0,0,0,0,0.8,0,0,0.76,0,0,0,0]
+      "velocities": [0.92,0,0,0,0,0,0,0,0.8,0,0,0.76,0,0,0,0],
+      "punch": 0.32,
+      "clean": 0.28,
+      "tight": 0.78
     },
     {
       "id": "trip-snare-backbeat",


### PR DESCRIPTION
## Summary
- introduce a dedicated Kick Designer instrument that layers transient, body, and sub voices with macro controls
- update the engine, control panel, and loop workflow so kick tracks use the new macros and adopt character defaults automatically
- refresh every sound pack to expose Kick Designer characters, macro defaults, and representative kick patterns

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ce0de81cb08328931001fd6d3d88b8