### PR TITLE
Rebrand loop library and polish copy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1098,7 +1098,7 @@ export default function App() {
         return;
       }
       if (pendingLoopStripAction === "openLibrary") {
-        handle.openSequenceLibrary();
+        handle.openLoopsLibrary();
       }
       setPendingLoopStripAction(null);
     };
@@ -1509,16 +1509,16 @@ export default function App() {
     };
   }, []);
 
-  const handleOpenSequenceLibrary = () => {
+  const handleOpenLoopsLibrary = () => {
     if (viewMode !== "track") {
       setViewMode("track");
       setPendingLoopStripAction("openLibrary");
       return;
     }
-    loopStripRef.current?.openSequenceLibrary();
+    loopStripRef.current?.openLoopsLibrary();
   };
 
-  const handleSelectSequenceFromSongView = useCallback(
+  const handleSelectLoopFromSongView = useCallback(
     (groupId: string) => {
       setSelectedGroupId(groupId);
       setEditing(null);
@@ -2329,8 +2329,8 @@ export default function App() {
                 setBpm={setBpm}
                 onToggleTransport={handlePlayStop}
                 selectedGroupId={selectedGroupId}
-                onOpenSequenceLibrary={handleOpenSequenceLibrary}
-                onSelectSequence={handleSelectSequenceFromSongView}
+                onOpenLoopsLibrary={handleOpenLoopsLibrary}
+                onSelectLoop={handleSelectLoopFromSongView}
               />
             )}
           </div>

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -207,7 +207,7 @@ type GroupEditorState =
     };
 
 export interface LoopStripHandle {
-  openSequenceLibrary: () => void;
+  openLoopsLibrary: () => void;
   addTrack: () => void;
   addTrackWithOptions: (options: AddTrackRequest) => void;
   updateTrackWithOptions: (trackId: number, options: AddTrackRequest) => void;
@@ -260,7 +260,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
   const [stepEditing, setStepEditing] = useState<
     { trackId: number; index: number } | null
   >(null);
-  const [isSequenceLibraryOpen, setIsSequenceLibraryOpen] = useState(false);
+  const [isLoopsLibraryOpen, setIsLoopsLibraryOpen] = useState(false);
   const swipeRef = useRef(0);
   const trackAreaRef = useRef<HTMLDivElement>(null);
   const labelLongPressRef = useRef<Map<number, boolean>>(new Map());
@@ -323,7 +323,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
         setSelectedGroupId(null);
       }
       setGroupEditor(null);
-      setIsSequenceLibraryOpen(false);
+      setIsLoopsLibraryOpen(false);
       return;
     }
     const exists = selectedGroupId
@@ -672,7 +672,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
   useImperativeHandle(
     ref,
     () => ({
-      openSequenceLibrary: () => setIsSequenceLibraryOpen(true),
+      openLoopsLibrary: () => setIsLoopsLibraryOpen(true),
       addTrack: () => handleAddTrack(),
       addTrackWithOptions: (options: AddTrackRequest) =>
         handleAddTrackWithOptions(options),
@@ -903,7 +903,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
         <button
           type="button"
           onClick={() =>
-            setIsSequenceLibraryOpen((open) => !open && patternGroups.length > 0)
+            setIsLoopsLibraryOpen((open) => !open && patternGroups.length > 0)
           }
           disabled={patternGroups.length === 0}
           style={{
@@ -1180,9 +1180,9 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
           );
         })}
       </div>
-      {isSequenceLibraryOpen && (
+      {isLoopsLibraryOpen && (
         <div
-          onClick={() => setIsSequenceLibraryOpen(false)}
+          onClick={() => setIsLoopsLibraryOpen(false)}
           style={{
             position: "fixed",
             inset: 0,
@@ -1224,11 +1224,11 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                   color: "#e6f2ff",
                 }}
               >
-                Loop Library
+                Loops Library
               </h3>
               <button
                 type="button"
-                onClick={() => setIsSequenceLibraryOpen(false)}
+                onClick={() => setIsLoopsLibraryOpen(false)}
                 style={{
                   marginLeft: "auto",
                   padding: "4px 8px",
@@ -1281,7 +1281,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                   const value = event.target.value;
                   setSelectedGroupId(value || null);
                   setGroupEditor(null);
-                  setIsSequenceLibraryOpen(false);
+                  setIsLoopsLibraryOpen(false);
                 }}
                 style={{
                   flex: "1 1 auto",
@@ -1295,7 +1295,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
               >
                 {patternGroups.map((group) => (
                   <option key={group.id} value={group.id}>
-                    {group.name}
+                    📼 {group.name}
                   </option>
                 ))}
               </select>
@@ -1448,7 +1448,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                     type="button"
                     onClick={() => {
                       handleSaveGroup();
-                      setIsSequenceLibraryOpen(false);
+                      setIsLoopsLibraryOpen(false);
                     }}
                     style={{
                       padding: "8px 12px",
@@ -1483,7 +1483,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
             ) : selectedGroup ? (
               <span style={{ fontSize: 12, color: "#94a3b8" }}>
                 {selectedGroup.tracks.length === 0
-                  ? "No saved tracks yet. Tap Save Loop to capture the current loop."
+                  ? "Save this beat to use again later!"
                   : `${selectedGroup.tracks.length} saved track${
                       selectedGroup.tracks.length === 1 ? "" : "s"
                     } including mute states.`}

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -18,8 +18,8 @@ interface SongViewProps {
   setBpm: Dispatch<SetStateAction<number>>;
   onToggleTransport: () => void;
   selectedGroupId: string | null;
-  onOpenSequenceLibrary: () => void;
-  onSelectSequence: (groupId: string) => void;
+  onOpenLoopsLibrary: () => void;
+  onSelectLoop: (groupId: string) => void;
 }
 
 const SLOT_WIDTH = 150;
@@ -39,8 +39,8 @@ export function SongView({
   setBpm,
   onToggleTransport,
   selectedGroupId,
-  onOpenSequenceLibrary,
-  onSelectSequence,
+  onOpenLoopsLibrary,
+  onSelectLoop,
 }: SongViewProps) {
   const [editingSlot, setEditingSlot] = useState<
     { rowIndex: number; columnIndex: number } | null
@@ -170,7 +170,7 @@ export function SongView({
       >
         <button
           type="button"
-          onClick={onOpenSequenceLibrary}
+          onClick={onOpenLoopsLibrary}
           disabled={patternGroups.length === 0}
           style={{
             padding: "6px 14px",
@@ -660,7 +660,7 @@ export function SongView({
               color: "#e6f2ff",
             }}
           >
-            Loop Library
+            Loops Library
           </h3>
           <span
             style={{
@@ -702,7 +702,7 @@ export function SongView({
                 <button
                   key={group.id}
                   type="button"
-                  onClick={() => onSelectSequence(group.id)}
+                  onClick={() => onSelectLoop(group.id)}
                   style={{
                     borderRadius: 10,
                     border: `1px solid ${isActive ? "#27E0B0" : "#333"}`,
@@ -726,6 +726,9 @@ export function SongView({
                       gap: 8,
                     }}
                   >
+                    <span aria-hidden="true" style={{ fontSize: 16 }}>
+                      📼
+                    </span>
                     <span style={{ fontWeight: 600 }}>{group.name}</span>
                     <span
                       style={{


### PR DESCRIPTION
## Summary
- rename the Sequence Library to "Loops Library" across the track and song views
- add a cassette icon next to saved loop entries and refresh the empty-state messaging

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d244c5da6c8328b3fc124db520b7ab