### PR TITLE
Fix iOS PWA audio context reinitialization

### DIFF
--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -37,8 +37,15 @@ export const frequencyToFilterValue = (frequency: number) => {
 };
 
 export const ensureAudioContextRunning = async (): Promise<void> => {
-  const context = Tone.getContext();
-  const rawContext = context.rawContext as AudioContext;
+  let rawContext = Tone.getContext().rawContext as AudioContext | undefined;
+
+  if (!rawContext || rawContext.state === "closed") {
+    console.log("Audio context closed, creating fresh context");
+    const newContext = new Tone.Context();
+    Tone.setContext(newContext);
+    rawContext = newContext.rawContext as AudioContext;
+  }
+
   let state: AudioContextState = rawContext.state;
 
   if (state === "running") {


### PR DESCRIPTION
## Summary
- Harden PWA restoration detection and aggressively rebuild Tone audio contexts on iOS
- Retry audio initialization, add visibility handling, and improve new project startup logging
- Refresh ensureAudioContextRunning so closed contexts are recreated before unlock attempts

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d090b490f48328a833c02c7cc68690