### PR TITLE
Refactor kick designer to Tone.js membrane synth pipeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -849,7 +849,7 @@ export default function App() {
     ) => {
       if (instrumentId === "kick") {
         const defaults = normalizeKickDesignerState(character.defaults);
-        const instrument = createKickDesigner(defaults);
+        const instrument = createKickDesigner(defaults, character.kick);
         instrument.toDestination();
         return { instrument: instrument as ToneInstrument };
       }
@@ -1011,6 +1011,7 @@ export default function App() {
         };
         if (instrumentId === "kick") {
           const kick = inst as unknown as KickDesignerInstrument;
+          kick.setStyle?.(character.kick);
           if (kick.setMacroState) {
             const defaults = normalizeKickDesignerState(character.defaults);
             const merged = mergeKickDesignerState(defaults, {

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -164,7 +164,7 @@ const createInstrumentInstance = (
 } => {
   if (instrumentId === "kick") {
     const defaults = normalizeKickDesignerState(character.defaults);
-    const instrument = createKickDesigner(defaults);
+    const instrument = createKickDesigner(defaults, character.kick);
     instrument.toDestination();
     return { instrument: instrument as ToneInstrument };
   }

--- a/src/instruments/kickDesigner.ts
+++ b/src/instruments/kickDesigner.ts
@@ -68,117 +68,86 @@ export const createKickDesigner = (
 ): KickDesignerInstrument => {
   const state = normalizeKickDesignerState(initialState);
 
-  const output = new Tone.Gain(1) as KickDesignerInstrument;
+  const kickOut = new Tone.Gain(1) as KickDesignerInstrument;
 
-  const transient = new Tone.NoiseSynth({
+  const kickSub = new Tone.MembraneSynth({
+    pitchDecay: 0.05,
+    octaves: 6,
+    oscillator: { type: "sine", phase: 0 },
+    envelope: {
+      attack: 0.005,
+      decay: 0.3,
+      sustain: 0,
+      release: 0.1,
+    },
+  });
+  const toneFilter = new Tone.Filter({ type: "lowpass", frequency: 4500, rolloff: -12 });
+  const subGain = new Tone.Gain(1);
+
+  const kickClick = new Tone.NoiseSynth({
     noise: { type: "white" },
-    envelope: { attack: 0, decay: 0.015, sustain: 0, release: 0.02 },
+    envelope: {
+      attack: 0.001,
+      decay: 0.02,
+      sustain: 0,
+      release: 0.01,
+    },
   });
-  const transientFilter = new Tone.Filter({
-    type: "highpass",
-    frequency: 2000,
-    rolloff: -24,
-  });
-  const transientGain = new Tone.Gain(0.5);
+  const clickGain = new Tone.Gain(0.1);
 
-  const body = new Tone.MembraneSynth({
-    pitchDecay: 0.04,
-    octaves: 4,
-    envelope: { attack: 0.001, decay: 0.3, sustain: 0.01, release: 0.2 },
-    volume: -4,
-  });
-  const bodyFilter = new Tone.Filter({ type: "lowpass", frequency: 5000, rolloff: -24 });
-  const bodyGain = new Tone.Gain(0.75);
+  kickSub.connect(toneFilter);
+  toneFilter.connect(subGain);
+  subGain.connect(kickOut);
 
-  const sub = new Tone.Synth({
-    oscillator: { type: "sine" },
-    envelope: { attack: 0, decay: 0.6, sustain: 0, release: 0.8 },
-    volume: -2,
-  });
-  const subFilter = new Tone.Filter({ type: "lowpass", frequency: 180, rolloff: -24 });
-  const subGain = new Tone.Gain(0.7);
-
-  const mix = new Tone.Gain(1);
-  const saturation = new Tone.Distortion({ distortion: 0.1, oversample: "4x", wet: 0.2 });
-  const eq = new Tone.EQ3({ low: 0, mid: 0, high: 0 });
-  const compressor = new Tone.Compressor({
-    threshold: -20,
-    ratio: 3,
-    attack: 0.01,
-    release: 0.25,
-  });
-  const limiter = new Tone.Limiter({ threshold: -6 });
-  const outputGain = new Tone.Gain(0.9);
-
-  transient.connect(transientFilter);
-  transientFilter.connect(transientGain);
-  transientGain.connect(mix);
-
-  body.connect(bodyFilter);
-  bodyFilter.connect(bodyGain);
-  bodyGain.connect(mix);
-
-  sub.connect(subFilter);
-  subFilter.connect(subGain);
-  subGain.connect(mix);
-
-  mix.connect(saturation);
-  saturation.connect(eq);
-  eq.connect(compressor);
-  compressor.connect(limiter);
-  limiter.connect(outputGain);
-  outputGain.connect(output);
+  kickClick.connect(clickGain);
+  clickGain.connect(kickOut);
 
   const applyState = () => {
     const punch = clamp(state.punch, 0, 1);
     const clean = clamp(state.clean, 0, 1);
     const tight = clamp(state.tight, 0, 1);
 
-    const transientLevel = Math.sqrt(1 - punch);
-    const subLevel = Math.sqrt(punch);
-    const bodyLevel = 0.8 + (1 - punch) * 0.15;
+    const pitchDecay = 0.035 + (1 - tight) * 0.035 + punch * 0.01;
+    const octaves = 5 + punch * 1.5 + (1 - tight) * 0.5;
+    const envelopeDecay = 0.24 + (1 - tight) * 0.25 + (1 - clean) * 0.05;
+    const envelopeRelease = 0.12 + (1 - tight) * 0.35 + (1 - clean) * 0.1;
 
-    transientGain.gain.rampTo(0.75 * transientLevel, 0.05);
-    subGain.gain.rampTo(1.1 * subLevel, 0.05);
-    bodyGain.gain.rampTo(bodyLevel, 0.05);
-
-    const transientDecay = 0.01 + (1 - tight) * 0.02;
-    transient.set({
-      envelope: { attack: 0, decay: transientDecay, sustain: 0, release: 0.015 + (1 - tight) * 0.02 },
+    kickSub.set({
+      pitchDecay,
+      octaves,
+      envelope: {
+        attack: 0.005,
+        decay: envelopeDecay,
+        sustain: 0,
+        release: envelopeRelease,
+      },
     });
-    transientFilter.frequency.rampTo(1800 + (1 - punch) * 1800 + (1 - tight) * 600, 0.05);
 
-    const bodyDecay = 0.18 + tight * 0.45;
-    const bodyRelease = 0.12 + tight * 0.4;
-    const bodyPitchDecay = 0.018 + (1 - tight) * 0.05;
-    const bodyOctaves = 3.5 + (1 - tight) * 1.5;
-    body.set({
-      pitchDecay: bodyPitchDecay,
-      octaves: bodyOctaves,
-      envelope: { attack: 0.001, decay: bodyDecay, sustain: 0.01, release: bodyRelease },
+    const clickDecay = 0.01 + (1 - tight) * 0.02;
+    kickClick.set({
+      envelope: {
+        attack: 0.001,
+        decay: clickDecay,
+        sustain: 0,
+        release: 0.01 + (1 - tight) * 0.015,
+      },
     });
-    bodyFilter.frequency.rampTo(3500 + punch * 1500, 0.05);
 
-    const subDecay = 0.35 + tight * 0.8;
-    const subRelease = 0.45 + tight * 1.1;
-    sub.set({
-      envelope: { attack: 0, decay: subDecay, sustain: 0, release: subRelease },
-    });
-    subFilter.frequency.rampTo(120 + tight * 80 + punch * 30, 0.05);
+    const clickLevel = 0.05 + punch * 0.35;
+    clickGain.gain.rampTo(clickLevel, 0.05);
 
-    saturation.distortion = 0.08 + (1 - clean) * 0.75;
-    saturation.wet.value = 0.1 + (1 - clean) * 0.85;
+    const filterFrequency = 1500 + clean * 3200 - (1 - punch) * 200;
+    toneFilter.frequency.rampTo(filterFrequency, 0.05);
 
-    eq.high.value = (1 - punch) * 5 - 2;
-    eq.mid.value = -1 - (1 - clean) * 2 + (0.5 - punch) * 1.2;
-    eq.low.value = punch * 6 - 1.5;
+    const subLevel = 0.8 + (1 - clean) * 0.15 + (1 - punch) * 0.1;
+    subGain.gain.rampTo(subLevel, 0.05);
 
-    outputGain.gain.rampTo(0.85 + (1 - clean) * 0.12, 0.05);
+    kickOut.gain.rampTo(0.9 + (1 - clean) * 0.08, 0.05);
   };
 
   applyState();
 
-  output.setMacroState = (partial) => {
+  kickOut.setMacroState = (partial) => {
     const next = normalizeKickDesignerState({
       punch: partial.punch ?? state.punch,
       clean: partial.clean ?? state.clean,
@@ -190,9 +159,9 @@ export const createKickDesigner = (
     applyState();
   };
 
-  output.getMacroState = () => ({ ...state });
+  kickOut.getMacroState = () => ({ ...state });
 
-  output.triggerAttackRelease = (
+  kickOut.triggerAttackRelease = (
     note = "C2",
     duration: Tone.Unit.Time = "8n",
     time?: Tone.Unit.Time,
@@ -200,60 +169,33 @@ export const createKickDesigner = (
   ) => {
     const when = time ?? Tone.now();
     const tight = state.tight;
-    const punch = state.punch;
-    const whenSeconds = Tone.Time(when).toSeconds();
-
     const baseNote = typeof note === "number" ? note : note || "C2";
-    const baseFrequency = Tone.Frequency(baseNote).toFrequency();
 
-    const transientVelocity = Math.min(1, velocity * (0.85 + (1 - punch) * 0.3));
-    transient.triggerAttackRelease("32n", when, transientVelocity);
+    kickSub.oscillator.phase = 0;
+    if (typeof kickSub.oscillator.restart === "function") {
+      kickSub.oscillator.restart(when);
+    }
 
-    const bodyDuration = Math.max(0.15, 0.35 + tight * 0.4);
-    const bodyStart = baseFrequency * (1 + (1 - tight) * 1.4);
-    body.frequency.setValueAtTime(bodyStart, whenSeconds);
-    body.frequency.exponentialRampToValueAtTime(
-      Math.max(30, baseFrequency),
-      whenSeconds + 0.08 + (1 - tight) * 0.05
-    );
-    body.triggerAttackRelease(baseNote, bodyDuration, when, Math.min(1, velocity * 0.95));
+    const baseDuration = Math.max(0.2, 0.35 + (1 - tight) * 0.45);
+    const requestedDuration = Tone.Time(duration).toSeconds();
+    const memDuration = Math.max(baseDuration, requestedDuration);
+    kickSub.triggerAttackRelease(baseNote, memDuration, when, velocity);
 
-    const subNote = Tone.Frequency(baseNote).transpose(-12 + punch * -2).toNote();
-    const subDuration = Math.max(0.4, 0.6 + tight * 1.2);
-    sub.frequency.setValueAtTime(baseFrequency * 0.5, whenSeconds);
-    sub.frequency.exponentialRampToValueAtTime(
-      Math.max(20, baseFrequency * 0.5),
-      whenSeconds + 0.12 + tight * 0.2
-    );
-    sub.triggerAttackRelease(subNote, subDuration, when, Math.min(1, velocity * (0.7 + punch * 0.4)));
-
-    const releaseTime = Tone.Time(duration).toSeconds();
-    const totalRelease = whenSeconds + releaseTime;
-    mix.gain.cancelAndHoldAtTime(totalRelease);
-    mix.gain.rampTo(0, 0.2, totalRelease);
-    mix.gain.rampTo(1, 0.001, whenSeconds);
+    if (clickGain.gain.value > 0.001) {
+      kickClick.triggerAttackRelease("8n", when, Math.min(1, velocity * 1.1));
+    }
   };
 
-  const originalDispose = output.dispose.bind(output);
-  output.dispose = () => {
-    transient.dispose();
-    transientFilter.dispose();
-    transientGain.dispose();
-    body.dispose();
-    bodyFilter.dispose();
-    bodyGain.dispose();
-    sub.dispose();
-    subFilter.dispose();
+  const originalDispose = kickOut.dispose.bind(kickOut);
+  kickOut.dispose = () => {
+    kickSub.dispose();
+    toneFilter.dispose();
     subGain.dispose();
-    mix.dispose();
-    saturation.dispose();
-    eq.dispose();
-    compressor.dispose();
-    limiter.dispose();
-    outputGain.dispose();
+    kickClick.dispose();
+    clickGain.dispose();
     return originalDispose();
   };
 
-  return output;
+  return kickOut;
 };
 

--- a/src/packs.ts
+++ b/src/packs.ts
@@ -1,5 +1,8 @@
 import type { Chunk } from "./chunks";
-import type { KickDesignerState } from "./instruments/kickDesigner";
+import type {
+  KickDesignerState,
+  KickDesignerStyleConfig,
+} from "./instruments/kickDesigner";
 
 export interface InstrumentSpec {
   type?: string;
@@ -13,6 +16,7 @@ export interface InstrumentCharacter extends InstrumentSpec {
   name: string;
   description?: string;
   defaults?: Partial<KickDesignerState>;
+  kick?: KickDesignerStyleConfig;
 }
 
 export interface InstrumentDefinition {

--- a/src/packs/chiptune.json
+++ b/src/packs/chiptune.json
@@ -10,12 +10,40 @@
         {
           "id": "chip_square_thump",
           "name": "Square Thump",
-          "defaults": { "punch": 0.6, "clean": 0.8, "tight": 0.5 }
+          "defaults": { "punch": 0.6, "clean": 0.8, "tight": 0.5 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.06,
+              "octaves": 4.5,
+              "oscillator": { "type": "square" },
+              "envelope": { "decay": 0.22, "release": 0.18 },
+              "filter": { "type": "lowpass", "frequency": 2800, "Q": 0.9 },
+              "gain": 0.9
+            },
+            "noise": {
+              "gain": 0.08,
+              "filter": { "type": "highpass", "frequency": 7000, "Q": 0.8 }
+            }
+          }
         },
         {
           "id": "chip_noise_pop",
           "name": "Noise Pop",
-          "defaults": { "punch": 0.7, "clean": 0.9, "tight": 0.4 }
+          "defaults": { "punch": 0.7, "clean": 0.9, "tight": 0.4 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.052,
+              "octaves": 4,
+              "oscillator": { "type": "square" },
+              "envelope": { "decay": 0.18, "release": 0.16 },
+              "filter": { "type": "lowpass", "frequency": 2600, "Q": 0.7 },
+              "gain": 0.8
+            },
+            "noise": {
+              "gain": 0.16,
+              "filter": { "type": "bandpass", "frequency": 5000, "Q": 1.2 }
+            }
+          }
         }
       ],
       "patterns": [

--- a/src/packs/early-2000s-edm.json
+++ b/src/packs/early-2000s-edm.json
@@ -10,12 +10,38 @@
         {
           "id": "edm_club_punch",
           "name": "Club Punch",
-          "defaults": { "punch": 0.85, "clean": 0.85, "tight": 0.75 }
+          "defaults": { "punch": 0.85, "clean": 0.85, "tight": 0.75 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.032,
+              "octaves": 6.5,
+              "envelope": { "decay": 0.24, "release": 0.18 },
+              "filter": { "type": "lowpass", "frequency": 5200, "Q": 0.8 },
+              "gain": 0.9
+            },
+            "noise": {
+              "gain": 0.24,
+              "filter": { "type": "highpass", "frequency": 10500, "Q": 0.85 }
+            }
+          }
         },
         {
           "id": "edm_trance_boom",
           "name": "Trance Boom",
-          "defaults": { "punch": 0.6, "clean": 0.7, "tight": 0.5 }
+          "defaults": { "punch": 0.6, "clean": 0.7, "tight": 0.5 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.04,
+              "octaves": 6,
+              "envelope": { "decay": 0.32, "release": 0.28 },
+              "filter": { "type": "lowpass", "frequency": 4200, "Q": 0.75 },
+              "gain": 1
+            },
+            "noise": {
+              "gain": 0.14,
+              "filter": { "type": "highpass", "frequency": 9000, "Q": 0.8 }
+            }
+          }
         }
       ],
       "patterns": [

--- a/src/packs/early-2000s-edm.json
+++ b/src/packs/early-2000s-edm.json
@@ -10,12 +10,12 @@
         {
           "id": "edm_club_punch",
           "name": "Club Punch",
-          "defaults": { "punch": 0.7, "clean": 0.9, "tight": 0.4 }
+          "defaults": { "punch": 0.85, "clean": 0.85, "tight": 0.75 }
         },
         {
           "id": "edm_trance_boom",
           "name": "Trance Boom",
-          "defaults": { "punch": 0.5, "clean": 0.7, "tight": 0.5 }
+          "defaults": { "punch": 0.6, "clean": 0.7, "tight": 0.5 }
         }
       ],
       "patterns": [

--- a/src/packs/kraftwerk.json
+++ b/src/packs/kraftwerk.json
@@ -10,12 +10,40 @@
         {
           "id": "kraftwerk_motor_drive",
           "name": "Motor Drive",
-          "defaults": { "punch": 0.5, "clean": 0.8, "tight": 0.55 }
+          "defaults": { "punch": 0.5, "clean": 0.8, "tight": 0.55 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.048,
+              "octaves": 5.6,
+              "oscillator": { "type": "triangle" },
+              "envelope": { "decay": 0.3, "release": 0.25 },
+              "filter": { "type": "lowpass", "frequency": 4000, "Q": 0.7 },
+              "gain": 0.9
+            },
+            "noise": {
+              "gain": 0.12,
+              "filter": { "type": "highpass", "frequency": 9500, "Q": 0.9 }
+            }
+          }
         },
         {
           "id": "kraftwerk_robotic_snap",
           "name": "Robotic Snap",
-          "defaults": { "punch": 0.35, "clean": 0.6, "tight": 0.45 }
+          "defaults": { "punch": 0.35, "clean": 0.6, "tight": 0.45 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.04,
+              "octaves": 5.2,
+              "oscillator": { "type": "triangle" },
+              "envelope": { "decay": 0.24, "release": 0.2 },
+              "filter": { "type": "lowpass", "frequency": 3600, "Q": 0.8 },
+              "gain": 0.85
+            },
+            "noise": {
+              "gain": 0.18,
+              "filter": { "type": "bandpass", "frequency": 6500, "Q": 1 }
+            }
+          }
         }
       ],
       "patterns": [

--- a/src/packs/phonk.json
+++ b/src/packs/phonk.json
@@ -10,12 +10,12 @@
         {
           "id": "phonk_memphis_distorted",
           "name": "Memphis Distorted",
-          "defaults": { "punch": 0.5, "clean": 0.1, "tight": 0.6 }
+          "defaults": { "punch": 0.4, "clean": 0.15, "tight": 0.25 }
         },
         {
           "id": "phonk_tape_slam",
           "name": "Tape Slam",
-          "defaults": { "punch": 0.4, "clean": 0.3, "tight": 0.7 }
+          "defaults": { "punch": 0.35, "clean": 0.25, "tight": 0.35 }
         }
       ],
       "patterns": [

--- a/src/packs/phonk.json
+++ b/src/packs/phonk.json
@@ -10,12 +10,40 @@
         {
           "id": "phonk_memphis_distorted",
           "name": "Memphis Distorted",
-          "defaults": { "punch": 0.4, "clean": 0.15, "tight": 0.25 }
+          "defaults": { "punch": 0.4, "clean": 0.15, "tight": 0.25 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.052,
+              "octaves": 5.2,
+              "envelope": { "decay": 0.6, "release": 0.7 },
+              "filter": { "type": "lowpass", "frequency": 2600, "Q": 0.7, "rolloff": -24 },
+              "gain": 1.1
+            },
+            "noise": {
+              "type": "pink",
+              "gain": 0.12,
+              "filter": { "type": "bandpass", "frequency": 3500, "Q": 1.2 }
+            }
+          }
         },
         {
           "id": "phonk_tape_slam",
           "name": "Tape Slam",
-          "defaults": { "punch": 0.35, "clean": 0.25, "tight": 0.35 }
+          "defaults": { "punch": 0.35, "clean": 0.25, "tight": 0.35 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.048,
+              "octaves": 5,
+              "envelope": { "decay": 0.5, "release": 0.6 },
+              "filter": { "type": "lowpass", "frequency": 2800, "Q": 0.8, "rolloff": -24 },
+              "gain": 1.05
+            },
+            "noise": {
+              "type": "pink",
+              "gain": 0.1,
+              "filter": { "type": "bandpass", "frequency": 3200, "Q": 1 }
+            }
+          }
         }
       ],
       "patterns": [

--- a/src/packs/trap.json
+++ b/src/packs/trap.json
@@ -10,12 +10,38 @@
         {
           "id": "trap_808_boom",
           "name": "808 Boom",
-          "defaults": { "punch": 0.18, "clean": 0.45, "tight": 0.35 }
+          "defaults": { "punch": 0.18, "clean": 0.45, "tight": 0.35 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.058,
+              "octaves": 5.4,
+              "envelope": { "decay": 0.55, "release": 0.65 },
+              "filter": { "type": "lowpass", "frequency": 3000, "Q": 0.9, "rolloff": -24 },
+              "gain": 1.1
+            },
+            "noise": {
+              "gain": 0.04,
+              "filter": { "type": "highpass", "frequency": 6500, "Q": 0.8 }
+            }
+          }
         },
         {
           "id": "trap_hard_clip",
           "name": "Hard Clip",
-          "defaults": { "punch": 0.48, "clean": 0.35, "tight": 0.55 }
+          "defaults": { "punch": 0.48, "clean": 0.35, "tight": 0.55 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.045,
+              "octaves": 6.2,
+              "envelope": { "decay": 0.38, "release": 0.32 },
+              "filter": { "type": "lowpass", "frequency": 3600, "Q": 0.95, "rolloff": -12 },
+              "gain": 0.95
+            },
+            "noise": {
+              "gain": 0.18,
+              "filter": { "type": "highpass", "frequency": 9000, "Q": 0.9 }
+            }
+          }
         }
       ],
       "patterns": [

--- a/src/packs/trap.json
+++ b/src/packs/trap.json
@@ -10,12 +10,12 @@
         {
           "id": "trap_808_boom",
           "name": "808 Boom",
-          "defaults": { "punch": 0.2, "clean": 0.6, "tight": 0.7 }
+          "defaults": { "punch": 0.18, "clean": 0.45, "tight": 0.35 }
         },
         {
           "id": "trap_hard_clip",
           "name": "Hard Clip",
-          "defaults": { "punch": 0.4, "clean": 0.2, "tight": 0.6 }
+          "defaults": { "punch": 0.48, "clean": 0.35, "tight": 0.55 }
         }
       ],
       "patterns": [

--- a/src/packs/triphop.json
+++ b/src/packs/triphop.json
@@ -10,12 +10,40 @@
         {
           "id": "triphop_lofi_thump",
           "name": "Lo-Fi Thump",
-          "defaults": { "punch": 0.3, "clean": 0.3, "tight": 0.8 }
+          "defaults": { "punch": 0.3, "clean": 0.3, "tight": 0.8 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.045,
+              "octaves": 5.1,
+              "envelope": { "decay": 0.4, "release": 0.55 },
+              "filter": { "type": "lowpass", "frequency": 2400, "Q": 0.9 },
+              "gain": 0.95
+            },
+            "noise": {
+              "type": "pink",
+              "gain": 0.08,
+              "filter": { "type": "lowpass", "frequency": 3800, "Q": 0.7 }
+            }
+          }
         },
         {
           "id": "triphop_vinyl_kick",
           "name": "Vinyl Kick",
-          "defaults": { "punch": 0.4, "clean": 0.2, "tight": 0.7 }
+          "defaults": { "punch": 0.4, "clean": 0.2, "tight": 0.7 },
+          "kick": {
+            "sub": {
+              "pitchDecay": 0.042,
+              "octaves": 5,
+              "envelope": { "decay": 0.45, "release": 0.6 },
+              "filter": { "type": "lowpass", "frequency": 2200, "Q": 1 },
+              "gain": 1
+            },
+            "noise": {
+              "type": "pink",
+              "gain": 0.12,
+              "filter": { "type": "bandpass", "frequency": 3000, "Q": 1.1 }
+            }
+          }
         }
       ],
       "patterns": [


### PR DESCRIPTION
## Summary
- replace the layered kick instrument chain with a single Tone.MembraneSynth sub voice and optional NoiseSynth click routed through a shared gain
- map macro controls to the new synth parameters so styles adjust pitch decay, envelopes, filtering, and click intensity without layering
- retune trap, early-2000s EDM, and phonk kick defaults to highlight sub-heavy, punchy, and dark variations of the new synth

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d61214cddc8328b8d5aa16fd891c7d