### PR TITLE
Update UI terminology and enhance onboarding empty states

### DIFF
--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -116,7 +116,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
       if (!pack || !selectedInstrumentId) return;
       if (!isUserPresetId(presetId)) return;
       const actualId = stripUserPresetPrefix(presetId);
-      const confirmed = window.confirm("Delete this saved preset pattern?");
+      const confirmed = window.confirm("Delete this saved loop?");
       if (!confirmed) return;
       const removed = deleteInstrumentPreset(pack.id, selectedInstrumentId, actualId);
       if (removed) {
@@ -131,13 +131,13 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
 
   const handleSavePresetPattern = useCallback(() => {
     if (!pack || !selectedInstrumentId || !editingTrackPattern) {
-      window.alert("No pattern data available to save as a preset pattern.");
+      window.alert("No pattern data available to save as a loop.");
       return;
     }
     const suggestedName =
       editingTrackName?.trim() || formatInstrumentLabel(selectedInstrumentId);
     const defaultName = `${suggestedName} Pattern`;
-    const name = window.prompt("Name your preset pattern", defaultName);
+    const name = window.prompt("Name your saved loop", defaultName);
     if (!name) return;
     const pattern: Chunk = {
       ...editingTrackPattern,
@@ -152,12 +152,12 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
       pattern,
     });
     if (!record) {
-      window.alert("Unable to save this preset pattern.");
+      window.alert("Unable to save this loop.");
       return;
     }
     onSelectPreset(`${USER_PRESET_PREFIX}${record.id}`);
     refreshUserPresets();
-    window.alert("Preset pattern saved.");
+    window.alert("Loop saved.");
   }, [
     pack,
     selectedInstrumentId,
@@ -205,8 +205,8 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
   const isEditMode = mode === "edit";
   const title = isEditMode ? "Edit Track" : "Add Track";
   const description = isEditMode
-    ? "Adjust the sound pack, instrument, character, and preset pattern for this track."
-    : "Choose a sound pack, instrument, character, and optional preset pattern to start a new groove.";
+    ? "Adjust the sound pack, instrument, style, and saved loop for this track."
+    : "Choose a sound pack, instrument, style, and optional saved loop to start a new groove.";
   const confirmLabel = isEditMode ? "Update Track" : "Add Track";
   const showSavePresetAction = isEditMode && Boolean(editingTrackPattern);
 
@@ -441,7 +441,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
         </label>
 
         <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <span style={{ fontSize: 13, color: "#cbd5f5" }}>Character</span>
+          <span style={{ fontSize: 13, color: "#cbd5f5" }}>Style</span>
           <select
             value={selectedCharacterId}
             onChange={(event) => onSelectCharacter(event.target.value)}
@@ -456,7 +456,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
           >
             {characterOptions.length === 0 ? (
               <option value="" disabled>
-                No characters
+                No styles
               </option>
             ) : (
               characterOptions.map((character) => (
@@ -488,15 +488,15 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
               }}
             >
               <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                <span style={{ fontWeight: 600 }}>Preset Patterns</span>
+                <span style={{ fontWeight: 600 }}>Saved Loops</span>
                 <span style={{ fontSize: 12, color: "#94a3b8" }}>
-                  Save the current pattern or load one of your favorites.
+                  Save the current loop or load one of your favorites.
                 </span>
               </div>
               {showSavePresetAction ? (
                 <IconButton
                   icon="save"
-                  label="Save current pattern as preset"
+                  label="Save current loop"
                   tone="accent"
                   iconSize={20}
                   style={compactIconButtonStyle}
@@ -508,7 +508,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
               <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
                 <span style={{ fontSize: 12, color: "#cbd5f5", fontWeight: 600 }}>
-                  Your Presets
+                  Your Saved Loops
                 </span>
                 <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
                   <div
@@ -546,7 +546,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                         padding: "12px 0",
                       }}
                     >
-                      No presets saved yet
+                      No saved loops yet
                     </div>
                   )}
                 </div>
@@ -554,7 +554,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
               {packPresets.length > 0 ? (
                 <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
                   <span style={{ fontSize: 12, color: "#cbd5f5", fontWeight: 600 }}>
-                    Pack Presets
+                    Pack Loops
                   </span>
                   <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
                     {packPresets.map((preset) => renderPresetRow(preset, "pack"))}
@@ -573,7 +573,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             color: "#94a3b8",
           }}
         >
-          <span>Current preset: {currentPresetLabel}</span>
+          <span>Current saved loop: {currentPresetLabel}</span>
         </div>
       </div>
     </Modal>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,118 @@ const createInitialPatternGroup = (): PatternGroup => ({
   tracks: [],
 });
 
+const cloneChunkForDemo = (chunk: Chunk): Chunk => ({
+  ...chunk,
+  steps: chunk.steps.slice(),
+  velocities: chunk.velocities ? chunk.velocities.slice() : undefined,
+  pitches: chunk.pitches ? chunk.pitches.slice() : undefined,
+  notes: chunk.notes ? chunk.notes.slice() : undefined,
+  degrees: chunk.degrees ? chunk.degrees.slice() : undefined,
+  noteEvents: chunk.noteEvents
+    ? chunk.noteEvents.map((event) => ({ ...event }))
+    : undefined,
+  harmoniaStepDegrees: chunk.harmoniaStepDegrees
+    ? chunk.harmoniaStepDegrees.slice()
+    : undefined,
+});
+
+const createDemoSongProject = (): StoredProjectData => {
+  const preferredPackId = "chiptune";
+  const resolvedPackIndex = Math.max(
+    0,
+    packs.findIndex((candidate) => candidate.id === preferredPackId)
+  );
+  const pack = packs[resolvedPackIndex] ?? packs[0];
+
+  if (!pack) {
+    return {
+      packIndex: 0,
+      bpm: 110,
+      subdivision: "16n",
+      isPlaying: false,
+      tracks: [],
+      patternGroups: [createInitialPatternGroup()],
+      songRows: [createSongRow()],
+      selectedGroupId: null,
+      currentSectionIndex: 0,
+    };
+  }
+
+  const findChunk = (instrument: string, preferredId?: string): Chunk | null => {
+    if (preferredId) {
+      const preferred = pack.chunks.find((chunk) => chunk.id === preferredId);
+      if (preferred) return preferred;
+    }
+    return pack.chunks.find((chunk) => chunk.instrument === instrument) ?? null;
+  };
+
+  const demoChunks: { chunk: Chunk | null; fallbackName: string }[] = [
+    { chunk: findChunk("kick", "chip-kick-sync"), fallbackName: "Kick" },
+    { chunk: findChunk("snare", "chip-snare-ghost"), fallbackName: "Snare" },
+    { chunk: findChunk("hihat", "chip-hat-8ths"), fallbackName: "Hi-hat" },
+  ];
+
+  const tracks: Track[] = demoChunks
+    .map(({ chunk, fallbackName }, index) => {
+      if (!chunk) {
+        return null;
+      }
+      const pattern = {
+        ...cloneChunkForDemo(chunk),
+        id: `${chunk.id}-demo-${index + 1}`,
+        name: chunk.name,
+      };
+      return {
+        id: index + 1,
+        name: chunk.name ?? fallbackName,
+        instrument: chunk.instrument as keyof TriggerMap,
+        pattern,
+        muted: false,
+        source: {
+          packId: pack.id,
+          instrumentId: chunk.instrument,
+          characterId: chunk.characterId ?? "",
+          presetId: chunk.id,
+        },
+      } satisfies Track;
+    })
+    .filter((track): track is Track => Boolean(track));
+
+  const groupId = createPatternGroupId();
+  const groupTracks = tracks.map((track) => ({
+    ...track,
+    pattern: track.pattern
+      ? {
+          ...cloneChunkForDemo(track.pattern),
+          id: `${track.pattern.id}-snapshot`,
+        }
+      : null,
+  }));
+
+  const patternGroups: PatternGroup[] = [
+    {
+      id: groupId,
+      name: "demo-loop",
+      tracks: groupTracks,
+    },
+  ];
+
+  const songRow = createSongRow(1);
+  songRow.slots[0] = groupId;
+
+  return {
+    packIndex: resolvedPackIndex,
+    bpm: 110,
+    subdivision: "16n",
+    isPlaying: false,
+    tracks,
+    patternGroups,
+    songRows: [songRow],
+    selectedGroupId: groupId,
+    currentSectionIndex: 0,
+  };
+};
+
 type Subdivision = "16n" | "8n" | "4n";
 
 const CONTROL_BUTTON_SIZE = 44;
@@ -1113,7 +1225,7 @@ export default function App() {
       });
     } catch (error) {
       console.error(error);
-      window.alert("Failed to export project JSON");
+      window.alert("Failed to export song JSON");
     }
   }, [buildProjectSnapshot, activeProjectName]);
 
@@ -1190,7 +1302,7 @@ export default function App() {
   const handleConfirmSaveProject = () => {
     const trimmed = projectNameInput.trim();
     if (!trimmed) {
-      setProjectModalError("Enter a project name");
+      setProjectModalError("Enter a song name");
       return;
     }
     try {
@@ -1202,7 +1314,7 @@ export default function App() {
       setProjectModalMode(null);
     } catch (error) {
       console.error(error);
-      setProjectModalError("Failed to save project");
+      setProjectModalError("Failed to save song");
     }
   };
 
@@ -1258,7 +1370,7 @@ export default function App() {
     (name: string) => {
       const project = loadStoredProject(name);
       if (!project) {
-        setProjectModalError("Project not found");
+        setProjectModalError("Song not found");
         return;
       }
       applyLoadedProject(project);
@@ -1271,7 +1383,7 @@ export default function App() {
 
   const handleDeleteProject = useCallback(
     (name: string) => {
-      const confirmed = window.confirm(`Delete project "${name}"? This can't be undone.`);
+      const confirmed = window.confirm(`Delete song "${name}"? This can't be undone.`);
       if (!confirmed) return;
       deleteProject(name);
       refreshProjectList();
@@ -1301,7 +1413,7 @@ export default function App() {
   }, [bpm]);
 
   const handleNewProjectClick = useCallback(() => {
-    console.log("New project button clicked");
+    console.log("New song button clicked");
     setActiveProjectName("untitled");
     setStarted(true);
     setViewMode("track");
@@ -1325,6 +1437,33 @@ export default function App() {
     },
     [handleLoadProjectByName, initAudioGraph, started]
   );
+
+  const handleLaunchDemoSong = useCallback(async () => {
+    const demoProject = createDemoSongProject();
+    if (!started) {
+      try {
+        await initAudioContext();
+      } catch {
+        return;
+      }
+      initAudioGraph();
+    }
+    applyLoadedProject(demoProject);
+    setActiveProjectName("Demo Jam");
+    setProjectModalMode(null);
+    setProjectModalError(null);
+    setViewMode("track");
+    setPendingLoopStripAction(null);
+  }, [
+    applyLoadedProject,
+    initAudioGraph,
+    setActiveProjectName,
+    setProjectModalMode,
+    setProjectModalError,
+    setPendingLoopStripAction,
+    setViewMode,
+    started,
+  ]);
 
   const handlePlayStop = () => {
     if (isPlaying) {
@@ -1484,18 +1623,18 @@ export default function App() {
         <Modal
           isOpen={projectModalMode !== null}
           onClose={closeProjectModal}
-          title={projectModalMode === "save" ? "Save Project" : "Load Project"}
+          title={projectModalMode === "save" ? "Save Song" : "Load Song"}
           subtitle={
             projectModalMode === "save"
               ? "Name your jam to store it locally on this device."
-              : "Open a saved project from local storage."
+              : "Open a saved song from local storage."
           }
           maxWidth={460}
           footer={
             projectModalMode === "save" ? (
               <IconButton
                 icon="save"
-                label="Save project"
+                label="Save song"
                 tone="accent"
                 onClick={handleConfirmSaveProject}
                 disabled={!projectNameInput.trim()}
@@ -1506,7 +1645,7 @@ export default function App() {
           {projectModalMode === "save" ? (
             <>
               <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                <span style={{ fontSize: 13, color: "#cbd5f5" }}>Project name</span>
+                <span style={{ fontSize: 13, color: "#cbd5f5" }}>Song name</span>
                 <input
                   id="project-name"
                   value={projectNameInput}
@@ -1532,7 +1671,7 @@ export default function App() {
               >
                 {projectList.length === 0 ? (
                   <div style={{ fontSize: 13, color: "#94a3b8" }}>
-                    No projects saved yet
+                    No songs saved yet
                   </div>
                 ) : (
                   projectList.map((name) => {
@@ -1563,13 +1702,13 @@ export default function App() {
                             fontSize: 14,
                             cursor: "pointer",
                           }}
-                          title={`Use project name ${name}`}
+                          title={`Use song name ${name}`}
                         >
                           {name}
                         </button>
                         <IconButton
                           icon="delete"
-                          label={`Delete project ${name}`}
+                          label={`Delete song ${name}`}
                           tone="danger"
                           onClick={() => handleDeleteProject(name)}
                         />
@@ -1591,7 +1730,7 @@ export default function App() {
             >
               {projectList.length === 0 ? (
                 <div style={{ fontSize: 13, color: "#94a3b8" }}>
-                  No projects saved yet
+                  No songs saved yet
                 </div>
               ) : (
                 projectList.map((name) => (
@@ -1617,13 +1756,13 @@ export default function App() {
                     <div style={{ display: "flex", gap: 8 }}>
                       <IconButton
                         icon="folder_open"
-                        label={`Load project ${name}`}
+                        label={`Load song ${name}`}
                         tone="accent"
                         onClick={() => handleLoadProjectByName(name)}
                       />
                       <IconButton
                         icon="delete"
-                        label={`Delete project ${name}`}
+                        label={`Delete song ${name}`}
                         tone="danger"
                         onClick={() => handleDeleteProject(name)}
                       />
@@ -1643,7 +1782,7 @@ export default function App() {
         <Modal
           isOpen={isExportModalOpen || isAudioExporting}
           onClose={handleCloseExportModal}
-          title="Export Project"
+          title="Export Song"
           subtitle="Download your jam as JSON or render audio offline."
           maxWidth={420}
         >
@@ -1657,7 +1796,7 @@ export default function App() {
           >
             <IconButton
               icon="file_download"
-              label="Export project JSON"
+              label="Export song JSON"
               tone="accent"
               onClick={handleExportJson}
               disabled={isAudioExporting}
@@ -1729,7 +1868,7 @@ export default function App() {
                 cursor: "pointer",
               }}
             >
-              New Project
+              New Song
             </button>
             <div
               style={{
@@ -1739,46 +1878,113 @@ export default function App() {
               }}
             >
               <div style={{ fontSize: 16, fontWeight: 600, color: "#e6f2ff" }}>
-                Saved Projects
+                Saved Songs
               </div>
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 12,
-                  maxHeight: "60vh",
-                  overflowY: "auto",
-                }}
-              >
-                {projectList.length === 0 ? (
-                  <div style={{ fontSize: 13, color: "#94a3b8" }}>
-                    No projects saved yet
+              {projectList.length === 0 ? (
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 16,
+                    padding: 20,
+                    borderRadius: 16,
+                    border: "1px dashed #27364b",
+                    background: "linear-gradient(135deg, #0b1424, #101a2d)",
+                    textAlign: "center",
+                    color: "#cbd5f5",
+                  }}
+                >
+                  <div style={{ fontSize: 20, fontWeight: 700 }}>
+                    🎶 Start your first jam!
                   </div>
-                ) : (
-                  projectList.map((name) => (
-                    <button
-                      key={name}
-                      onClick={() => handleLaunchProject(name)}
-                      style={{
-                        padding: "12px 16px",
-                        borderRadius: 14,
-                        border: "1px solid #1f2937",
-                        background: "#0f172a",
-                        color: "#e6f2ff",
-                        textAlign: "left",
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 4,
-                      }}
-                    >
-                      <span style={{ fontSize: 15, fontWeight: 600 }}>{name}</span>
-                      <span style={{ fontSize: 11, color: "#94a3b8" }}>
-                        Tap to load project
-                      </span>
-                    </button>
-                  ))
-                )}
-              </div>
+                  <div style={{ fontSize: 13, lineHeight: 1.5 }}>
+                    Save songs to see them here. Want to hear how it works?
+                    Load our demo loop and tweak away.
+                  </div>
+                  <div
+                    style={{
+                      width: "100%",
+                      borderRadius: 12,
+                      border: "1px dashed #334155",
+                      padding: 24,
+                      background: "rgba(15, 23, 42, 0.6)",
+                      color: "#1e293b",
+                      fontSize: 32,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    🎛️
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleLaunchDemoSong}
+                    style={{
+                      alignSelf: "center",
+                      padding: "10px 20px",
+                      borderRadius: 999,
+                      border: "none",
+                      background: "#27E0B0",
+                      color: "#1F2532",
+                      fontWeight: 700,
+                      cursor: "pointer",
+                    }}
+                  >
+                    Try Demo Song
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={handleLaunchDemoSong}
+                    style={{
+                      padding: "10px 16px",
+                      borderRadius: 999,
+                      border: "1px solid #1f2937",
+                      background: "#132034",
+                      color: "#e6f2ff",
+                      fontWeight: 600,
+                      cursor: "pointer",
+                    }}
+                  >
+                    Try Demo Song
+                  </button>
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 12,
+                      maxHeight: "60vh",
+                      overflowY: "auto",
+                    }}
+                  >
+                    {projectList.map((name) => (
+                      <button
+                        key={name}
+                        onClick={() => handleLaunchProject(name)}
+                        style={{
+                          padding: "12px 16px",
+                          borderRadius: 14,
+                          border: "1px solid #1f2937",
+                          background: "#0f172a",
+                          color: "#e6f2ff",
+                          textAlign: "left",
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: 4,
+                        }}
+                      >
+                        <span style={{ fontSize: 15, fontWeight: 600 }}>{name}</span>
+                        <span style={{ fontSize: 11, color: "#94a3b8" }}>
+                          Tap to load song
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -1837,12 +2043,12 @@ export default function App() {
               >
                 <IconButton
                   icon="save"
-                  label="Save project"
+                  label="Save song"
                   onClick={openSaveProjectModal}
                 />
                 <IconButton
                   icon="folder_open"
-                  label="Load project"
+                  label="Load song"
                   onClick={openLoadProjectModal}
                 />
                 <IconButton

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -1667,7 +1667,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
 
   const handleDeleteUserPreset = useCallback(() => {
     if (!packId || !sourceInstrumentId || !userPresetId) return;
-    const confirmed = window.confirm("Delete this saved preset pattern?");
+    const confirmed = window.confirm("Delete this saved loop?");
     if (!confirmed) return;
     const removed = deleteInstrumentPreset(packId, sourceInstrumentId, userPresetId);
     if (removed) {
@@ -1681,7 +1681,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <span style={{ fontSize: 11, fontWeight: 600, color: "#94a3b8" }}>
-            Load Saved Preset Pattern
+            Load Saved Loop
           </span>
           <select
             value={userPresetId}
@@ -1696,8 +1696,8 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
           >
             <option value="">
               {userPresets.length > 0
-                ? "Select a preset pattern"
-                : "No saved preset patterns for this instrument"}
+                ? "Select a saved loop"
+                : "No saved loops for this instrument"}
             </option>
             {userPresets.map((preset) => (
               <option key={preset.id} value={preset.id}>
@@ -1723,7 +1723,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
               cursor: userPresetId ? "pointer" : "not-allowed",
             }}
           >
-            Load Preset Pattern
+            Load Saved Loop
           </button>
           <button
             type="button"
@@ -1741,7 +1741,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
               cursor: userPresetId ? "pointer" : "not-allowed",
             }}
           >
-            Delete Preset Pattern
+            Delete Saved Loop
           </button>
         </div>
       </div>
@@ -2623,11 +2623,11 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
                 ) : null}
               </div>
             </CollapsibleSection>
-            <CollapsibleSection title="Preset Patterns & FX" defaultOpen>
+            <CollapsibleSection title="Saved Loops & FX" defaultOpen>
               <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
                 <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
                   <span style={{ fontSize: 12, fontWeight: 600, color: "#94a3b8" }}>
-                    Preset Pattern
+                    Saved Loop
                   </span>
                   <select
                     value={presetSelection}
@@ -3060,7 +3060,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
           </div>
           {track.source?.characterId ? (
             <div style={{ display: "flex", justifyContent: "space-between" }}>
-              <span>Character</span>
+              <span>Style</span>
               <span style={{ color: "#e6f2ff" }}>
                 {formatInstrumentLabel(track.source.characterId)}
               </span>

--- a/src/Keyboard.tsx
+++ b/src/Keyboard.tsx
@@ -807,7 +807,7 @@ export function Keyboard({
               fontSize: 12,
             }}
           >
-            <span style={{ fontWeight: 600 }}>Preset Pattern</span>
+            <span style={{ fontWeight: 600 }}>Saved Loop</span>
             <select
               value={preset}
               onChange={(event) => {

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -268,6 +268,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
   const instrumentOptions = Object.keys(pack.instruments);
   const canAddTrack = instrumentOptions.length > 0;
   const addTrackEnabled = canAddTrack;
+  const showHeroAddTrack = addTrackEnabled && tracks.length === 0;
 
   useEffect(() => {
     console.log("Track view mounted");
@@ -920,7 +921,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
             cursor: patternGroups.length === 0 ? "not-allowed" : "pointer",
           }}
         >
-          <span>Sequence: {selectedGroup?.name ?? "None"}</span>
+          <span>Loop: {selectedGroup?.name ?? "None"}</span>
           <span aria-hidden="true" style={{ fontSize: 10 }}>
             ▴
           </span>
@@ -935,16 +936,29 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
           style={{
             padding: "6px 16px",
             borderRadius: 999,
-            border: "1px solid #333",
-            background: addTrackEnabled ? "#27E0B0" : "#1f2532",
-            color: addTrackEnabled ? "#1F2532" : "#475569",
+            border: showHeroAddTrack ? "1px solid rgba(39, 224, 176, 0.8)" : "1px solid #333",
+            background: showHeroAddTrack
+              ? "linear-gradient(135deg, #27E0B0, #63F5CE)"
+              : addTrackEnabled
+              ? "#27E0B0"
+              : "#1f2532",
+            color: showHeroAddTrack
+              ? "#082127"
+              : addTrackEnabled
+              ? "#1F2532"
+              : "#475569",
             fontSize: 13,
             fontWeight: 700,
             letterSpacing: 0.3,
             cursor: addTrackEnabled ? "pointer" : "not-allowed",
-            boxShadow: addTrackEnabled
+            boxShadow: showHeroAddTrack
+              ? "0 12px 32px rgba(39, 224, 176, 0.35)"
+              : addTrackEnabled
               ? "0 2px 6px rgba(15, 20, 32, 0.35)"
               : "none",
+            transform: showHeroAddTrack ? "scale(1.03)" : "none",
+            transition:
+              "transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border 0.2s ease",
           }}
         >
           + Track
@@ -972,7 +986,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
               color: "#94a3b8",
             }}
           >
-            Tap “Add Track” to start building your loop.
+            No beats yet — add a track to get the groove started.
           </div>
         )}
         {tracks.map((t) => {
@@ -1211,7 +1225,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                   color: "#e6f2ff",
                 }}
               >
-                Sequence Library
+                Loop Library
               </h3>
               <button
                 type="button"
@@ -1240,8 +1254,8 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
               <button
                 type="button"
                 onClick={openCreateGroup}
-                aria-label="Create new sequence"
-                title="Create new sequence"
+                aria-label="Create new loop"
+                title="Create new loop"
                 style={{
                   width: 36,
                   height: 36,
@@ -1262,7 +1276,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 </span>
               </button>
               <select
-                aria-label="Current sequence"
+                aria-label="Current loop"
                 value={selectedGroupId ?? patternGroups[0]?.id ?? ""}
                 onChange={(event) => {
                   const value = event.target.value;
@@ -1376,7 +1390,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 type="button"
                 onClick={handleDeleteGroup}
                 disabled={!selectedGroup || patternGroups.length <= 1}
-                aria-label="Delete sequence"
+                aria-label="Delete loop"
                 style={{
                   flex: "1 1 110px",
                   minWidth: 0,
@@ -1427,8 +1441,8 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 />
                 <span style={{ fontSize: 12, color: "#94a3b8" }}>
                   {groupEditor.mode === "create"
-                    ? "New sequences start blank. Name it to keep things organized."
-                    : "Rename this sequence."}
+                    ? "New loops start blank. Name it to keep things organized."
+                    : "Rename this loop."}
                 </span>
                 <div style={{ display: "flex", gap: 8 }}>
                   <button
@@ -1448,7 +1462,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                     }}
                   >
                     {groupEditor.mode === "create"
-                      ? "Create New Sequence"
+                      ? "Create New Loop"
                       : "Save Changes"}
                   </button>
                   <button
@@ -1470,14 +1484,14 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
             ) : selectedGroup ? (
               <span style={{ fontSize: 12, color: "#94a3b8" }}>
                 {selectedGroup.tracks.length === 0
-                  ? "No saved tracks yet. Tap Save Sequence to capture the current loop."
+                  ? "No saved tracks yet. Tap Save Loop to capture the current loop."
                   : `${selectedGroup.tracks.length} saved track${
                       selectedGroup.tracks.length === 1 ? "" : "s"
                     } including mute states.`}
               </span>
             ) : (
               <span style={{ fontSize: 12, color: "#94a3b8" }}>
-                Create a sequence to capture the current track mix.
+                Create a loop to capture the current track mix.
               </span>
             )}
           </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -188,7 +188,7 @@ export function SongView({
           }}
         >
           <span>
-            Sequence: {activeGroup?.name ?? "None"}
+            Loop: {activeGroup?.name ?? "None"}
           </span>
           <span aria-hidden="true" style={{ fontSize: 10 }}>
             ▴
@@ -660,7 +660,7 @@ export function SongView({
               color: "#e6f2ff",
             }}
           >
-            Sequence Library
+            Loop Library
           </h3>
           <span
             style={{
@@ -668,7 +668,7 @@ export function SongView({
               color: "#94a3b8",
             }}
           >
-            Save and edit sequences in Track view, then place them onto the song
+            Save and edit loops in Track view, then place them onto the song
             timeline.
           </span>
         </div>
@@ -682,7 +682,7 @@ export function SongView({
               fontSize: 13,
             }}
           >
-            No sequences yet. Create sequences in Track view to start arranging
+            No loops yet. Create loops in Track view to start arranging
             the song.
           </div>
         ) : (
@@ -739,7 +739,7 @@ export function SongView({
                   </div>
                   {trackLabels.length === 0 ? (
                     <span style={{ fontSize: 12, color: "#94a3b8" }}>
-                      This sequence has no playable tracks.
+                      This loop is empty — add instruments in Tracks view first.
                     </span>
                   ) : (
                     <div

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -107,7 +107,7 @@ export const saveInstrumentPreset = (
   const now = Date.now();
   const record: InstrumentPreset = {
     id: createId(),
-    name: name.trim() || pattern.name || "Untitled Preset Pattern",
+    name: name.trim() || pattern.name || "Untitled Saved Loop",
     packId,
     instrumentId,
     characterId: characterId ?? null,


### PR DESCRIPTION
## Summary
- rename project-facing UI copy to use "Song" phrasing for saving, loading, and exporting.
- retitle sequence controls in track and song views to use "Loop" language across selectors and library dialogs.
- refresh modal and control panel labels to talk about "Style" and "Saved Loops," including prompts, alerts, and preset defaults.
- add welcoming empty states with a demo song entry point and a hero "+ Track" button to guide first-time users.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1897fd1548328992d9b011007c433