### PR TITLE
Refactor kick designer layering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   mergeKickDesignerState,
   normalizeKickDesignerState,
   type KickDesignerInstrument,
+  type KickStyleParameters,
 } from "./instruments/kickDesigner";
 import { SongView } from "./SongView";
 import { PatternPlaybackManager } from "./PatternPlaybackManager";
@@ -968,6 +969,7 @@ export default function App() {
             characterId
           );
           if (!character) return;
+          const definition = pack.instruments[instrumentId];
           const key = `${pack.id}:${instrumentId}:${character.id}`;
           let inst = instrumentRefs.current[key];
           if (!inst) {
@@ -1011,6 +1013,17 @@ export default function App() {
         };
         if (instrumentId === "kick") {
           const kick = inst as unknown as KickDesignerInstrument;
+          if (kick.setStyle) {
+            const styleId = chunk?.style ?? definition?.defaultStyleId ?? null;
+            let style: KickStyleParameters | null = null;
+            if (styleId && definition?.styles) {
+              const matched = definition.styles.find((candidate) => candidate.id === styleId);
+              if (matched && matched.parameters !== undefined) {
+                style = (matched.parameters ?? null) as KickStyleParameters | null;
+              }
+            }
+            kick.setStyle(style);
+          }
           if (kick.setMacroState) {
             const defaults = normalizeKickDesignerState(character.defaults);
             const merged = mergeKickDesignerState(defaults, {

--- a/src/packs.ts
+++ b/src/packs.ts
@@ -1,5 +1,8 @@
 import type { Chunk } from "./chunks";
-import type { KickDesignerState } from "./instruments/kickDesigner";
+import type {
+  KickDesignerState,
+  KickStyleParameters,
+} from "./instruments/kickDesigner";
 
 export interface InstrumentSpec {
   type?: string;
@@ -22,6 +25,8 @@ export interface InstrumentDefinition {
   characters: InstrumentCharacter[];
   defaultPatternId?: string;
   patterns?: InstrumentPatternPreset[];
+  defaultStyleId?: string;
+  styles?: InstrumentStyleDefinition[];
 }
 
 export interface InstrumentPatternPreset {
@@ -34,6 +39,13 @@ export interface InstrumentPatternPreset {
   punch?: number;
   clean?: number;
   tight?: number;
+}
+
+export interface InstrumentStyleDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  parameters?: KickStyleParameters | null;
 }
 
 export interface EffectSpec {


### PR DESCRIPTION
## Summary
- refactor the kick designer to share a gain stage between the MembraneSynth sub and optional NoiseSynth click while honoring style parameters
- reset oscillator phase and schedule both sub and click at the transport time for more consistent triggers
- extend pack metadata and trigger handling so kick styles from sound packs can drive the instrument configuration

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d65a79b48883288137e575b3bc09dc