### PR TITLE
Use pack defaults when creating kick instruments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,8 @@ import {
 import {
   createKick,
   mergeKickDesignerState,
-  normalizeKickDesignerState,
+  resolveKickCharacterDefaults,
+  DEFAULT_KICK_STATE,
   type KickDesignerInstrument,
 } from "./instruments/kickDesigner";
 import { SongView } from "./SongView";
@@ -1012,7 +1013,8 @@ export default function App() {
         if (instrumentId === "kick") {
           const kick = inst as unknown as KickDesignerInstrument;
           if (kick.setMacroState) {
-            const defaults = normalizeKickDesignerState(character.defaults);
+            const defaults =
+              resolveKickCharacterDefaults(pack.id, character.id) ?? DEFAULT_KICK_STATE;
             const merged = mergeKickDesignerState(defaults, {
               punch: chunk?.punch,
               clean: chunk?.clean,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import {
   type HarmoniaNodes,
 } from "./instruments/harmonia";
 import {
-  createKickDesigner,
+  createKick,
   mergeKickDesignerState,
   normalizeKickDesignerState,
   type KickDesignerInstrument,
@@ -844,12 +844,12 @@ export default function App() {
     disposeAll();
 
     const createInstrumentInstance = (
+      packId: string,
       instrumentId: string,
       character: InstrumentCharacter
     ) => {
       if (instrumentId === "kick") {
-        const defaults = normalizeKickDesignerState(character.defaults);
-        const instrument = createKickDesigner(defaults);
+        const instrument = createKick(packId, character.id);
         instrument.toDestination();
         return { instrument: instrument as ToneInstrument };
       }
@@ -971,7 +971,7 @@ export default function App() {
           const key = `${pack.id}:${instrumentId}:${character.id}`;
           let inst = instrumentRefs.current[key];
           if (!inst) {
-            const created = createInstrumentInstance(instrumentId, character);
+            const created = createInstrumentInstance(pack.id, instrumentId, character);
             inst = created.instrument;
             instrumentRefs.current[key] = inst;
             if (created.keyboardFx) {

--- a/src/PatternPlaybackManager.tsx
+++ b/src/PatternPlaybackManager.tsx
@@ -77,6 +77,8 @@ export function PatternPlaybackManager({
             0,
             Math.min(1, velocity * velocityFactor)
           );
+          const resolvedCharacterId =
+            chunk?.characterId ?? track.source?.characterId;
           trigger(
             time,
             combinedVelocity,
@@ -84,7 +86,7 @@ export function PatternPlaybackManager({
             note,
             sustain,
             chunk,
-            track.source?.characterId
+            resolvedCharacterId
           );
         };
         const isTrackActive = () => !row.muted && !track.muted;
@@ -124,7 +126,7 @@ export function PatternPlaybackManager({
                 note,
                 sustain,
                 chunk,
-                track.source?.characterId
+                chunk?.characterId ?? track.source?.characterId
               )
             }
             started={started}

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -17,7 +17,8 @@ import {
 import {
   createKick,
   mergeKickDesignerState,
-  normalizeKickDesignerState,
+  resolveKickCharacterDefaults,
+  DEFAULT_KICK_STATE,
   type KickDesignerInstrument,
 } from "./instruments/kickDesigner";
 
@@ -349,7 +350,8 @@ const createOfflineTriggerMap = (
       if (instrumentId === "kick") {
         const kick = inst as unknown as KickDesignerInstrument;
         if (kick.setMacroState) {
-          const defaults = normalizeKickDesignerState(character.defaults);
+          const defaults =
+            resolveKickCharacterDefaults(pack.id, character.id) ?? DEFAULT_KICK_STATE;
           const merged = mergeKickDesignerState(defaults, {
             punch: chunk?.punch,
             clean: chunk?.clean,

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -15,7 +15,7 @@ import {
   type HarmoniaNodes,
 } from "./instruments/harmonia";
 import {
-  createKickDesigner,
+  createKick,
   mergeKickDesignerState,
   normalizeKickDesignerState,
   type KickDesignerInstrument,
@@ -155,6 +155,7 @@ type BoundTone = ReturnType<typeof fromContext>;
 
 const createInstrumentInstance = (
   tone: BoundTone,
+  packId: string,
   instrumentId: string,
   character: InstrumentCharacter
 ): {
@@ -163,8 +164,7 @@ const createInstrumentInstance = (
   harmoniaNodes?: HarmoniaNodes;
 } => {
   if (instrumentId === "kick") {
-    const defaults = normalizeKickDesignerState(character.defaults);
-    const instrument = createKickDesigner(defaults);
+    const instrument = createKick(packId, character.id);
     instrument.toDestination();
     return { instrument: instrument as ToneInstrument };
   }
@@ -305,7 +305,7 @@ const createOfflineTriggerMap = (
       const key = `${instrumentId}:${character.id}`;
       let inst = instrumentRefs[key];
       if (!inst) {
-        const created = createInstrumentInstance(tone, instrumentId, character);
+        const created = createInstrumentInstance(tone, pack.id, instrumentId, character);
         inst = created.instrument;
         instrumentRefs[key] = inst;
         if (created.keyboardFx) {

--- a/src/instruments/kickDesigner.ts
+++ b/src/instruments/kickDesigner.ts
@@ -1,6 +1,7 @@
 import * as Tone from "tone";
 
 import type { Chunk } from "../chunks";
+import { packs } from "../packs";
 
 export interface KickDesignerState {
   punch: number;
@@ -256,4 +257,23 @@ export const createKickDesigner = (
 
   return output;
 };
+
+export function createKick(packId: string, characterId: string) {
+  const pack = packs.find((candidate) => candidate.id === packId);
+  if (!pack) {
+    return createKickDesigner();
+  }
+
+  const kickInstrument = pack.instruments.kick;
+  if (!kickInstrument) {
+    return createKickDesigner();
+  }
+
+  const character = kickInstrument.characters?.find((c) => c.id === characterId);
+  if (!character || !character.defaults) {
+    return createKickDesigner();
+  }
+
+  return createKickDesigner(character.defaults);
+}
 


### PR DESCRIPTION
## Summary
- add a createKick helper that looks up kick character defaults in pack data
- update the app runtime and exporter to build kick instruments with pack-aware defaults

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d71d399b348328b694963c8c633288