### PR TITLE
Refine kick instrument handling for soundpack characters

### DIFF
--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -26,6 +26,7 @@ import { Modal } from "./components/Modal";
 import { IconButton } from "./components/IconButton";
 import { createTriggerKey, type TriggerMap } from "./tracks";
 import { initAudioContext } from "./utils/audio";
+import { createKick } from "./instruments/kickDesigner";
 
 type SelectField = "pack" | "instrument" | "style" | "preset";
 
@@ -339,15 +340,27 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
   const previewStyle = useCallback(
     async (characterId: string) => {
       if (!characterId || !selectedInstrumentId || !selectedPackId) return;
-      const trigger =
-        triggers[createTriggerKey(selectedPackId, selectedInstrumentId)];
-      if (!trigger) return;
       try {
         await initAudioContext();
       } catch {
         return;
       }
       const start = Tone.now() + 0.05;
+
+      if (selectedInstrumentId === "kick") {
+        const kick = createKick(selectedPackId, characterId);
+        kick.triggerAttackRelease("C2", "8n", start, 0.9);
+        const releaseDelaySeconds = Math.max(0, start - Tone.now() + 1.5);
+        setTimeout(() => {
+          kick.dispose();
+        }, releaseDelaySeconds * 1000);
+        return;
+      }
+
+      const trigger =
+        triggers[createTriggerKey(selectedPackId, selectedInstrumentId)];
+      if (!trigger) return;
+
       const previewChunk: Chunk = {
         id: "style-preview",
         name: "Style Preview",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import {
   type HarmoniaNodes,
 } from "./instruments/harmonia";
 import {
-  createKickDesigner,
+  createKick,
   mergeKickDesignerState,
   normalizeKickDesignerState,
   type KickDesignerInstrument,
@@ -844,13 +844,12 @@ export default function App() {
     disposeAll();
 
     const createInstrumentInstance = (
+      packId: string,
       instrumentId: string,
       character: InstrumentCharacter
     ) => {
       if (instrumentId === "kick") {
-        const defaults = normalizeKickDesignerState(character.defaults);
-        const instrument = createKickDesigner(defaults);
-        instrument.toDestination();
+        const instrument = createKick(packId, character.id);
         return { instrument: instrument as ToneInstrument };
       }
 
@@ -971,7 +970,7 @@ export default function App() {
           const key = `${pack.id}:${instrumentId}:${character.id}`;
           let inst = instrumentRefs.current[key];
           if (!inst) {
-            const created = createInstrumentInstance(instrumentId, character);
+            const created = createInstrumentInstance(pack.id, instrumentId, character);
             inst = created.instrument;
             instrumentRefs.current[key] = inst;
             if (created.keyboardFx) {

--- a/src/instruments/kickDesigner.ts
+++ b/src/instruments/kickDesigner.ts
@@ -1,5 +1,7 @@
 import * as Tone from "tone";
 
+import { packs } from "@/soundpacks";
+
 import type { Chunk } from "../chunks";
 
 export interface KickDesignerState {
@@ -255,5 +257,25 @@ export const createKickDesigner = (
   };
 
   return output;
+};
+
+export const createKick = (
+  packId: string,
+  characterId: string
+): KickDesignerInstrument => {
+  const pack = packs[packId];
+  const instrument = pack?.instruments?.kick;
+  let character = instrument?.characters.find((candidate) => candidate.id === characterId);
+  if (!character && instrument?.defaultCharacterId) {
+    character = instrument.characters.find(
+      (candidate) => candidate.id === instrument.defaultCharacterId
+    );
+  }
+  if (!character && instrument?.characters.length) {
+    character = instrument.characters[0];
+  }
+  const kick = createKickDesigner(character?.defaults);
+  kick.toDestination();
+  return kick;
 };
 

--- a/src/soundpacks/index.ts
+++ b/src/soundpacks/index.ts
@@ -1,0 +1,16 @@
+import type { Pack } from "../packs";
+import { packs as packList } from "../packs";
+
+export type SoundpackRegistry = Record<string, Pack>;
+
+export const packs: SoundpackRegistry = packList.reduce<SoundpackRegistry>(
+  (registry, pack) => {
+    registry[pack.id] = pack;
+    return registry;
+  },
+  {}
+);
+
+export const packArray = packList;
+
+export type { Pack };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,6 +10,10 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
   define: {
     __BUILD_TIME__: JSON.stringify(buildTimestamp),
   },
+  resolve: {
+    alias: {
+      '@': resolve(rootDir, 'src'),
+    },
+  },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- add a soundpack registry and alias support so kick creation can look up pack data by id
- build a createKick helper that applies character defaults and reuse it for playback and previews
- tidy preview cleanup to dispose kick previews after triggering and avoid duplicate synth instantiation

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7225b11548328b4bb2213ba1bb1f1