### PR TITLE
Implement quantized performance recording in Song View

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1364,6 +1364,49 @@ export default function App() {
     ]
   );
 
+  const updatePerformanceTrack = useCallback(
+    (
+      trackId: string,
+      updater: (track: PerformanceTrack) => PerformanceTrack
+    ) => {
+      setPerformanceTracks((prev) => {
+        const index = prev.findIndex((track) => track.id === trackId);
+        if (index < 0) {
+          return prev;
+        }
+        const current = prev[index];
+        const nextTrack = updater(current);
+        if (nextTrack === current) {
+          return prev;
+        }
+        const next = prev.slice();
+        next[index] = nextTrack;
+        return next;
+      });
+    },
+    [setPerformanceTracks]
+  );
+
+  const removePerformanceTrack = useCallback(
+    (trackId: string) => {
+      if (!trackId) return;
+      setPerformanceTracks((prev) =>
+        prev.filter((track) => track.id !== trackId)
+      );
+      setSongRows((rows) =>
+        rows.map((row) =>
+          row.performanceTrackId === trackId
+            ? { ...row, performanceTrackId: null }
+            : row
+        )
+      );
+      setActivePerformanceTrackId((current) =>
+        current === trackId ? null : current
+      );
+    },
+    [setPerformanceTracks, setSongRows, setActivePerformanceTrackId]
+  );
+
   const clearTrackPattern = useCallback(
     (trackId: number) => {
       updateTrackPattern(trackId, (pattern) => {
@@ -2995,6 +3038,8 @@ export default function App() {
                 triggers={triggers}
                 onEnsurePerformanceRow={ensurePerformanceRow}
                 activePerformanceTrackId={activePerformanceTrackId}
+                onUpdatePerformanceTrack={updatePerformanceTrack}
+                onRemovePerformanceTrack={removePerformanceTrack}
                 onPlayInstrumentOpenChange={setIsSongInstrumentPanelOpen}
               />
             )}

--- a/src/song.ts
+++ b/src/song.ts
@@ -7,9 +7,9 @@ export interface PatternGroup {
 }
 
 export interface PerformanceNote {
-  time: number;
+  time: string | number;
   note: string;
-  duration: number;
+  duration: string | number;
   velocity: number;
 }
 
@@ -24,6 +24,7 @@ export interface SongRow {
   slots: (string | null)[];
   muted: boolean;
   velocity: number;
+  solo?: boolean;
   performanceTrackId?: string | null;
 }
 
@@ -34,6 +35,7 @@ export const createSongRow = (length = 0): SongRow => ({
   slots: Array.from({ length }, () => null),
   muted: false,
   velocity: 1,
+  solo: false,
   performanceTrackId: null,
 });
 


### PR DESCRIPTION
## Summary
- capture live performance input in Song View with Tone transport-aware timing, quantization toggle, and real-time ghost notes
- enhance timeline rows with double-tap solo, live recording previews, and pass recording state to the instrument panel
- extend the song data model and App callbacks so recorded notes persist on performance tracks and rows clean up when removed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d14027b88328affd3681ffb70ac3