### PR TITLE
Fix iOS PWA audio unlock behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,8 @@ import {
 } from "./presets";
 import { getInstrumentColor } from "./utils/color";
 import { resolveInstrumentCharacterId } from "./instrumentCharacters";
-import { unlockAudio } from "./utils/audioUnlock";
+import { unlockAudioSync } from "./utils/audioUnlock";
+import { initFirstGestureUnlock } from "./utils/initFirstGestureUnlock";
 
 const isPWARestore = () => {
   if (typeof window === "undefined") {
@@ -2114,16 +2115,8 @@ export default function App() {
     };
   }, [ensureAudioReady, handlerVersion, requestProjectAction, started]);
 
-  const unlockAndRun = useCallback((action?: () => void) => {
-    void (async () => {
-      try {
-        await unlockAudio();
-      } catch (error) {
-        console.warn("unlockAudio failed before action:", error);
-      } finally {
-        action?.();
-      }
-    })();
+  useEffect(() => {
+    initFirstGestureUnlock();
   }, []);
 
   useEffect(() => {
@@ -2614,7 +2607,10 @@ export default function App() {
                         icon="folder_open"
                         label={`Load song ${name}`}
                         tone="accent"
-                        onClick={() => unlockAndRun(() => loadProject(name))}
+                        onClick={() => {
+                          unlockAudioSync();
+                          loadProject(name);
+                        }}
                       />
                       <IconButton
                         icon="delete"
@@ -2847,7 +2843,10 @@ export default function App() {
           </div>
           <button
             type="button"
-            onClick={() => unlockAndRun(createNewProject)}
+            onClick={() => {
+              unlockAudioSync();
+              createNewProject();
+            }}
             style={{
               padding: "20px 48px",
               borderRadius: 999,
@@ -2884,12 +2883,16 @@ export default function App() {
               projects={projectList}
               sortOrder={projectSortOrder}
               onChangeSortOrder={handleChangeProjectSortOrder}
-              onSelectProject={(name) =>
-                unlockAndRun(() => loadProject(name))
-              }
+              onSelectProject={(name) => {
+                unlockAudioSync();
+                loadProject(name);
+              }}
               onRenameProject={handleRenameProject}
               onDeleteProject={handleDeleteProject}
-              onTryDemoSong={() => unlockAndRun(handleLoadDemoSong)}
+              onTryDemoSong={() => {
+                unlockAudioSync();
+                handleLoadDemoSong();
+              }}
             />
           </div>
         </div>

--- a/src/utils/audioUnlock.ts
+++ b/src/utils/audioUnlock.ts
@@ -1,56 +1,101 @@
 import * as Tone from "tone";
 
-export async function unlockAudio(): Promise<void> {
-  if (typeof window === "undefined") {
-    return;
-  }
+type ToneLikeContext = {
+  rawContext?: unknown;
+  state: AudioContextState | "interrupted" | string;
+};
 
-  const context = Tone.getContext();
-  const rawContext = context.rawContext as AudioContext | undefined;
+const getToneContext = (): ToneLikeContext | undefined => {
+  const context = (Tone.getContext?.() ?? Tone.context) as ToneLikeContext | undefined;
+  return context;
+};
 
+/**
+ * Synchronous unlock for use INSIDE a user gesture.
+ * Immediately resumes and tickles the raw AudioContext.
+ */
+export function unlockAudioSync(): void {
   try {
-    let state = context.state as string;
+    const toneContext = getToneContext();
+    const ctx = toneContext?.rawContext as AudioContext | undefined;
 
-    if (state === "running") {
+    if (!ctx) {
+      try {
+        (Tone.start as unknown as (() => void) | undefined)?.();
+      } catch {
+        // ignore
+      }
+      return;
+    }
+
+    if (ctx.state === "running") {
       return;
     }
 
     try {
-      await Tone.start();
-    } catch (error) {
-      console.warn("Tone.js failed to start during unlock:", error);
+      ctx.resume?.();
+    } catch {
+      // ignore
     }
 
-    state = context.state as string;
+    try {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      gain.gain.value = 0;
+      osc.connect(gain).connect(ctx.destination);
+      const now = ctx.currentTime;
+      osc.start(now);
+      osc.stop(now + 0.001);
+    } catch {
+      // ignore
+    }
+  } catch {
+    try {
+      (Tone.start as unknown as (() => void) | undefined)?.();
+    } catch {
+      // ignore
+    }
+  }
+}
 
-    if (state === "interrupted" && rawContext) {
-      console.warn("Audio context is 'interrupted', trying low-level resume");
+/**
+ * Async unlock for resume/visibility. Handles iOS 26.0.1 “interrupted” state.
+ */
+export async function unlockAudio(): Promise<void> {
+  try {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const toneContext = getToneContext();
+    const rawContext = toneContext?.rawContext as AudioContext | undefined;
+
+    if (toneContext?.state === "running") {
+      return;
+    }
+
+    await Tone.start();
+
+    if (toneContext?.state === "interrupted" && rawContext) {
       try {
         await rawContext.resume();
-      } catch (resumeError) {
-        console.error("Direct resume failed:", resumeError);
+      } catch (err) {
+        console.error("Raw resume failed:", err);
       }
-      state = context.state as string;
     }
 
-    const rawState = rawContext?.state as string | undefined;
-
-    if (state !== "running" && rawState !== "running" && rawContext) {
-      console.warn("Audio context still not running, playing silent buffer");
+    if (toneContext?.state !== "running" && rawContext) {
       try {
-        const buffer = rawContext.createBuffer(1, 1, rawContext.sampleRate);
+        const buffer = rawContext.createBuffer(1, 1, 22050);
         const source = rawContext.createBufferSource();
         source.buffer = buffer;
         source.connect(rawContext.destination);
-        source.start();
-        source.onended = () => {
-          source.disconnect();
-        };
-      } catch (bufferError) {
-        console.error("Silent buffer trick failed:", bufferError);
+        source.start(0);
+      } catch (err) {
+        console.error("Silent buffer unlock failed:", err);
       }
     }
-  } catch (error) {
-    console.error("unlockAudio error:", error);
+  } catch (err) {
+    console.error("unlockAudio error:", err);
   }
 }

--- a/src/utils/initFirstGestureUnlock.ts
+++ b/src/utils/initFirstGestureUnlock.ts
@@ -1,0 +1,25 @@
+import { unlockAudioSync } from "./audioUnlock";
+
+let installed = false;
+
+/**
+ * On the first pointerup/touchend/click, run unlockAudioSync() once.
+ */
+export function initFirstGestureUnlock() {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  const handler = () => {
+    try {
+      unlockAudioSync();
+    } catch {
+      // ignore
+    }
+  };
+
+  window.addEventListener("pointerup", handler, { capture: true, once: true });
+  window.addEventListener("touchend", handler, { capture: true, once: true });
+  window.addEventListener("click", handler, { capture: true, once: true });
+}

--- a/src/utils/initFirstGestureUnlock.ts
+++ b/src/utils/initFirstGestureUnlock.ts
@@ -3,15 +3,32 @@ import { unlockAudioSync } from "./audioUnlock";
 let installed = false;
 
 /**
- * On the first pointerup/touchend/click, run unlockAudioSync() once.
+ * On the first pointer/touch/click, run unlockAudioSync() once at capture time.
  */
 export function initFirstGestureUnlock() {
-  if (installed) {
+  if (installed || typeof window === "undefined") {
     return;
   }
   installed = true;
 
+  const eventTypes: Array<keyof WindowEventMap> = [
+    "pointerdown",
+    "pointerup",
+    "touchstart",
+    "touchend",
+    "click",
+  ];
+
+  const options: AddEventListenerOptions = { capture: true };
+
+  const cleanup = () => {
+    for (const type of eventTypes) {
+      window.removeEventListener(type, handler, options);
+    }
+  };
+
   const handler = () => {
+    cleanup();
     try {
       unlockAudioSync();
     } catch {
@@ -19,7 +36,7 @@ export function initFirstGestureUnlock() {
     }
   };
 
-  window.addEventListener("pointerup", handler, { capture: true, once: true });
-  window.addEventListener("touchend", handler, { capture: true, once: true });
-  window.addEventListener("click", handler, { capture: true, once: true });
+  for (const type of eventTypes) {
+    window.addEventListener(type, handler, options);
+  }
 }


### PR DESCRIPTION
## Summary
- add synchronous and async audio unlock helpers to handle iOS 26 PWA quirks
- arm a one-time global listener that primes the audio context on the first user gesture
- call the synchronous unlock before start screen and saved song actions so taps work on the first try

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7c70b8988328bd3aee7ba5f47dee