### PR TITLE
Add performance track schema support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import {
   refreshAudioReadyState,
   audioReady,
 } from "./utils/audio";
-import type { PatternGroup, SongRow } from "./song";
+import type { PatternGroup, PerformanceTrack, SongRow } from "./song";
 import { createPatternGroupId, createSongRow } from "./song";
 import { AddTrackModal } from "./AddTrackModal";
 import { Modal } from "./components/Modal";
@@ -266,6 +266,7 @@ const createDemoProjectData = (): StoredProjectData => {
     tracks: trackSnapshots,
     patternGroups,
     songRows,
+    performanceTracks: [],
     selectedGroupId: patternGroupId,
     currentSectionIndex: 0,
   };
@@ -281,6 +282,7 @@ const createEmptyProjectData = (): StoredProjectData => {
     tracks: [],
     patternGroups: [group],
     songRows: [createSongRow()],
+    performanceTracks: [],
     selectedGroupId: group.id,
     currentSectionIndex: 0,
   };
@@ -331,6 +333,9 @@ export default function App() {
   const [songRows, setSongRows] = useState<SongRow[]>([
     createSongRow(),
   ]);
+  const [performanceTracks, setPerformanceTracks] = useState<PerformanceTrack[]>(
+    []
+  );
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const loopStripRef = useRef<LoopStripHandle | null>(null);
   const currentLoopDraftRef = useRef<Track[] | null>(null);
@@ -1312,6 +1317,7 @@ export default function App() {
     tracks,
     patternGroups,
     songRows,
+    performanceTracks,
     selectedGroupId,
     currentSectionIndex,
   }), [
@@ -1322,6 +1328,7 @@ export default function App() {
     tracks,
     patternGroups,
     songRows,
+    performanceTracks,
     selectedGroupId,
     currentSectionIndex,
   ]);
@@ -1481,6 +1488,11 @@ export default function App() {
         project.songRows.length > 0
           ? project.songRows
           : [createSongRow()]
+      );
+      setPerformanceTracks(
+        Array.isArray(project.performanceTracks)
+          ? project.performanceTracks
+          : []
       );
       setSelectedGroupId(project.selectedGroupId ?? null);
       setCurrentSectionIndex(project.currentSectionIndex ?? 0);

--- a/src/song.ts
+++ b/src/song.ts
@@ -1,5 +1,19 @@
 import type { Track } from "./tracks";
 
+export interface PerformanceNote {
+  time: number;
+  note: string;
+  duration: number;
+  velocity: number;
+}
+
+export interface PerformanceTrack {
+  id: string;
+  instrument: string;
+  channel?: number;
+  notes: PerformanceNote[];
+}
+
 export interface PatternGroup {
   id: string;
   name: string;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,5 +1,10 @@
 import type { Chunk } from "./chunks";
-import type { PatternGroup, SongRow } from "./song";
+import type {
+  PatternGroup,
+  PerformanceTrack,
+  PerformanceNote,
+  SongRow,
+} from "./song";
 import type { Track } from "./tracks";
 
 const STORAGE_KEY = "sequencer_projects";
@@ -13,6 +18,7 @@ export interface StoredProjectData {
   tracks: Track[];
   patternGroups: PatternGroup[];
   songRows: SongRow[];
+  performanceTracks?: PerformanceTrack[];
   selectedGroupId: string | null;
   currentSectionIndex?: number;
 }
@@ -70,11 +76,27 @@ const cloneSongRow = (row: SongRow): SongRow => ({
   slots: row.slots.slice(),
 });
 
+const clonePerformanceNote = (note: PerformanceNote): PerformanceNote => ({
+  ...note,
+});
+
+const clonePerformanceTrack = (
+  track: PerformanceTrack
+): PerformanceTrack => ({
+  ...track,
+  notes: Array.isArray(track.notes)
+    ? track.notes.map((note) => clonePerformanceNote(note))
+    : [],
+});
+
 const cloneProjectData = (project: StoredProjectData): StoredProjectData => ({
   ...project,
   tracks: project.tracks.map((track) => cloneTrack(track)),
   patternGroups: project.patternGroups.map((group) => clonePatternGroup(group)),
   songRows: project.songRows.map((row) => cloneSongRow(row)),
+  performanceTracks: Array.isArray(project.performanceTracks)
+    ? project.performanceTracks.map((track) => clonePerformanceTrack(track))
+    : [],
 });
 
 const cloneLoopDraftData = (draft: StoredLoopDraftData): StoredLoopDraftData => ({


### PR DESCRIPTION
## Summary
- add performance note and track interfaces to the song schema
- persist performance tracks in stored project cloning routines
- include performance tracks in app state snapshots and defaults

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8e0dc0b6c8328943dd4acb420159d