### PR TITLE
Fix iOS PWA audio unlock handling

### DIFF
--- a/src/components/SavedSongsList.tsx
+++ b/src/components/SavedSongsList.tsx
@@ -177,6 +177,10 @@ export const SavedSongsList = ({
       <button
         type="button"
         onClick={onTryDemoSong}
+        onTouchEnd={(event) => {
+          event.preventDefault();
+          onTryDemoSong();
+        }}
         style={{
           padding: "12px 24px",
           borderRadius: 999,
@@ -334,6 +338,10 @@ export const SavedSongsList = ({
                       <button
                         type="button"
                         onClick={() => onSelectProject(project.name)}
+                        onTouchEnd={(event) => {
+                          event.preventDefault();
+                          onSelectProject(project.name);
+                        }}
                         style={{
                           display: "flex",
                           flexDirection: "column",
@@ -371,6 +379,11 @@ export const SavedSongsList = ({
                             event.stopPropagation();
                             onRenameProject(project.name);
                           }}
+                          onTouchEnd={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            onRenameProject(project.name);
+                          }}
                           style={{
                             width: 32,
                             height: 32,
@@ -396,6 +409,11 @@ export const SavedSongsList = ({
                         <button
                           type="button"
                           onClick={(event) => {
+                            event.stopPropagation();
+                            onDeleteProject(project.name);
+                          }}
+                          onTouchEnd={(event) => {
+                            event.preventDefault();
                             event.stopPropagation();
                             onDeleteProject(project.name);
                           }}


### PR DESCRIPTION
## Summary
- add a synchronous Tone.js unlock helper alongside the enhanced async fallback for interrupted contexts
- invoke the sync unlock from start-screen interactions while still running the async unlock in the background
- add touch handlers to start screen buttons so new, demo, and saved songs trigger reliably on iOS

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6f99c1908328982d48a7dceb45a1