### PR TITLE
Refactor kick builder to use pack defaults

### DIFF
--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -11,6 +11,7 @@ import * as Tone from "tone";
 
 import type { Pack } from "./packs";
 import { getCharacterOptions } from "./addTrackOptions";
+import { createKick } from "@/instruments/kickDesigner";
 import { formatInstrumentLabel } from "./utils/instrument";
 import {
   deleteInstrumentPreset,
@@ -339,15 +340,26 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
   const previewStyle = useCallback(
     async (characterId: string) => {
       if (!characterId || !selectedInstrumentId || !selectedPackId) return;
-      const trigger =
-        triggers[createTriggerKey(selectedPackId, selectedInstrumentId)];
-      if (!trigger) return;
       try {
         await initAudioContext();
       } catch {
         return;
       }
-      const start = Tone.now() + 0.05;
+
+      const when = Tone.now() + 0.05;
+
+      if (selectedInstrumentId === "kick") {
+        const voice = createKick(selectedPackId, characterId);
+        voice.triggerAttackRelease("C1", "8n", when, 0.9);
+        setTimeout(() => {
+          voice.dispose();
+        }, 600);
+        return;
+      }
+
+      const trigger =
+        triggers[createTriggerKey(selectedPackId, selectedInstrumentId)];
+      if (!trigger) return;
       const previewChunk: Chunk = {
         id: "style-preview",
         name: "Style Preview",
@@ -355,7 +367,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
         characterId: characterId,
         steps: [],
       };
-      trigger(start, 0.9, 0, undefined, 0.5, previewChunk, characterId);
+      trigger(when, 0.9, 0, undefined, 0.5, previewChunk, characterId);
     },
     [selectedInstrumentId, selectedPackId, triggers]
   );

--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -11,7 +11,7 @@ import * as Tone from "tone";
 
 import type { Pack } from "./packs";
 import { getCharacterOptions } from "./addTrackOptions";
-import { createKick } from "@/instruments/kickDesigner";
+import { createKick } from "./instruments/kickDesigner";
 import { formatInstrumentLabel } from "./utils/instrument";
 import {
   deleteInstrumentPreset,

--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -11,7 +11,7 @@ import * as Tone from "tone";
 
 import type { Pack } from "./packs";
 import { getCharacterOptions } from "./addTrackOptions";
-import { createKick } from "./instruments/kickDesigner";
+import { createKick } from "@/instruments/kickDesigner";
 import { formatInstrumentLabel } from "./utils/instrument";
 import {
   deleteInstrumentPreset,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,12 +13,7 @@ import {
   HARMONIA_BASE_VOLUME_DB,
   type HarmoniaNodes,
 } from "./instruments/harmonia";
-import {
-  createKickDesigner,
-  mergeKickDesignerState,
-  normalizeKickDesignerState,
-  type KickDesignerInstrument,
-} from "./instruments/kickDesigner";
+import { createKick } from "./instruments/kickDesigner";
 import { SongView } from "./SongView";
 import { PatternPlaybackManager } from "./PatternPlaybackManager";
 import {
@@ -844,12 +839,12 @@ export default function App() {
     disposeAll();
 
     const createInstrumentInstance = (
+      packId: string,
       instrumentId: string,
       character: InstrumentCharacter
     ) => {
       if (instrumentId === "kick") {
-        const defaults = normalizeKickDesignerState(character.defaults);
-        const instrument = createKickDesigner(defaults);
+        const instrument = createKick(packId, character.id);
         instrument.toDestination();
         return { instrument: instrument as ToneInstrument };
       }
@@ -971,7 +966,7 @@ export default function App() {
           const key = `${pack.id}:${instrumentId}:${character.id}`;
           let inst = instrumentRefs.current[key];
           if (!inst) {
-            const created = createInstrumentInstance(instrumentId, character);
+            const created = createInstrumentInstance(pack.id, instrumentId, character);
             inst = created.instrument;
             instrumentRefs.current[key] = inst;
             if (created.keyboardFx) {
@@ -1009,19 +1004,6 @@ export default function App() {
         const settable = inst as unknown as {
           set?: (values: Record<string, unknown>) => void;
         };
-        if (instrumentId === "kick") {
-          const kick = inst as unknown as KickDesignerInstrument;
-          if (kick.setMacroState) {
-            const defaults = normalizeKickDesignerState(character.defaults);
-            const merged = mergeKickDesignerState(defaults, {
-              punch: chunk?.punch,
-              clean: chunk?.clean,
-              tight: chunk?.tight,
-            });
-            kick.setMacroState(merged);
-          }
-        }
-
         if (chunk?.attack !== undefined || chunk?.sustain !== undefined) {
           const envelope: Record<string, unknown> = {};
           if (chunk.attack !== undefined) envelope.attack = chunk.attack;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,10 @@ import {
   type HarmoniaNodes,
 } from "./instruments/harmonia";
 import { createKick, type KickInstrument } from "@/instruments/kickDesigner";
+import {
+  mergeKickDesignerState,
+  normalizeKickDesignerState,
+} from "./instruments/kickState";
 import { SongView } from "./SongView";
 import { PatternPlaybackManager } from "./PatternPlaybackManager";
 import {
@@ -1131,6 +1135,15 @@ export default function App() {
             sustainArg ?? (chunk?.sustain !== undefined ? chunk.sustain : undefined);
           if (instrumentId === "kick") {
             const kick = inst as KickInstrument;
+            const baseStyle = normalizeKickDesignerState(character.defaults);
+            const style = chunk
+              ? mergeKickDesignerState(baseStyle, {
+                  punch: chunk.punch,
+                  clean: chunk.clean,
+                  tight: chunk.tight,
+                })
+              : baseStyle;
+            kick.setStyle(style);
             const duration = sustainOverride ?? "8n";
             const resolvedVelocity = velocity ?? 0.9;
             kick.triggerAttackRelease("C1", duration, time, resolvedVelocity);

--- a/src/InstrumentControlPanel.tsx
+++ b/src/InstrumentControlPanel.tsx
@@ -36,7 +36,7 @@ import {
   DEFAULT_KICK_STATE,
   mergeKickDesignerState,
   normalizeKickDesignerState,
-} from "./instruments/kickDesigner";
+} from "./instruments/kickState";
 import type {
   HarmoniaComplexity,
   HarmoniaPatternId,

--- a/src/PatternPlaybackManager.tsx
+++ b/src/PatternPlaybackManager.tsx
@@ -24,6 +24,7 @@ interface PatternPlaybackManagerProps {
   patternGroups: PatternGroup[];
   songRows: SongRow[];
   currentSectionIndex: number;
+  onRepairKickSource?: (track: Track) => void;
 }
 
 export function PatternPlaybackManager({
@@ -34,6 +35,7 @@ export function PatternPlaybackManager({
   patternGroups,
   songRows,
   currentSectionIndex,
+  onRepairKickSource,
 }: PatternPlaybackManagerProps) {
   const patternGroupMap = useMemo(
     () => new Map(patternGroups.map((group) => [group.id, group])),
@@ -63,6 +65,13 @@ export function PatternPlaybackManager({
         if (!track.pattern) return;
         const instrument = track.instrument;
         if (!instrument) return;
+        if (
+          instrument === "kick" &&
+          (!track.source?.packId || !track.source.characterId)
+        ) {
+          onRepairKickSource?.(track);
+          return;
+        }
         const trigger = resolveTrigger(instrument, track.source?.packId);
         if (!trigger) return;
         const scaledTrigger = (
@@ -109,6 +118,13 @@ export function PatternPlaybackManager({
         if (!track.pattern) return null;
         const instrument = track.instrument;
         if (!instrument) return null;
+        if (
+          instrument === "kick" &&
+          (!track.source?.packId || !track.source.characterId)
+        ) {
+          onRepairKickSource?.(track);
+          return null;
+        }
         const trigger = resolveTrigger(instrument, track.source?.packId);
         if (!trigger) return null;
         const isTrackActive = () => !track.muted;

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -15,6 +15,10 @@ import {
   type HarmoniaNodes,
 } from "./instruments/harmonia";
 import { createKick, type KickInstrument } from "@/instruments/kickDesigner";
+import {
+  mergeKickDesignerState,
+  normalizeKickDesignerState,
+} from "./instruments/kickState";
 
 interface KeyboardFxNodes {
   reverb: Tone.Reverb;
@@ -318,6 +322,15 @@ const createOfflineTriggerMap = (
 
       if (instrumentId === "kick") {
         const kick = inst as KickInstrument;
+        const baseStyle = normalizeKickDesignerState(character.defaults);
+        const style = chunk
+          ? mergeKickDesignerState(baseStyle, {
+              punch: chunk.punch,
+              clean: chunk.clean,
+              tight: chunk.tight,
+            })
+          : baseStyle;
+        kick.setStyle(style);
         const duration = sustainOverride ?? "8n";
         const resolvedVelocity = velocity ?? 0.9;
         kick.triggerAttackRelease("C1", duration, time, resolvedVelocity);

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -14,12 +14,7 @@ import {
   triggerHarmoniaChord,
   type HarmoniaNodes,
 } from "./instruments/harmonia";
-import {
-  createKickDesigner,
-  mergeKickDesignerState,
-  normalizeKickDesignerState,
-  type KickDesignerInstrument,
-} from "./instruments/kickDesigner";
+import { createKick } from "./instruments/kickDesigner";
 
 interface KeyboardFxNodes {
   reverb: Tone.Reverb;
@@ -155,6 +150,7 @@ type BoundTone = ReturnType<typeof fromContext>;
 
 const createInstrumentInstance = (
   tone: BoundTone,
+  packId: string,
   instrumentId: string,
   character: InstrumentCharacter
 ): {
@@ -163,8 +159,7 @@ const createInstrumentInstance = (
   harmoniaNodes?: HarmoniaNodes;
 } => {
   if (instrumentId === "kick") {
-    const defaults = normalizeKickDesignerState(character.defaults);
-    const instrument = createKickDesigner(defaults);
+    const instrument = createKick(packId, character.id);
     instrument.toDestination();
     return { instrument: instrument as ToneInstrument };
   }
@@ -305,7 +300,7 @@ const createOfflineTriggerMap = (
       const key = `${instrumentId}:${character.id}`;
       let inst = instrumentRefs[key];
       if (!inst) {
-        const created = createInstrumentInstance(tone, instrumentId, character);
+        const created = createInstrumentInstance(tone, pack.id, instrumentId, character);
         inst = created.instrument;
         instrumentRefs[key] = inst;
         if (created.keyboardFx) {
@@ -346,18 +341,6 @@ const createOfflineTriggerMap = (
       const settable = inst as unknown as {
         set?: (values: Record<string, unknown>) => void;
       };
-      if (instrumentId === "kick") {
-        const kick = inst as unknown as KickDesignerInstrument;
-        if (kick.setMacroState) {
-          const defaults = normalizeKickDesignerState(character.defaults);
-          const merged = mergeKickDesignerState(defaults, {
-            punch: chunk?.punch,
-            clean: chunk?.clean,
-            tight: chunk?.tight,
-          });
-          kick.setMacroState(merged);
-        }
-      }
       if (chunk?.attack !== undefined || chunk?.sustain !== undefined) {
         const envelope: Record<string, unknown> = {};
         if (chunk.attack !== undefined) envelope.attack = chunk.attack;

--- a/src/instrumentCharacters.ts
+++ b/src/instrumentCharacters.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_KICK_STATE,
   mergeKickDesignerState,
   normalizeKickDesignerState,
-} from "./instruments/kickDesigner";
+} from "./instruments/kickState";
 import type { InstrumentDefinition } from "./packs";
 
 export const resolveInstrumentCharacterId = (

--- a/src/instruments/kickDesigner.ts
+++ b/src/instruments/kickDesigner.ts
@@ -1,7 +1,11 @@
 import * as Tone from "tone";
 
 import { packs } from "@/soundpacks";
-import { DEFAULT_KICK_STATE } from "./kickState";
+import {
+  DEFAULT_KICK_STATE,
+  normalizeKickDesignerState,
+  type KickDesignerState,
+} from "./kickState";
 
 export interface KickInstrument {
   triggerAttackRelease: (
@@ -10,6 +14,7 @@ export interface KickInstrument {
     time?: Tone.Unit.Time,
     velocity?: number
   ) => void;
+  setStyle: (style: KickDesignerState) => void;
   dispose: () => void;
 }
 
@@ -17,13 +22,13 @@ export function createKick(packId: string, characterId: string): KickInstrument 
   const pack = packs[packId];
   if (!pack) {
     console.warn("[kick] pack not found", { packId, characterId });
-    return createKickFromParams(mapKickParams(DEFAULT_KICK_STATE));
+    return buildKickInstrument(DEFAULT_KICK_STATE);
   }
 
   const instrument = pack.instruments?.kick;
   if (!instrument) {
     console.warn("[kick] kick instrument missing", { packId, characterId });
-    return createKickFromParams(mapKickParams(DEFAULT_KICK_STATE));
+    return buildKickInstrument(DEFAULT_KICK_STATE);
   }
 
   let character = instrument.characters.find((candidate) => candidate.id === characterId);
@@ -36,80 +41,135 @@ export function createKick(packId: string, characterId: string): KickInstrument 
 
   if (!character) {
     console.warn("[kick] could not resolve character", { packId, characterId });
-    return createKickFromParams(mapKickParams(DEFAULT_KICK_STATE));
+    return buildKickInstrument(DEFAULT_KICK_STATE);
   }
 
-  const {
-    punch = DEFAULT_KICK_STATE.punch,
-    clean = DEFAULT_KICK_STATE.clean,
-    tight = DEFAULT_KICK_STATE.tight,
-  } = character.defaults ?? {};
-
-  return createKickFromParams(
-    mapKickParams({
-      punch,
-      clean,
-      tight,
-    })
+  const defaults = normalizeKickDesignerState(
+    character.defaults ?? DEFAULT_KICK_STATE
   );
+
+  return buildKickInstrument(defaults);
 }
 
-function mapKickParams({
-  punch,
-  clean,
-  tight,
-}: {
-  punch: number;
-  clean: number;
-  tight: number;
-}) {
-  const p = Math.max(0, Math.min(1, punch));
-  const c = Math.max(0, Math.min(1, clean));
-  const t = Math.max(0, Math.min(1, tight));
-  return {
-    sub: {
-      pitchDecay: 0.01 + p * 0.02,
-      octaves: 2 + Math.round(p * 2),
-      decay: 0.25 + (1 - c) * 0.25,
-      release: 0.05 + (1 - c) * 0.1,
-      oscillator: { type: "sine" as const },
-    },
-    noiseDb: -30 + (1 - t) * 10,
-  } as const;
+const CLICK_DISABLE_THRESHOLD_DB = -55;
+
+interface KickSynthesisParams {
+  sub: {
+    pitchDecay: number;
+    octaves: number;
+    attack: number;
+    decay: number;
+    release: number;
+    filterFrequency: number;
+    filterQ: number;
+    outputDb: number;
+    oscillator: { type: "sine" };
+  };
+  click: {
+    gainDb: number;
+    decay: number;
+    filterFrequency: number;
+  };
 }
 
-function createKickFromParams(params: ReturnType<typeof mapKickParams>): KickInstrument {
-  const output = new Tone.Gain().toDestination();
+function buildKickInstrument(initialStyle: KickDesignerState): KickInstrument {
+  let currentStyle = normalizeKickDesignerState(initialStyle);
+  let currentParams = mapKickParams(currentStyle);
 
-  const sub = new Tone.MembraneSynth({
-    pitchDecay: params.sub.pitchDecay,
-    octaves: params.sub.octaves,
-    oscillator: params.sub.oscillator ?? { type: "sine" },
-    envelope: {
-      attack: 0.005,
-      decay: params.sub.decay,
-      sustain: 0,
-      release: params.sub.release,
-    },
+  const output = new Tone.Gain({
+    gain: Tone.dbToGain(currentParams.sub.outputDb),
+  }).toDestination();
+
+  const subFilter = new Tone.Filter({
+    type: "lowpass",
+    frequency: currentParams.sub.filterFrequency,
+    Q: currentParams.sub.filterQ,
+    rolloff: -24,
   }).connect(output);
 
-  let noise: Tone.NoiseSynth | null = null;
-  let noiseGain: Tone.Gain | null = null;
+  const sub = new Tone.MembraneSynth({
+    pitchDecay: currentParams.sub.pitchDecay,
+    octaves: currentParams.sub.octaves,
+    oscillator: currentParams.sub.oscillator,
+    envelope: {
+      attack: currentParams.sub.attack,
+      decay: currentParams.sub.decay,
+      sustain: 0,
+      release: currentParams.sub.release,
+    },
+  }).connect(subFilter);
 
-  if (params.noiseDb > -30) {
-    noise = new Tone.NoiseSynth({
+  type ClickNodes = {
+    synth: Tone.NoiseSynth;
+    filter: Tone.Filter;
+    gain: Tone.Gain;
+  };
+
+  let click: ClickNodes | null = null;
+
+  const ensureClick = () => {
+    if (click) return;
+    const noise = new Tone.NoiseSynth({
       envelope: {
         attack: 0.001,
-        decay: 0.02,
+        decay: currentParams.click.decay,
         sustain: 0,
-        release: 0.01,
+        release: 0.02,
       },
     });
+    const filter = new Tone.Filter({
+      type: "highpass",
+      frequency: currentParams.click.filterFrequency,
+      rolloff: -24,
+    });
+    const gain = new Tone.Gain({
+      gain: Tone.dbToGain(currentParams.click.gainDb),
+    });
+    noise.connect(filter);
+    filter.connect(gain);
+    gain.connect(output);
+    click = { synth: noise, filter, gain };
+  };
 
-    noiseGain = new Tone.Gain({ gain: Tone.dbToGain(params.noiseDb) });
-    noise.connect(noiseGain);
-    noiseGain.connect(output);
-  }
+  const disposeClick = () => {
+    if (!click) return;
+    click.synth.dispose();
+    click.filter.dispose();
+    click.gain.dispose();
+    click = null;
+  };
+
+  const applyParams = (params: KickSynthesisParams) => {
+    currentParams = params;
+    output.gain.value = Tone.dbToGain(params.sub.outputDb);
+    sub.octaves = params.sub.octaves;
+    sub.pitchDecay = params.sub.pitchDecay;
+    sub.envelope.attack = params.sub.attack;
+    sub.envelope.decay = params.sub.decay;
+    sub.envelope.release = params.sub.release;
+    subFilter.frequency.value = params.sub.filterFrequency;
+    subFilter.Q.value = params.sub.filterQ;
+
+    if (params.click.gainDb <= CLICK_DISABLE_THRESHOLD_DB) {
+      disposeClick();
+      return;
+    }
+
+    ensureClick();
+    if (!click) return;
+    click.gain.gain.value = Tone.dbToGain(params.click.gainDb);
+    click.filter.frequency.value = params.click.filterFrequency;
+    click.synth.set({
+      envelope: {
+        attack: 0.001,
+        decay: params.click.decay,
+        sustain: 0,
+        release: 0.02,
+      },
+    });
+  };
+
+  applyParams(currentParams);
 
   return {
     triggerAttackRelease(_note, duration, time, velocity) {
@@ -119,15 +179,57 @@ function createKickFromParams(params: ReturnType<typeof mapKickParams>): KickIns
       sub.oscillator.phase = 0;
       sub.triggerAttackRelease("C1", resolvedDuration, time, resolvedVelocity);
 
-      if (noise) {
-        noise.triggerAttackRelease("8n", time, resolvedVelocity);
+      if (click) {
+        click.synth.triggerAttackRelease("8n", time, resolvedVelocity);
       }
+    },
+    setStyle(style) {
+      currentStyle = normalizeKickDesignerState(style);
+      applyParams(mapKickParams(currentStyle));
     },
     dispose() {
       sub.dispose();
-      noise?.dispose();
-      noiseGain?.dispose();
+      subFilter.dispose();
+      disposeClick();
       output.dispose();
+    },
+  };
+}
+
+function mapKickParams({ punch, clean, tight }: KickDesignerState): KickSynthesisParams {
+  const clamp = (value: number) => Math.max(0, Math.min(1, value));
+  const p = clamp(punch);
+  const c = clamp(clean);
+  const t = clamp(tight);
+
+  const pitchDecay = 0.006 + p * 0.07;
+  const octaves = 1.5 + p * 3.5;
+  const attack = 0.001 + (1 - p) * 0.004;
+  const decay = 0.2 + (1 - c) * 0.5;
+  const release = 0.05 + (1 - c) * 0.35;
+  const filterFrequency = 90 + c * 160;
+  const filterQ = 0.7 + (1 - c) * 2.3;
+  const outputDb = -10 + p * 5 + c * 2;
+  const clickGainDb = -46 + (1 - t) * 20 - (1 - c) * 4;
+  const clickDecay = 0.012 + (1 - t) * 0.035;
+  const clickFilterFrequency = 2500 + t * 4500;
+
+  return {
+    sub: {
+      pitchDecay,
+      octaves,
+      attack,
+      decay,
+      release,
+      filterFrequency,
+      filterQ,
+      outputDb,
+      oscillator: { type: "sine" as const },
+    },
+    click: {
+      gainDb: clickGainDb,
+      decay: clickDecay,
+      filterFrequency: clickFilterFrequency,
     },
   };
 }

--- a/src/instruments/kickState.ts
+++ b/src/instruments/kickState.ts
@@ -1,0 +1,52 @@
+import type { Chunk } from "../chunks";
+
+export interface KickDesignerState {
+  punch: number;
+  clean: number;
+  tight: number;
+}
+
+export const DEFAULT_KICK_STATE: KickDesignerState = {
+  punch: 0.5,
+  clean: 0.5,
+  tight: 0.5,
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+export const normalizeKickDesignerState = (
+  state?: Partial<KickDesignerState> | null
+): KickDesignerState => ({
+  punch: clamp(state?.punch ?? DEFAULT_KICK_STATE.punch, 0, 1),
+  clean: clamp(state?.clean ?? DEFAULT_KICK_STATE.clean, 0, 1),
+  tight: clamp(state?.tight ?? DEFAULT_KICK_STATE.tight, 0, 1),
+});
+
+export const mergeKickDesignerState = (
+  defaults: Partial<KickDesignerState> | null | undefined,
+  overrides: Partial<KickDesignerState> | null | undefined
+): KickDesignerState =>
+  normalizeKickDesignerState({
+    punch: overrides?.punch ?? defaults?.punch,
+    clean: overrides?.clean ?? defaults?.clean,
+    tight: overrides?.tight ?? defaults?.tight,
+  });
+
+export const applyKickDefaultsToChunk = (
+  chunk: Chunk,
+  defaults: Partial<KickDesignerState> | null | undefined
+): Chunk => {
+  const state = mergeKickDesignerState(defaults, {
+    punch: chunk.punch,
+    clean: chunk.clean,
+    tight: chunk.tight,
+  });
+  return {
+    ...chunk,
+    punch: state.punch,
+    clean: state.clean,
+    tight: state.tight,
+  };
+};
+

--- a/src/packs.ts
+++ b/src/packs.ts
@@ -1,5 +1,5 @@
 import type { Chunk } from "./chunks";
-import type { KickDesignerState } from "./instruments/kickDesigner";
+import type { KickDesignerState } from "./instruments/kickState";
 
 export interface InstrumentSpec {
   type?: string;

--- a/src/soundpacks.ts
+++ b/src/soundpacks.ts
@@ -1,0 +1,12 @@
+import type { Pack } from "./packs";
+import { packs as packList } from "./packs";
+
+export const packs: Record<string, Pack> = packList.reduce<Record<string, Pack>>(
+  (acc, pack) => {
+    acc[pack.id] = pack;
+    return acc;
+  },
+  {}
+);
+
+export type { Pack };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,6 +14,10 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "jsx": "react-jsx",
 
     /* Linting */

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -12,6 +12,10 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,11 @@ const rootDir = fileURLToPath(new URL('.', import.meta.url))
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(rootDir, 'src'),
+    },
+  },
   define: {
     __BUILD_TIME__: JSON.stringify(buildTimestamp),
   },


### PR DESCRIPTION
## Summary
- replace the legacy kick designer with a pack-aware `createKick` builder that maps character defaults to safe drum parameters
- extract kick macro state helpers into a dedicated `kickState` module and update consumers to import from it
- wire the app and exporter to instantiate kicks through the new pack+character API

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6f43efbe483289957cf3a8ba0e073