### PR TITLE
Refactor Add Track modal to use horizontal option lists

### DIFF
--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -135,23 +135,31 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     [userPresets]
   );
 
-  const presetSelectionItems = useMemo(
+  type PresetSource = "none" | "user" | "pack";
+  type PresetSelectionItem = {
+    id: string | null;
+    name: string;
+    source: PresetSource;
+    characterId: string | null;
+    pattern?: Chunk;
+  };
+
+  const presetSelectionItems = useMemo<PresetSelectionItem[]>(
     () =>
       [
         {
-          id: null as const,
+          id: null,
           name: "None",
-          source: "none" as const,
+          source: "none",
           characterId: null,
-          pattern: undefined,
         },
         ...userPresetItems.map((preset) => ({
           ...preset,
-          source: "user" as const,
+          source: "user" as PresetSource,
         })),
         ...packPresets.map((preset) => ({
           ...preset,
-          source: "pack" as const,
+          source: "pack" as PresetSource,
         })),
       ],
     [packPresets, userPresetItems]

--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -30,6 +30,7 @@ import {
   FALLBACK_INSTRUMENT_COLOR,
   getInstrumentColor,
   hexToRgba,
+  lightenColor,
 } from "./utils/color";
 
 type SelectField = "pack" | "instrument" | "style" | "preset";
@@ -813,14 +814,22 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
       minHeight?: number;
     }
   ): CSSProperties => {
+    const safeAccentColor = accentColor || FALLBACK_INSTRUMENT_COLOR;
+    const activeBackground = `radial-gradient(circle, ${hexToRgba(
+      lightenColor(safeAccentColor, 0.18),
+      0.85
+    )}, ${hexToRgba(safeAccentColor, 0.85)})`;
+    const activeBorderColor = hexToRgba(safeAccentColor, 0.65);
+    const activeGlowColor = hexToRgba(safeAccentColor, 0.55);
+
     return {
       minWidth,
       minHeight,
       padding: "12px 16px 14px",
       borderRadius: 12,
-      border: "1px solid #273144",
+      border: isActive ? `1px solid ${activeBorderColor}` : "1px solid #273144",
       background: isActive
-        ? "#27E0B0"
+        ? activeBackground
         : "radial-gradient(circle at center, #1e293b 0%, #101726 72%)",
       color: isActive ? "#0e151f" : "#e2e8f0",
       display: "flex",
@@ -831,7 +840,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
       textAlign: "left",
       flex: "0 0 auto",
       boxShadow: isActive
-        ? `0 0 12px rgba(39, 224, 176, 0.4), 0 6px 14px rgba(2, 12, 23, 0.45)`
+        ? `0 0 12px ${activeGlowColor}, 0 6px 14px rgba(2, 12, 23, 0.45)`
         : "none",
       transform: isActive ? "translateY(2px)" : "translateY(0)",
       transition:

--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -26,6 +26,12 @@ import { Modal } from "./components/Modal";
 import { IconButton } from "./components/IconButton";
 import { createTriggerKey, type TriggerMap } from "./tracks";
 import { initAudioContext } from "./utils/audio";
+import {
+  FALLBACK_INSTRUMENT_COLOR,
+  getInstrumentColor,
+  hexToRgba,
+  lightenColor,
+} from "./utils/color";
 
 type SelectField = "pack" | "instrument" | "style" | "preset";
 
@@ -785,69 +791,111 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
 
   const horizontalScrollAreaStyle: CSSProperties = {
     display: "flex",
-    gap: 12,
+    gap: 16,
     overflowX: "auto",
-    padding: "4px 0 8px",
+    padding: "6px 2px 12px",
     WebkitOverflowScrolling: "touch",
     scrollbarWidth: "none",
+    msOverflowStyle: "none",
+    scrollSnapType: "x proximity",
   };
 
-  const optionButtonBaseStyle: CSSProperties = {
-    minWidth: 120,
-    padding: "12px 16px",
-    borderRadius: 14,
-    border: "1px solid #1d2636",
-    background: "#10192c",
-    color: "#e6f2ff",
+  const createPadButtonStyle = (
+    accentColor: string,
+    {
+      isActive,
+      isDisabled,
+      minWidth = 132,
+      minHeight = 92,
+    }: {
+      isActive: boolean;
+      isDisabled?: boolean;
+      minWidth?: number;
+      minHeight?: number;
+    }
+  ): CSSProperties => {
+    const safeColor = accentColor || FALLBACK_INSTRUMENT_COLOR;
+    const activeBorder = hexToRgba(lightenColor(safeColor, 0.1), 0.9);
+    const restingBorder = "rgba(17, 26, 44, 0.9)";
+    return {
+      minWidth,
+      minHeight,
+      padding: "16px 18px",
+      borderRadius: 18,
+      border: `1px solid ${isActive ? activeBorder : restingBorder}`,
+      background: isActive
+        ? `radial-gradient(circle at 30% 20%, ${hexToRgba(
+            lightenColor(safeColor, 0.45),
+            0.95
+          )} 0%, ${hexToRgba(lightenColor(safeColor, 0.15), 0.9)} 42%, rgba(12, 19, 32, 0.92) 100%)`
+        : "linear-gradient(145deg, #111a2e, #0a111f)",
+      color: isActive ? "#04121c" : "#e2e8f0",
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "flex-start",
+      gap: 6,
+      position: "relative",
+      textAlign: "left",
+      flex: "0 0 auto",
+      boxShadow: isActive
+        ? `0 0 12px ${hexToRgba(safeColor, 0.55)}, 0 0 28px ${hexToRgba(
+            lightenColor(safeColor, 0.35),
+            0.5
+          )}, inset 0 0 18px ${hexToRgba(lightenColor(safeColor, 0.25), 0.45)}, inset 0 2px 6px rgba(255, 255, 255, 0.15)`
+        : "inset 0 6px 12px rgba(6, 10, 20, 0.78), inset 0 -6px 10px rgba(0, 0, 0, 0.7), 0 4px 10px rgba(2, 5, 12, 0.65)",
+      transform: isActive ? "translateY(3px)" : "translateY(0)",
+      transition:
+        "transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease, color 0.2s ease, opacity 0.2s ease",
+      cursor: isDisabled ? "not-allowed" : "pointer",
+      opacity: isDisabled ? 0.55 : 1,
+      filter: isDisabled ? "saturate(0.6)" : "none",
+      scrollSnapAlign: "start",
+      touchAction: "manipulation",
+    };
+  };
+
+  const createPadTitleStyle = (isActive: boolean): CSSProperties => ({
     fontSize: 15,
-    fontWeight: 500,
-    flex: "0 0 auto",
-    textAlign: "left",
-    display: "flex",
-    flexDirection: "column",
-    gap: 6,
-    transition:
-      "border-color 0.2s ease, background 0.2s ease, color 0.2s ease, opacity 0.2s ease",
-  };
+    fontWeight: 700,
+    letterSpacing: 0.2,
+    color: isActive ? "#04121c" : "#e2e8f0",
+    textShadow: isActive
+      ? `0 0 12px ${hexToRgba("#ffffff", 0.55)}`
+      : "0 1px 0 rgba(4, 7, 14, 0.65)",
+    transition: "color 0.2s ease, text-shadow 0.2s ease",
+  });
 
-  const optionButtonActiveStyle: CSSProperties = {
-    borderColor: "#27E0B0",
-    background: "rgba(39, 224, 176, 0.12)",
-  };
-
-  const optionButtonDisabledStyle: CSSProperties = {
-    opacity: 0.5,
-    cursor: "not-allowed",
-  };
-
-  const optionNameStyle: CSSProperties = {
-    fontSize: 15,
-    fontWeight: 600,
-    color: "inherit",
-  };
-
-  const optionBadgeStyle: CSSProperties = {
+  const createPadBadgeStyle = (
+    accentColor: string,
+    isActive: boolean,
+    variant: "user" | "pack"
+  ): CSSProperties => ({
     display: "inline-flex",
     alignItems: "center",
     alignSelf: "flex-start",
     borderRadius: 999,
-    border: "1px solid #273247",
-    background: "rgba(148, 163, 184, 0.14)",
-    color: "#94a3b8",
+    padding: "2px 10px",
     fontSize: 11,
-    fontWeight: 600,
+    fontWeight: 700,
     letterSpacing: 0.5,
-    padding: "2px 8px",
     textTransform: "uppercase",
-  };
+    border: `1px solid ${
+      isActive ? hexToRgba(lightenColor(accentColor, 0.05), 0.7) : "rgba(148, 163, 184, 0.32)"
+    }`,
+    background: isActive
+      ? hexToRgba(
+          lightenColor(accentColor, variant === "user" ? 0.35 : 0.2),
+          variant === "user" ? 0.4 : 0.3
+        )
+      : "rgba(148, 163, 184, 0.08)",
+    color: isActive ? "#04121c" : "#94a3b8",
+    transition: "border-color 0.2s ease, background 0.2s ease, color 0.2s ease",
+  });
 
   const emptyStateTextStyle: CSSProperties = {
     fontSize: 13,
     color: "#94a3b8",
   };
-
-  const optionNameDefaultColor = "#e2e8f0";
-  const optionNameActiveColor = "#27E0B0";
 
   const packSelectDisabled = handoffLock !== null && handoffLock !== "pack";
 
@@ -898,6 +946,8 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     : userPresetItems.length === 0 && packPresets.length === 0
     ? "No saved loops available yet."
     : null;
+
+  const selectedInstrumentAccent = getInstrumentColor(selectedInstrumentId);
 
   return (
     <Modal
@@ -956,6 +1006,10 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             <div style={horizontalScrollAreaStyle}>
               {packs.map((option) => {
                 const isActive = option.id === selectedPackId;
+                const buttonStyle = createPadButtonStyle(selectedInstrumentAccent, {
+                  isActive,
+                  isDisabled: packSelectDisabled,
+                });
                 return (
                   <button
                     key={option.id}
@@ -963,20 +1017,9 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     disabled={packSelectDisabled}
                     aria-pressed={isActive}
                     onClick={() => handlePackSelect(option.id)}
-                    style={{
-                      ...optionButtonBaseStyle,
-                      ...(isActive ? optionButtonActiveStyle : {}),
-                      ...(packSelectDisabled ? optionButtonDisabledStyle : {}),
-                    }}
+                    style={buttonStyle}
                   >
-                    <span
-                      style={{
-                        ...optionNameStyle,
-                        color: isActive
-                          ? optionNameActiveColor
-                          : optionNameDefaultColor,
-                      }}
-                    >
+                    <span style={createPadTitleStyle(isActive)}>
                       {option.name}
                     </span>
                   </button>
@@ -1003,6 +1046,11 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             <div style={horizontalScrollAreaStyle}>
               {instrumentOptions.map((instrument) => {
                 const isActive = instrument === selectedInstrumentId;
+                const accentColor = getInstrumentColor(instrument);
+                const buttonStyle = createPadButtonStyle(accentColor, {
+                  isActive,
+                  isDisabled: instrumentSelectDisabled,
+                });
                 return (
                   <button
                     key={instrument}
@@ -1010,22 +1058,9 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     disabled={instrumentSelectDisabled}
                     aria-pressed={isActive}
                     onClick={() => handleInstrumentSelect(instrument)}
-                    style={{
-                      ...optionButtonBaseStyle,
-                      ...(isActive ? optionButtonActiveStyle : {}),
-                      ...(instrumentSelectDisabled
-                        ? optionButtonDisabledStyle
-                        : {}),
-                    }}
+                    style={buttonStyle}
                   >
-                    <span
-                      style={{
-                        ...optionNameStyle,
-                        color: isActive
-                          ? optionNameActiveColor
-                          : optionNameDefaultColor,
-                      }}
-                    >
+                    <span style={createPadTitleStyle(isActive)}>
                       {formatInstrumentLabel(instrument)}
                     </span>
                   </button>
@@ -1060,6 +1095,10 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             <div style={horizontalScrollAreaStyle}>
               {characterOptions.map((character) => {
                 const isActive = character.id === selectedCharacterId;
+                const buttonStyle = createPadButtonStyle(selectedInstrumentAccent, {
+                  isActive,
+                  isDisabled: styleSelectDisabled,
+                });
                 return (
                   <button
                     key={character.id}
@@ -1067,20 +1106,9 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     disabled={styleSelectDisabled}
                     aria-pressed={isActive}
                     onClick={() => handleStyleSelect(character.id)}
-                    style={{
-                      ...optionButtonBaseStyle,
-                      ...(isActive ? optionButtonActiveStyle : {}),
-                      ...(styleSelectDisabled ? optionButtonDisabledStyle : {}),
-                    }}
+                    style={buttonStyle}
                   >
-                    <span
-                      style={{
-                        ...optionNameStyle,
-                        color: isActive
-                          ? optionNameActiveColor
-                          : optionNameDefaultColor,
-                      }}
-                    >
+                    <span style={createPadTitleStyle(isActive)}>
                       {character.name}
                     </span>
                   </button>
@@ -1120,15 +1148,15 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                   ? selectedPresetId === null
                   : preset.id === selectedPresetId;
                 const presetKey = preset.id ?? "preset-none";
+                const accentColor = selectedInstrumentAccent;
+                const buttonStyle = createPadButtonStyle(accentColor, {
+                  isActive,
+                  isDisabled: presetSelectDisabled,
+                  minWidth: 148,
+                });
                 const badgeStyle =
-                  preset.source === "user"
-                    ? {
-                        ...optionBadgeStyle,
-                        borderColor: optionNameActiveColor,
-                        color: optionNameActiveColor,
-                      }
-                    : preset.source === "pack"
-                    ? optionBadgeStyle
+                  preset.source === "user" || preset.source === "pack"
+                    ? createPadBadgeStyle(accentColor, isActive, preset.source)
                     : null;
                 return (
                   <button
@@ -1137,20 +1165,9 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     disabled={presetSelectDisabled}
                     aria-pressed={isActive}
                     onClick={() => handlePresetSelect(preset.id)}
-                    style={{
-                      ...optionButtonBaseStyle,
-                      ...(isActive ? optionButtonActiveStyle : {}),
-                      ...(presetSelectDisabled ? optionButtonDisabledStyle : {}),
-                    }}
+                    style={buttonStyle}
                   >
-                    <span
-                      style={{
-                        ...optionNameStyle,
-                        color: isActive
-                          ? optionNameActiveColor
-                          : optionNameDefaultColor,
-                      }}
-                    >
+                    <span style={createPadTitleStyle(isActive)}>
                       {preset.name}
                     </span>
                     {badgeStyle ? (

--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -854,20 +854,6 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     };
   };
 
-  const createPadAccentStyle = (
-    accentColor: string,
-    isActive: boolean
-  ): CSSProperties => ({
-    display: "inline-block",
-    alignSelf: "stretch",
-    height: 4,
-    borderRadius: 999,
-    background: hexToRgba(accentColor || FALLBACK_INSTRUMENT_COLOR, isActive ? 0.95 : 0.55),
-    boxShadow: isActive
-      ? `0 0 10px ${hexToRgba(accentColor || FALLBACK_INSTRUMENT_COLOR, 0.55)}`
-      : "none",
-  });
-
   const createPadTitleStyle = (isActive: boolean): CSSProperties => ({
     fontSize: 14,
     fontWeight: 700,
@@ -1011,7 +997,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             <div style={horizontalScrollAreaStyle}>
               {packs.map((option) => {
                 const isActive = option.id === selectedPackId;
-                const accentColor = selectedInstrumentAccent;
+                const accentColor = FALLBACK_INSTRUMENT_COLOR;
                 const buttonStyle = createPadButtonStyle(accentColor, {
                   isActive,
                   isDisabled: packSelectDisabled,
@@ -1025,10 +1011,6 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     onClick={() => handlePackSelect(option.id)}
                     style={buttonStyle}
                   >
-                    <span
-                      aria-hidden="true"
-                      style={createPadAccentStyle(accentColor, isActive)}
-                    />
                     <span style={createPadTitleStyle(isActive)}>
                       {option.name}
                     </span>
@@ -1070,10 +1052,6 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     onClick={() => handleInstrumentSelect(instrument)}
                     style={buttonStyle}
                   >
-                    <span
-                      aria-hidden="true"
-                      style={createPadAccentStyle(accentColor, isActive)}
-                    />
                     <span style={createPadTitleStyle(isActive)}>
                       {formatInstrumentLabel(instrument)}
                     </span>
@@ -1123,10 +1101,6 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     onClick={() => handleStyleSelect(character.id)}
                     style={buttonStyle}
                   >
-                    <span
-                      aria-hidden="true"
-                      style={createPadAccentStyle(accentColor, isActive)}
-                    />
                     <span style={createPadTitleStyle(isActive)}>
                       {character.name}
                     </span>
@@ -1186,10 +1160,6 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     onClick={() => handlePresetSelect(preset.id)}
                     style={buttonStyle}
                   >
-                    <span
-                      aria-hidden="true"
-                      style={createPadAccentStyle(accentColor, isActive)}
-                    />
                     <span style={createPadTitleStyle(isActive)}>
                       {preset.name}
                     </span>

--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -30,7 +30,6 @@ import {
   FALLBACK_INSTRUMENT_COLOR,
   getInstrumentColor,
   hexToRgba,
-  lightenColor,
 } from "./utils/color";
 
 type SelectField = "pack" | "instrument" | "style" | "preset";
@@ -805,8 +804,8 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     {
       isActive,
       isDisabled,
-      minWidth = 132,
-      minHeight = 92,
+      minWidth = 124,
+      minHeight = 74,
     }: {
       isActive: boolean;
       isDisabled?: boolean;
@@ -814,55 +813,63 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
       minHeight?: number;
     }
   ): CSSProperties => {
-    const safeColor = accentColor || FALLBACK_INSTRUMENT_COLOR;
-    const activeBorder = hexToRgba(lightenColor(safeColor, 0.1), 0.9);
-    const restingBorder = hexToRgba(lightenColor(safeColor, -0.35), 0.5);
     return {
       minWidth,
       minHeight,
-      padding: "16px 18px",
-      borderRadius: 10,
-      border: `1px solid ${isActive ? activeBorder : restingBorder}`,
+      padding: "12px 16px 14px",
+      borderRadius: 12,
+      border: "1px solid #273144",
       background: isActive
-        ? "radial-gradient(circle, rgba(255, 235, 191, 0.85), rgba(255, 199, 68, 0.85))"
-        : "radial-gradient(circle, rgba(255, 235, 191, 0.25), rgba(255, 199, 68, 0.25))",
-      color: isActive ? "#2d1600" : "#f8fafc",
+        ? "#27E0B0"
+        : "radial-gradient(circle at center, #1e293b 0%, #101726 72%)",
+      color: isActive ? "#0e151f" : "#e2e8f0",
       display: "flex",
       flexDirection: "column",
-      justifyContent: "flex-start",
-      gap: 6,
+      justifyContent: "center",
+      gap: 8,
       position: "relative",
       textAlign: "left",
       flex: "0 0 auto",
       boxShadow: isActive
-        ? "inset 0 0 12px rgba(255,255,255,0.4), 0 0 12px rgba(234, 189, 115, 0.95), 0px 1px 3px 2px rgba(0, 0, 0, 1)"
-        : "inset 0 0 12px rgba(255,255,255,0.4), 0 0 0px rgba(234, 189, 115, 0.95), 0px 3px 3px 0px rgba(0, 0, 0, 0.5)",
-      transform: isActive ? "translateY(3px)" : "translateY(0)",
+        ? `0 0 12px rgba(39, 224, 176, 0.4), 0 6px 14px rgba(2, 12, 23, 0.45)`
+        : "none",
+      transform: isActive ? "translateY(2px)" : "translateY(0)",
       transition:
-        "transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease, color 0.2s ease, opacity 0.2s ease",
+        "transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, opacity 0.2s ease",
       cursor: isDisabled ? "not-allowed" : "pointer",
       opacity: isDisabled ? 0.55 : 1,
       filter: isDisabled ? "saturate(0.6)" : "none",
       scrollSnapAlign: "start",
       touchAction: "manipulation",
+      boxSizing: "border-box",
     };
   };
 
+  const createPadAccentStyle = (
+    accentColor: string,
+    isActive: boolean
+  ): CSSProperties => ({
+    display: "inline-block",
+    alignSelf: "stretch",
+    height: 4,
+    borderRadius: 999,
+    background: hexToRgba(accentColor || FALLBACK_INSTRUMENT_COLOR, isActive ? 0.95 : 0.55),
+    boxShadow: isActive
+      ? `0 0 10px ${hexToRgba(accentColor || FALLBACK_INSTRUMENT_COLOR, 0.55)}`
+      : "none",
+  });
+
   const createPadTitleStyle = (isActive: boolean): CSSProperties => ({
-    fontSize: 15,
+    fontSize: 14,
     fontWeight: 700,
     letterSpacing: 0.2,
-    color: isActive ? "#2d1600" : "#f8fafc",
-    textShadow: isActive
-      ? `0 0 8px ${hexToRgba("#ffffff", 0.5)}`
-      : "0 1px 0 rgba(4, 7, 14, 0.65)",
-    transition: "color 0.2s ease, text-shadow 0.2s ease",
+    color: isActive ? "#0e151f" : "#e2e8f0",
+    transition: "color 0.2s ease",
   });
 
   const createPadBadgeStyle = (
     accentColor: string,
-    isActive: boolean,
-    variant: "user" | "pack"
+    isActive: boolean
   ): CSSProperties => ({
     display: "inline-flex",
     alignItems: "center",
@@ -873,16 +880,11 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     fontWeight: 700,
     letterSpacing: 0.5,
     textTransform: "uppercase",
-    border: `1px solid ${
-      isActive ? hexToRgba(lightenColor(accentColor, 0.05), 0.7) : "rgba(148, 163, 184, 0.32)"
-    }`,
+    border: `1px solid ${hexToRgba(accentColor || FALLBACK_INSTRUMENT_COLOR, isActive ? 0.55 : 0.35)}`,
     background: isActive
-      ? hexToRgba(
-          lightenColor(accentColor, variant === "user" ? 0.35 : 0.2),
-          variant === "user" ? 0.4 : 0.3
-        )
-      : "rgba(148, 163, 184, 0.08)",
-    color: isActive ? "#2d1600" : "#94a3b8",
+      ? hexToRgba(accentColor || FALLBACK_INSTRUMENT_COLOR, 0.25)
+      : "rgba(148, 163, 184, 0.16)",
+    color: isActive ? "#0e151f" : "#94a3b8",
     transition: "border-color 0.2s ease, background 0.2s ease, color 0.2s ease",
   });
 
@@ -1000,7 +1002,8 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             <div style={horizontalScrollAreaStyle}>
               {packs.map((option) => {
                 const isActive = option.id === selectedPackId;
-                const buttonStyle = createPadButtonStyle(selectedInstrumentAccent, {
+                const accentColor = selectedInstrumentAccent;
+                const buttonStyle = createPadButtonStyle(accentColor, {
                   isActive,
                   isDisabled: packSelectDisabled,
                 });
@@ -1013,6 +1016,10 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     onClick={() => handlePackSelect(option.id)}
                     style={buttonStyle}
                   >
+                    <span
+                      aria-hidden="true"
+                      style={createPadAccentStyle(accentColor, isActive)}
+                    />
                     <span style={createPadTitleStyle(isActive)}>
                       {option.name}
                     </span>
@@ -1054,6 +1061,10 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     onClick={() => handleInstrumentSelect(instrument)}
                     style={buttonStyle}
                   >
+                    <span
+                      aria-hidden="true"
+                      style={createPadAccentStyle(accentColor, isActive)}
+                    />
                     <span style={createPadTitleStyle(isActive)}>
                       {formatInstrumentLabel(instrument)}
                     </span>
@@ -1089,7 +1100,8 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
             <div style={horizontalScrollAreaStyle}>
               {characterOptions.map((character) => {
                 const isActive = character.id === selectedCharacterId;
-                const buttonStyle = createPadButtonStyle(selectedInstrumentAccent, {
+                const accentColor = selectedInstrumentAccent;
+                const buttonStyle = createPadButtonStyle(accentColor, {
                   isActive,
                   isDisabled: styleSelectDisabled,
                 });
@@ -1102,6 +1114,10 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     onClick={() => handleStyleSelect(character.id)}
                     style={buttonStyle}
                   >
+                    <span
+                      aria-hidden="true"
+                      style={createPadAccentStyle(accentColor, isActive)}
+                    />
                     <span style={createPadTitleStyle(isActive)}>
                       {character.name}
                     </span>
@@ -1150,7 +1166,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                 });
                 const badgeStyle =
                   preset.source === "user" || preset.source === "pack"
-                    ? createPadBadgeStyle(accentColor, isActive, preset.source)
+                    ? createPadBadgeStyle(accentColor, isActive)
                     : null;
                 return (
                   <button
@@ -1161,6 +1177,10 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
                     onClick={() => handlePresetSelect(preset.id)}
                     style={buttonStyle}
                   >
+                    <span
+                      aria-hidden="true"
+                      style={createPadAccentStyle(accentColor, isActive)}
+                    />
                     <span style={createPadTitleStyle(isActive)}>
                       {preset.name}
                     </span>

--- a/src/AddTrackModal.tsx
+++ b/src/AddTrackModal.tsx
@@ -816,20 +816,17 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
   ): CSSProperties => {
     const safeColor = accentColor || FALLBACK_INSTRUMENT_COLOR;
     const activeBorder = hexToRgba(lightenColor(safeColor, 0.1), 0.9);
-    const restingBorder = "rgba(17, 26, 44, 0.9)";
+    const restingBorder = hexToRgba(lightenColor(safeColor, -0.35), 0.5);
     return {
       minWidth,
       minHeight,
       padding: "16px 18px",
-      borderRadius: 18,
+      borderRadius: 10,
       border: `1px solid ${isActive ? activeBorder : restingBorder}`,
       background: isActive
-        ? `radial-gradient(circle at 30% 20%, ${hexToRgba(
-            lightenColor(safeColor, 0.45),
-            0.95
-          )} 0%, ${hexToRgba(lightenColor(safeColor, 0.15), 0.9)} 42%, rgba(12, 19, 32, 0.92) 100%)`
-        : "linear-gradient(145deg, #111a2e, #0a111f)",
-      color: isActive ? "#04121c" : "#e2e8f0",
+        ? "radial-gradient(circle, rgba(255, 235, 191, 0.85), rgba(255, 199, 68, 0.85))"
+        : "radial-gradient(circle, rgba(255, 235, 191, 0.25), rgba(255, 199, 68, 0.25))",
+      color: isActive ? "#2d1600" : "#f8fafc",
       display: "flex",
       flexDirection: "column",
       justifyContent: "flex-start",
@@ -838,11 +835,8 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
       textAlign: "left",
       flex: "0 0 auto",
       boxShadow: isActive
-        ? `0 0 12px ${hexToRgba(safeColor, 0.55)}, 0 0 28px ${hexToRgba(
-            lightenColor(safeColor, 0.35),
-            0.5
-          )}, inset 0 0 18px ${hexToRgba(lightenColor(safeColor, 0.25), 0.45)}, inset 0 2px 6px rgba(255, 255, 255, 0.15)`
-        : "inset 0 6px 12px rgba(6, 10, 20, 0.78), inset 0 -6px 10px rgba(0, 0, 0, 0.7), 0 4px 10px rgba(2, 5, 12, 0.65)",
+        ? "inset 0 0 12px rgba(255,255,255,0.4), 0 0 12px rgba(234, 189, 115, 0.95), 0px 1px 3px 2px rgba(0, 0, 0, 1)"
+        : "inset 0 0 12px rgba(255,255,255,0.4), 0 0 0px rgba(234, 189, 115, 0.95), 0px 3px 3px 0px rgba(0, 0, 0, 0.5)",
       transform: isActive ? "translateY(3px)" : "translateY(0)",
       transition:
         "transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease, color 0.2s ease, opacity 0.2s ease",
@@ -858,9 +852,9 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
     fontSize: 15,
     fontWeight: 700,
     letterSpacing: 0.2,
-    color: isActive ? "#04121c" : "#e2e8f0",
+    color: isActive ? "#2d1600" : "#f8fafc",
     textShadow: isActive
-      ? `0 0 12px ${hexToRgba("#ffffff", 0.55)}`
+      ? `0 0 8px ${hexToRgba("#ffffff", 0.5)}`
       : "0 1px 0 rgba(4, 7, 14, 0.65)",
     transition: "color 0.2s ease, text-shadow 0.2s ease",
   });
@@ -888,7 +882,7 @@ export const AddTrackModal: FC<AddTrackModalProps> = ({
           variant === "user" ? 0.4 : 0.3
         )
       : "rgba(148, 163, 184, 0.08)",
-    color: isActive ? "#04121c" : "#94a3b8",
+    color: isActive ? "#2d1600" : "#94a3b8",
     transition: "border-color 0.2s ease, background 0.2s ease, color 0.2s ease",
   });
 

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -30,40 +30,7 @@ import { createPatternGroupId } from "./song";
 import { isUserPresetId, loadInstrumentPreset, stripUserPresetPrefix } from "./presets";
 import { resolveInstrumentCharacterId } from "./instrumentCharacters";
 import { isIOSPWA } from "./utils/audio";
-
-const baseInstrumentColors: Record<string, string> = {
-  kick: "#e74c3c",
-  snare: "#3498db",
-  hihat: "#f1c40f",
-  bass: "#1abc9c",
-  keyboard: "#2ecc71",
-  arp: "#9b59b6",
-};
-
-const FALLBACK_INSTRUMENT_COLOR = "#27E0B0";
-
-const lightenColor = (hex: string, amount: number) => {
-  const normalized = hex.replace("#", "");
-  if (!/^[0-9a-f]{3}$|^[0-9a-f]{6}$/i.test(normalized)) {
-    return hex;
-  }
-  const value =
-    normalized.length === 3
-      ? normalized
-          .split("")
-          .map((char) => char + char)
-          .join("")
-      : normalized;
-  const num = parseInt(value, 16);
-  const clamp = (component: number) => Math.max(0, Math.min(255, component));
-  const r = clamp(((num >> 16) & 0xff) + Math.round(255 * amount));
-  const g = clamp(((num >> 8) & 0xff) + Math.round(255 * amount));
-  const b = clamp((num & 0xff) + Math.round(255 * amount));
-  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, "0")}`;
-};
-
-const getInstrumentColor = (instrument: string) =>
-  baseInstrumentColors[instrument] ?? FALLBACK_INSTRUMENT_COLOR;
+import { getInstrumentColor, lightenColor } from "./utils/color";
 
 const getTrackNumberLabel = (tracks: Track[], trackId: number) => {
   const index = tracks.findIndex((track) => track.id === trackId);

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,62 @@
+const BASE_INSTRUMENT_COLORS: Record<string, string> = {
+  kick: "#e74c3c",
+  snare: "#3498db",
+  hihat: "#f1c40f",
+  bass: "#1abc9c",
+  keyboard: "#2ecc71",
+  arp: "#9b59b6",
+};
+
+export const FALLBACK_INSTRUMENT_COLOR = "#27E0B0";
+
+const normalizeHex = (hex: string) => hex.trim().replace(/^#/, "");
+
+const expandHex = (value: string) =>
+  value.length === 3
+    ? value
+        .split("")
+        .map((char) => char + char)
+        .join("")
+    : value;
+
+const isValidHex = (value: string) => /^[0-9a-f]{3}$|^[0-9a-f]{6}$/i.test(value);
+
+const toRgbTuple = (value: string) => {
+  const intValue = parseInt(value, 16);
+  return {
+    r: (intValue >> 16) & 0xff,
+    g: (intValue >> 8) & 0xff,
+    b: intValue & 0xff,
+  };
+};
+
+export const lightenColor = (hex: string, amount: number) => {
+  const normalized = normalizeHex(hex);
+  if (!isValidHex(normalized)) {
+    return hex;
+  }
+  const value = expandHex(normalized);
+  const { r, g, b } = toRgbTuple(value);
+  const delta = Math.round(255 * amount);
+  const clamp = (component: number) => Math.max(0, Math.min(255, component + delta));
+  const next = (clamp(r) << 16) | (clamp(g) << 8) | clamp(b);
+  return `#${next.toString(16).padStart(6, "0")}`;
+};
+
+export const hexToRgba = (hex: string, alpha: number) => {
+  const normalized = normalizeHex(hex);
+  if (!isValidHex(normalized)) {
+    return hex;
+  }
+  const value = expandHex(normalized);
+  const { r, g, b } = toRgbTuple(value);
+  const boundedAlpha = Math.max(0, Math.min(1, alpha));
+  return `rgba(${r}, ${g}, ${b}, ${boundedAlpha})`;
+};
+
+export const getInstrumentColor = (instrumentId: string | null | undefined) =>
+  instrumentId && BASE_INSTRUMENT_COLORS[instrumentId]
+    ? BASE_INSTRUMENT_COLORS[instrumentId]
+    : FALLBACK_INSTRUMENT_COLOR;
+
+export const withAlpha = (hex: string, alpha: number) => hexToRgba(hex, alpha);


### PR DESCRIPTION
## Summary
- replace the dropdowns in the Add Track modal with horizontally scrolling card buttons for packs, instruments, styles, and saved loops
- automatically default the style selection to the first available option and reset saved loop selection to None when prerequisites change
- combine user and pack loop presets into a unified list with badges while keeping preview and preset management hooks intact

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d83c9360fc8328849baf236d279064