### PR TITLE
Allow mixing sound packs per track

### DIFF
--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -26,7 +26,7 @@ import {
 import type { Chunk } from "./chunks";
 import { Modal } from "./components/Modal";
 import { IconButton } from "./components/IconButton";
-import type { TriggerMap } from "./tracks";
+import { createTriggerKey, type TriggerMap } from "./tracks";
 import { initAudioContext } from "./utils/audio";
 
 interface StepSectionProps {
@@ -368,8 +368,9 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
 
   const previewStyle = useCallback(
     async (characterId: string) => {
-      if (!characterId || !selectedInstrumentId) return;
-      const trigger = triggers[selectedInstrumentId];
+      if (!characterId || !selectedInstrumentId || !selectedPackId) return;
+      const trigger =
+        triggers[createTriggerKey(selectedPackId, selectedInstrumentId)];
       if (!trigger) return;
       try {
         await initAudioContext();
@@ -386,14 +387,14 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
       };
       trigger(start, 0.9, 0, undefined, 0.5, previewChunk, characterId);
     },
-    [selectedInstrumentId, triggers]
+    [selectedInstrumentId, selectedPackId, triggers]
   );
 
   const previewPreset = useCallback(
     async (chunk: Chunk, fallbackCharacterId?: string | null) => {
       const instrumentId = chunk.instrument || selectedInstrumentId;
-      if (!instrumentId) return;
-      const trigger = triggers[instrumentId];
+      if (!instrumentId || !selectedPackId) return;
+      const trigger = triggers[createTriggerKey(selectedPackId, instrumentId)];
       if (!trigger) return;
       try {
         await initAudioContext();
@@ -453,7 +454,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
         trigger(start, 0.9, 0, chunk.note, chunk.sustain, chunk, activeCharacterId ?? undefined);
       }
     },
-    [selectedCharacterId, selectedInstrumentId, triggers]
+    [selectedCharacterId, selectedInstrumentId, selectedPackId, triggers]
   );
 
   const handleCharacterChange = useCallback(

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -74,6 +74,7 @@ interface InstrumentControlPanelProps {
     tone: number;
     dynamics: number;
     characterId?: string | null;
+    packId?: string | null;
   }) => void;
 }
 
@@ -652,6 +653,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
         tone,
         dynamics,
         characterId: sourceCharacterId ?? patternCharacterId,
+        packId,
       });
     },
     [
@@ -661,6 +663,7 @@ export const InstrumentControlPanel: FC<InstrumentControlPanelProps> = ({
       sourceCharacterId,
       patternCharacterId,
       harmoniaLastChordRef,
+      packId,
     ]
   );
 

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -995,12 +995,6 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
           const isMuted = t.muted;
           const isEditing = editing === t.id;
           const trackLabel = getTrackNumberLabel(tracks, t.id);
-          const packName = t.source?.packId
-            ? packs.find((candidate) => candidate.id === t.source?.packId)?.name ?? "Unknown Pack"
-            : t.instrument
-            ? "Unknown Pack"
-            : undefined;
-
           const handleLabelPointerDown = (
             event: ReactPointerEvent<HTMLDivElement>
           ) => {
@@ -1103,27 +1097,6 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                     transition: "opacity 0.2s ease, filter 0.2s ease",
                   }}
                 >
-                  {packName ? (
-                    <div
-                      style={{
-                        position: "absolute",
-                        top: 6,
-                        right: 8,
-                        padding: "2px 6px",
-                        borderRadius: 8,
-                        background: "rgba(15, 20, 32, 0.85)",
-                        border: "1px solid #2a3344",
-                        color: "#cbd5f5",
-                        fontSize: 10,
-                        fontWeight: 600,
-                        letterSpacing: 0.4,
-                        textTransform: "uppercase",
-                        pointerEvents: "none",
-                      }}
-                    >
-                      {packName}
-                    </div>
-                  ) : null}
                   {t.pattern ? (
                     isEditing ? (
                       <PatternEditor

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -265,8 +265,9 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
   const trackAreaRef = useRef<HTMLDivElement>(null);
   const labelLongPressRef = useRef<Map<number, boolean>>(new Map());
   const pack = packs[packIndex];
-  const instrumentOptions = Object.keys(pack.instruments);
-  const canAddTrack = instrumentOptions.length > 0;
+  const canAddTrack = packs.some(
+    (candidate) => Object.keys(candidate.instruments).length > 0
+  );
   const addTrackEnabled = canAddTrack;
   const isHeroAddTrack = tracks.length === 0;
 
@@ -435,7 +436,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
       if (!addTrackEnabled) return;
       if (!instrumentId) return;
       const activePack = pack.id === packId ? pack : packs.find((p) => p.id === packId);
-      if (!activePack || activePack.id !== pack.id) {
+      if (!activePack) {
         return;
       }
       const resolvePreset = () => {
@@ -554,7 +555,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
     ) => {
       if (!instrumentId) return;
       const activePack = pack.id === packId ? pack : packs.find((p) => p.id === packId);
-      if (!activePack || activePack.id !== pack.id) {
+      if (!activePack) {
         return;
       }
       const resolvePreset = () => {
@@ -994,6 +995,11 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
           const isMuted = t.muted;
           const isEditing = editing === t.id;
           const trackLabel = getTrackNumberLabel(tracks, t.id);
+          const packName = t.source?.packId
+            ? packs.find((candidate) => candidate.id === t.source?.packId)?.name ?? "Unknown Pack"
+            : t.instrument
+            ? "Unknown Pack"
+            : undefined;
 
           const handleLabelPointerDown = (
             event: ReactPointerEvent<HTMLDivElement>
@@ -1097,6 +1103,27 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                     transition: "opacity 0.2s ease, filter 0.2s ease",
                   }}
                 >
+                  {packName ? (
+                    <div
+                      style={{
+                        position: "absolute",
+                        top: 6,
+                        right: 8,
+                        padding: "2px 6px",
+                        borderRadius: 8,
+                        background: "rgba(15, 20, 32, 0.85)",
+                        border: "1px solid #2a3344",
+                        color: "#cbd5f5",
+                        fontSize: 10,
+                        fontWeight: 600,
+                        letterSpacing: 0.4,
+                        textTransform: "uppercase",
+                        pointerEvents: "none",
+                      }}
+                    >
+                      {packName}
+                    </div>
+                  ) : null}
                   {t.pattern ? (
                     isEditing ? (
                       <PatternEditor

--- a/src/PatternPlaybackManager.tsx
+++ b/src/PatternPlaybackManager.tsx
@@ -12,7 +12,8 @@ import type {
   HarmoniaScaleDegree,
 } from "./instruments/harmonia";
 import { isScaleName, type ScaleName } from "./music/scales";
-import type { Track, TriggerMap } from "./tracks";
+import { createTriggerKey, type Track, type TriggerMap } from "./tracks";
+import { packs } from "./packs";
 import type { PatternGroup, SongRow } from "./song";
 
 interface PatternPlaybackManagerProps {
@@ -39,6 +40,15 @@ export function PatternPlaybackManager({
     [patternGroups]
   );
 
+  const resolveTrigger = (instrument: string, packId?: string | null) => {
+    const resolvedPackId =
+      packId ??
+      packs.find((candidate) => candidate.instruments[instrument])?.id ??
+      null;
+    if (!resolvedPackId) return undefined;
+    return triggers[createTriggerKey(resolvedPackId, instrument)];
+  };
+
   if (viewMode === "song") {
     const players: JSX.Element[] = [];
     songRows.forEach((row, rowIndex) => {
@@ -53,7 +63,7 @@ export function PatternPlaybackManager({
         if (!track.pattern) return;
         const instrument = track.instrument;
         if (!instrument) return;
-        const trigger = triggers[instrument];
+        const trigger = resolveTrigger(instrument, track.source?.packId);
         if (!trigger) return;
         const scaledTrigger = (
           time: number,
@@ -99,7 +109,7 @@ export function PatternPlaybackManager({
         if (!track.pattern) return null;
         const instrument = track.instrument;
         if (!instrument) return null;
-        const trigger = triggers[instrument];
+        const trigger = resolveTrigger(instrument, track.source?.packId);
         if (!trigger) return null;
         const isTrackActive = () => !track.muted;
         return (

--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -30,3 +30,6 @@ export interface Track {
   muted: boolean;
   source?: TrackSource;
 }
+
+export const createTriggerKey = (packId: string, instrumentId: string) =>
+  `${packId}::${instrumentId}`;


### PR DESCRIPTION
## Summary
- generate trigger keys per sound pack and rebuild audio graph so instruments from multiple packs can play side by side
- require pack selection when creating or editing tracks and reuse that pack for previews and pattern playback
- relax LoopStrip pack restrictions and show each track's pack label in the track list

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d30c6781e48328a11d36e9e630c1a8