### PR TITLE
Replace kick macro defaults with synth parameters

### DIFF
--- a/src/packs/chiptune.json
+++ b/src/packs/chiptune.json
@@ -10,12 +10,24 @@
         {
           "id": "chip_square_thump",
           "name": "Square Thump",
-          "defaults": { "punch": 0.6, "clean": 0.8, "tight": 0.5 }
+          "defaults": {
+            "pitchDecay": 0.026,
+            "octaves": 2.4,
+            "decay": 0.28,
+            "release": 0.09,
+            "noiseDb": -16
+          }
         },
         {
           "id": "chip_noise_pop",
           "name": "Noise Pop",
-          "defaults": { "punch": 0.7, "clean": 0.9, "tight": 0.4 }
+          "defaults": {
+            "pitchDecay": 0.022,
+            "octaves": 2,
+            "decay": 0.22,
+            "release": 0.07,
+            "noiseDb": -12
+          }
         }
       ],
       "patterns": [

--- a/src/packs/early-2000s-edm.json
+++ b/src/packs/early-2000s-edm.json
@@ -10,12 +10,24 @@
         {
           "id": "edm_club_punch",
           "name": "Club Punch",
-          "defaults": { "punch": 0.7, "clean": 0.9, "tight": 0.4 }
+          "defaults": {
+            "pitchDecay": 0.038,
+            "octaves": 3.8,
+            "decay": 0.65,
+            "release": 0.18,
+            "noiseDb": -24
+          }
         },
         {
           "id": "edm_trance_boom",
           "name": "Trance Boom",
-          "defaults": { "punch": 0.5, "clean": 0.7, "tight": 0.5 }
+          "defaults": {
+            "pitchDecay": 0.048,
+            "octaves": 4.2,
+            "decay": 0.78,
+            "release": 0.24,
+            "noiseDb": -28
+          }
         }
       ],
       "patterns": [

--- a/src/packs/kraftwerk.json
+++ b/src/packs/kraftwerk.json
@@ -10,12 +10,24 @@
         {
           "id": "kraftwerk_motor_drive",
           "name": "Motor Drive",
-          "defaults": { "punch": 0.5, "clean": 0.8, "tight": 0.55 }
+          "defaults": {
+            "pitchDecay": 0.034,
+            "octaves": 3.2,
+            "decay": 0.58,
+            "release": 0.17,
+            "noiseDb": -30
+          }
         },
         {
           "id": "kraftwerk_robotic_snap",
           "name": "Robotic Snap",
-          "defaults": { "punch": 0.35, "clean": 0.6, "tight": 0.45 }
+          "defaults": {
+            "pitchDecay": 0.03,
+            "octaves": 2.8,
+            "decay": 0.4,
+            "release": 0.12,
+            "noiseDb": -26
+          }
         }
       ],
       "patterns": [

--- a/src/packs/phonk.json
+++ b/src/packs/phonk.json
@@ -10,12 +10,24 @@
         {
           "id": "phonk_memphis_distorted",
           "name": "Memphis Distorted",
-          "defaults": { "punch": 0.5, "clean": 0.1, "tight": 0.6 }
+          "defaults": {
+            "pitchDecay": 0.05,
+            "octaves": 4,
+            "decay": 0.82,
+            "release": 0.26,
+            "noiseDb": -26
+          }
         },
         {
           "id": "phonk_tape_slam",
           "name": "Tape Slam",
-          "defaults": { "punch": 0.4, "clean": 0.3, "tight": 0.7 }
+          "defaults": {
+            "pitchDecay": 0.042,
+            "octaves": 3.5,
+            "decay": 0.68,
+            "release": 0.21,
+            "noiseDb": -22
+          }
         }
       ],
       "patterns": [

--- a/src/packs/trap.json
+++ b/src/packs/trap.json
@@ -10,12 +10,24 @@
         {
           "id": "trap_808_boom",
           "name": "808 Boom",
-          "defaults": { "punch": 0.2, "clean": 0.6, "tight": 0.7 }
+          "defaults": {
+            "pitchDecay": 0.055,
+            "octaves": 5.2,
+            "decay": 0.9,
+            "release": 0.28,
+            "noiseDb": -38
+          }
         },
         {
           "id": "trap_hard_clip",
           "name": "Hard Clip",
-          "defaults": { "punch": 0.4, "clean": 0.2, "tight": 0.6 }
+          "defaults": {
+            "pitchDecay": 0.045,
+            "octaves": 4.6,
+            "decay": 0.72,
+            "release": 0.22,
+            "noiseDb": -32
+          }
         }
       ],
       "patterns": [

--- a/src/packs/triphop.json
+++ b/src/packs/triphop.json
@@ -10,12 +10,24 @@
         {
           "id": "triphop_lofi_thump",
           "name": "Lo-Fi Thump",
-          "defaults": { "punch": 0.3, "clean": 0.3, "tight": 0.8 }
+          "defaults": {
+            "pitchDecay": 0.04,
+            "octaves": 3.1,
+            "decay": 0.74,
+            "release": 0.23,
+            "noiseDb": -24
+          }
         },
         {
           "id": "triphop_vinyl_kick",
           "name": "Vinyl Kick",
-          "defaults": { "punch": 0.4, "clean": 0.2, "tight": 0.7 }
+          "defaults": {
+            "pitchDecay": 0.035,
+            "octaves": 2.9,
+            "decay": 0.6,
+            "release": 0.2,
+            "noiseDb": -20
+          }
         }
       ],
       "patterns": [


### PR DESCRIPTION
## Summary
- replace kick macro defaults across all packs with explicit Tone.js drum synth parameters
- tune each character's decay, octave sweep, release, and noise levels to fit their pack vibe

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77db96ccc832894d86de39586f860