### PR TITLE
Add audio unlock overlay to start screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import {
 import { AddTrackModal } from "./AddTrackModal";
 import { Modal } from "./components/Modal";
 import { IconButton } from "./components/IconButton";
+import StartScreen from "./components/StartScreen";
 import { getCharacterOptions } from "./addTrackOptions";
 import { InstrumentControlPanel } from "./InstrumentControlPanel";
 import { exportProjectAudio, exportProjectJson } from "./exporter";
@@ -2735,154 +2736,12 @@ export default function App() {
         </Modal>
       ) : null}
       {!started ? (
-        <div
-          style={{
-            display: "flex",
-            flex: 1,
-            justifyContent: "center",
-            padding: 24,
-          }}
-        >
-          <div
-            style={{
-              width: "min(440px, 100%)",
-              display: "flex",
-              flexDirection: "column",
-              gap: 24,
-            }}
-          >
-            <button
-              type="button"
-              onClick={createNewProject}
-              style={{
-                padding: "18px 24px",
-                fontSize: "1.25rem",
-                borderRadius: 16,
-                border: "1px solid #333",
-                background: "#27E0B0",
-                color: "#1F2532",
-                fontWeight: 600,
-                cursor: "pointer",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: 12,
-              }}
-            >
-              + New Song
-            </button>
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 12,
-              }}
-            >
-              <div style={{ fontSize: 16, fontWeight: 600, color: "#e6f2ff" }}>
-                Saved Songs
-              </div>
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 12,
-                  maxHeight: "60vh",
-                  overflowY: "auto",
-                }}
-              >
-                {projectList.length === 0 ? (
-                  <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "center",
-                      gap: 16,
-                      padding: 20,
-                      borderRadius: 16,
-                      border: "1px dashed #1f2937",
-                      background: "#0b1624",
-                      textAlign: "center",
-                    }}
-                  >
-                    <div
-                      aria-hidden="true"
-                      style={{
-                        width: 72,
-                        height: 72,
-                        borderRadius: "50%",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        background: "rgba(39,224,176,0.12)",
-                        color: "#27E0B0",
-                        fontSize: 36,
-                      }}
-                    >
-                      🎶
-                    </div>
-                    <div
-                      style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 6,
-                        color: "#cbd5f5",
-                        fontSize: 14,
-                      }}
-                    >
-                      <strong style={{ fontSize: 16 }}>
-                        Start your first jam!
-                      </strong>
-                      <span>
-                        Save your creations to see them listed here, or dive in with
-                        our ready-made groove.
-                      </span>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={handleLoadDemoSong}
-                      style={{
-                        padding: "12px 20px",
-                        borderRadius: 999,
-                        border: "none",
-                        background: "linear-gradient(135deg, #27E0B0, #6AE0FF)",
-                        color: "#0b1220",
-                        fontWeight: 600,
-                        fontSize: 14,
-                        cursor: "pointer",
-                        boxShadow: "0 12px 24px rgba(39,224,176,0.25)",
-                      }}
-                    >
-                      Try Demo Song
-                    </button>
-                  </div>
-                ) : (
-                  projectList.map((name) => (
-                    <button
-                      key={name}
-                      onClick={() => loadProject(name)}
-                      style={{
-                        padding: "12px 16px",
-                        borderRadius: 14,
-                        border: "1px solid #1f2937",
-                        background: "#0f172a",
-                        color: "#e6f2ff",
-                        textAlign: "left",
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 4,
-                      }}
-                    >
-                      <span style={{ fontSize: 15, fontWeight: 600 }}>{name}</span>
-                      <span style={{ fontSize: 11, color: "#94a3b8" }}>
-                        Tap to load song
-                      </span>
-                    </button>
-                  ))
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
+        <StartScreen
+          onNewSong={createNewProject}
+          onLoadSong={loadProject}
+          onLoadDemoSong={handleLoadDemoSong}
+          savedSongs={projectList}
+        />
       ) : (
         <>
           <div

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type MouseEvent,
-  type TouchEvent,
-} from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import * as Tone from "tone";
 
 interface StartScreenProps {
@@ -28,38 +21,21 @@ const StartScreen = ({
   );
 
   const handleUnlock = useCallback((action?: () => void) => {
-    const startPromise = Tone.start();
-    console.log("Tone context state:", Tone.context.state);
+    Tone.start();
 
-    startPromise
-      .then(() => {
-        console.log("Tone context state after unlock:", Tone.context.state);
-        if (isAudioRunning()) {
-          setShowAudioOverlay(false);
-          action?.();
-        } else {
-          setShowAudioOverlay(true);
-        }
-      })
-      .catch((error) => {
-        console.error("Audio unlock failed:", error);
-        setShowAudioOverlay(true);
-      });
+    if (isAudioRunning()) {
+      setShowAudioOverlay(false);
+      action?.();
+    } else {
+      console.warn("Tone.js context still suspended");
+      setShowAudioOverlay(true);
+    }
   }, []);
 
   const createGestureHandler = useCallback(
-    (action?: () => void) =>
-      (
-        event:
-          | MouseEvent<HTMLButtonElement>
-          | TouchEvent<HTMLButtonElement>
-      ) => {
-        if (event.type === "touchend") {
-          event.preventDefault();
-        }
-
-        handleUnlock(action);
-      },
+    (action?: () => void) => () => {
+      handleUnlock(action);
+    },
     [handleUnlock]
   );
 

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -25,29 +25,21 @@ function StartScreen({
 }: StartScreenProps) {
   const [showAudioOverlay, setShowAudioOverlay] = useState(false);
 
-  const unlockAudio = useCallback(async (): Promise<boolean> => {
-    try {
-      if (!isAudioRunning()) {
-        await Tone.start();
-      }
-    } catch (error) {
-      console.error("Audio unlock failed:", error);
-    }
-
-    const running = isAudioRunning();
-    setShowAudioOverlay(!running);
-    return running;
+  const handleUnlock = useCallback((action?: () => void) => {
+    Tone.start()
+      .then(() => {
+        if (isAudioRunning()) {
+          setShowAudioOverlay(false);
+          action?.();
+        } else {
+          setShowAudioOverlay(true);
+        }
+      })
+      .catch((error) => {
+        console.error("Audio unlock failed:", error);
+        setShowAudioOverlay(true);
+      });
   }, []);
-
-  const handleUnlock = useCallback(
-    async (action?: () => void) => {
-      const unlocked = await unlockAudio();
-      if (unlocked) {
-        action?.();
-      }
-    },
-    [unlockAudio]
-  );
 
   const createUnlockHandler = useCallback(
     (action?: () => void) =>
@@ -55,16 +47,10 @@ function StartScreen({
         if (event.type === "touchstart") {
           event.preventDefault();
         }
-        void handleUnlock(action);
+        handleUnlock(action);
       },
     [handleUnlock]
   );
-
-  useEffect(() => {
-    if (!isAudioRunning()) {
-      setShowAudioOverlay(true);
-    }
-  }, []);
 
   useEffect(() => {
     const handleVisibilityChange = () => {

--- a/src/index.css
+++ b/src/index.css
@@ -118,3 +118,51 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.overlay-hidden,
+.overlay--inactive,
+.dismissed-overlay {
+  pointer-events: none !important;
+}
+
+.audio-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+}
+
+.audio-overlay .overlay-content {
+  background: #ffffff;
+  padding: 20px 30px;
+  border-radius: 8px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 200px;
+  color: #0b1220;
+}
+
+.audio-overlay .overlay-content p {
+  margin: 0;
+  font-size: 16px;
+}
+
+.audio-overlay .overlay-content button {
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #27e0b0, #6ae0ff);
+  color: #0b1220;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 10px 18px;
+}
+
+.audio-overlay.overlay-hidden {
+  opacity: 0;
+  visibility: hidden;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -166,3 +166,13 @@ button:focus-visible {
   opacity: 0;
   visibility: hidden;
 }
+
+/* Ensure taps aren’t interpreted as gestures or cause delayed clicks */
+button,
+[role="button"],
+.btn {
+  touch-action: manipulation;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
## Summary
- extract the start screen into a dedicated component that can manage audio unlocking
- show a full-screen overlay prompting the user to enable audio when Tone.js is suspended
- unlock audio before starting new songs, loading saved songs, or the demo so the overlay clears consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db4aeca7c88328954124e3b6c01778