### PR TITLE
Handle iOS 26 audio unlock interruptions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ import {
 import { getInstrumentColor } from "./utils/color";
 import { resolveInstrumentCharacterId } from "./instrumentCharacters";
 import { unlockAudio } from "./utils/audioUnlock";
+import { AudioDebugHUD } from "./components/AudioDebugHUD";
 
 const isPWARestore = () => {
   if (typeof window === "undefined") {
@@ -3309,6 +3310,7 @@ export default function App() {
           />
         </>
       )}
+      {process.env.NODE_ENV !== "production" && <AudioDebugHUD />}
     </div>
   );
 }

--- a/src/components/AudioDebugHUD.tsx
+++ b/src/components/AudioDebugHUD.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from "react";
+import { getAudioState, unlockAudio } from "../utils/audioUnlock";
+
+const box: React.CSSProperties = {
+  position: "fixed",
+  right: 8,
+  bottom: 8,
+  zIndex: 99999,
+  fontSize: 12,
+  padding: "8px 10px",
+  borderRadius: 8,
+  background: "rgba(0,0,0,0.6)",
+  color: "#fff",
+  userSelect: "none",
+  WebkitUserSelect: "none",
+  backdropFilter: "blur(6px)",
+};
+
+export const AudioDebugHUD: React.FC = () => {
+  const [state, setState] = useState(getAudioState());
+
+  useEffect(() => {
+    const id = setInterval(() => setState(getAudioState()), 400);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div style={box}>
+      <div>
+        Audio: <strong>{state}</strong>
+      </div>
+      <button
+        type="button"
+        onClick={() => unlockAudio()}
+        style={{ marginTop: 6, padding: "4px 8px", borderRadius: 6 }}
+      >
+        Try Unlock
+      </button>
+    </div>
+  );
+};

--- a/src/components/AudioGateOverlay.tsx
+++ b/src/components/AudioGateOverlay.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { unlockAudio, isAudioRunning } from "../utils/audioUnlock";
+
+type Props = { show: boolean; onUnlocked: () => void };
+
+export const AudioGateOverlay: React.FC<Props> = ({ show, onUnlocked }) => {
+  if (!show) return null;
+
+  const handleTap = async () => {
+    await unlockAudio();
+    if (isAudioRunning()) onUnlocked();
+  };
+
+  return (
+    <div
+      role="button"
+      aria-label="Tap to enable audio"
+      onClick={handleTap}
+      onTouchStart={handleTap}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 2147483647,
+        background: "rgba(0,0,0,0.6)",
+        color: "#fff",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: 18,
+        WebkitUserSelect: "none",
+        userSelect: "none",
+        backdropFilter: "blur(4px)",
+      }}
+    >
+      Tap to enable audio
+    </div>
+  );
+};

--- a/src/utils/audioUnlock.ts
+++ b/src/utils/audioUnlock.ts
@@ -1,60 +1,170 @@
 import * as Tone from "tone";
 
-/**
- * Unlock WebAudio on iOS 26.0.1:
- * 1) If already running, bail.
- * 2) Try Tone.start() (Tone's wrapper).
- * 3) If state is still "interrupted", call raw AudioContext.resume().
- * 4) If still not running, play a 1-frame silent buffer to nudge the graph.
- */
-export async function unlockAudio(): Promise<void> {
+type AudioState = AudioContextState | "interrupted";
+
+let hardUnlocked = false;
+
+export function getAudioState(): AudioState {
   try {
-    if (typeof window === "undefined") {
+    return (Tone.context?.state as AudioState) ?? "suspended";
+  } catch {
+    return "suspended";
+  }
+}
+
+/**
+ * Returns true if AudioContext is running.
+ */
+export function isAudioRunning(): boolean {
+  return getAudioState() === "running";
+}
+
+function ensureHiddenContainer(): HTMLElement {
+  let el = document.getElementById("__audio-unlock-bin__");
+  if (!el) {
+    el = document.createElement("div");
+    el.id = "__audio-unlock-bin__";
+    el.style.position = "fixed";
+    el.style.width = "0";
+    el.style.height = "0";
+    el.style.overflow = "hidden";
+    el.style.pointerEvents = "none";
+    el.style.opacity = "0";
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+// A 1-frame silent WAV (44-byte header + 0 data). Works in Safari.
+const SILENT_WAV_DATA_URI =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAAAABAA==";
+
+/**
+ * The most aggressive unlock:
+ *  - Synchronously poke WebAudio resume (no await)
+ *  - Play a hidden <audio> (Safari trusts media playback gestures)
+ *  - Nudge with a 1-frame silent buffer
+ * Call this inside the EARLIEST gesture (pointerdown/touchstart).
+ */
+export function unlockAudioSyncHard(): void {
+  try {
+    if (isAudioRunning()) {
+      hardUnlocked = true;
       return;
     }
 
-    const getContextState = () =>
-      (Tone.context.state as AudioContextState | "interrupted");
+    const ctx = (Tone.getContext?.() ?? Tone.context).rawContext as AudioContext;
 
-    // Case 1: Already running
-    if (getContextState() === "running") return;
+    // 1) Try to resume the raw context synchronously (do not await)
+    try {
+      ctx?.resume?.();
+    } catch {}
 
-    // Case 2: Suspended or interrupted — try Tone’s resume
+    // 2) Kick Tone’s wrapper (don’t await)
+    try {
+      (Tone.start as any)?.();
+    } catch {}
+
+    // 3) Use a trusted media playback: hidden <audio> .play()
+    try {
+      const bin = ensureHiddenContainer();
+      const el = document.createElement("audio");
+      el.setAttribute("playsinline", "");
+      el.muted = true;
+      el.preload = "auto";
+      el.src = SILENT_WAV_DATA_URI;
+      bin.appendChild(el);
+      // Do not await: keep within the same gesture turn
+      el.play().catch(() => {});
+      // Pause & cleanup soon after
+      setTimeout(() => {
+        try {
+          el.pause();
+        } catch {}
+        try {
+          bin.removeChild(el);
+        } catch {}
+      }, 200);
+    } catch {}
+
+    // 4) Nudge the audio graph with a 1-frame silent buffer
+    try {
+      const buffer = ctx.createBuffer(1, 1, 22050);
+      const src = ctx.createBufferSource();
+      src.buffer = buffer;
+      src.connect(ctx.destination);
+      src.start(0);
+    } catch {}
+
+    if (ctx.state === "running") hardUnlocked = true;
+  } catch {
+    // Ignore
+  }
+}
+
+/**
+ * Async unlock for non-gesture contexts (resume/visibility/etc).
+ * Handles iOS 26 "interrupted" and uses media element + silent buffer fallback.
+ */
+export async function unlockAudio(): Promise<void> {
+  try {
+    if (isAudioRunning()) return;
+
+    // Try Tone first
     await Tone.start();
 
-    // iOS 26 can report "interrupted" and ignore Tone.start()
-    if (getContextState() === "interrupted") {
-      console.warn("[audioUnlock] Context is 'interrupted' — trying raw resume()");
-      try {
-        await (Tone.context.rawContext as AudioContext).resume();
-      } catch (err) {
-        console.error("[audioUnlock] Raw resume failed:", err);
+    if (!isAudioRunning()) {
+      const ctx = (Tone.context?.rawContext as AudioContext) ?? null;
+      const state = ctx?.state as AudioState | undefined;
+      if (state === "interrupted") {
+        try {
+          await ctx.resume();
+        } catch (e) {
+          console.error("[audioUnlock] raw resume failed", e);
+        }
       }
     }
 
-    // Case 3: Still not running — silent buffer hack (one-time nudge)
-    if (getContextState() !== "running") {
-      console.warn("[audioUnlock] Still not running — playing silent buffer nudge");
+    if (!isAudioRunning()) {
+      // Try media element in async path too
       try {
-        const ctx = Tone.context.rawContext as AudioContext;
-        const buffer = ctx.createBuffer(1, 1, 22050); // 1 frame @ 22.05kHz is fine
-        const source = ctx.createBufferSource();
-        source.buffer = buffer;
-        source.connect(ctx.destination);
-        source.start(0);
-      } catch (err) {
-        console.error("[audioUnlock] Silent buffer trick failed:", err);
-      }
+        const bin = ensureHiddenContainer();
+        const el = document.createElement("audio");
+        el.setAttribute("playsinline", "");
+        el.muted = true;
+        el.preload = "auto";
+        el.src = SILENT_WAV_DATA_URI;
+        bin.appendChild(el);
+        await el.play().catch(() => {});
+        try {
+          el.pause();
+        } catch {}
+        try {
+          bin.removeChild(el);
+        } catch {}
+      } catch {}
+    }
+
+    if (!isAudioRunning()) {
+      // Final nudge
+      try {
+        const ctx = (Tone.getContext?.() ?? Tone.context).rawContext as AudioContext;
+        const buffer = ctx.createBuffer(1, 1, 22050);
+        const src = ctx.createBufferSource();
+        src.buffer = buffer;
+        src.connect(ctx.destination);
+        src.start(0);
+      } catch {}
+    }
+
+    if (isAudioRunning()) {
+      hardUnlocked = true;
     }
   } catch (err) {
     console.error("[audioUnlock] unlockAudio error:", err);
   }
 }
 
-/** Small helpers (useful for debugging/testing) */
-export function getAudioState(): AudioContextState {
-  return (Tone.context?.state ?? "suspended") as AudioContextState;
-}
-export function isAudioRunning(): boolean {
-  return getAudioState() === "running";
+export function hasHardUnlocked(): boolean {
+  return hardUnlocked || isAudioRunning();
 }

--- a/src/utils/installFirstGestureGate.ts
+++ b/src/utils/installFirstGestureGate.ts
@@ -12,96 +12,174 @@ export function installFirstGestureGate() {
 
   let downTarget: EventTarget | null = null;
   let downPointerId: number | null = null;
+  let downTouchId: number | null = null;
+  let downCoords: { x: number; y: number } | null = null;
 
-  const onDown = (e: Event) => {
-    downTarget = (e as any).target ?? null;
-    downPointerId = (e as PointerEvent).pointerId ?? null;
+  const extractPointerId = (event: Event): number | null => {
+    return typeof (event as PointerEvent).pointerId === "number"
+      ? (event as PointerEvent).pointerId
+      : null;
+  };
+
+  const extractTouchId = (event: Event): number | null => {
+    if ("changedTouches" in event) {
+      const changed = (event as TouchEvent).changedTouches?.[0];
+      if (changed) {
+        return typeof changed.identifier === "number" ? changed.identifier : null;
+      }
+    }
+    if ("touches" in event) {
+      const active = (event as TouchEvent).touches?.[0];
+      if (active) {
+        return typeof active.identifier === "number" ? active.identifier : null;
+      }
+    }
+    return null;
+  };
+
+  const extractCoords = (event: Event): { x: number; y: number } | null => {
+    if ("clientX" in event && "clientY" in event) {
+      const { clientX, clientY } = event as PointerEvent;
+      if (typeof clientX === "number" && typeof clientY === "number") {
+        return { x: clientX, y: clientY };
+      }
+    }
+
+    if ("changedTouches" in event) {
+      const touch = (event as TouchEvent).changedTouches?.[0];
+      if (touch) {
+        return { x: touch.clientX, y: touch.clientY };
+      }
+    }
+
+    if ("touches" in event) {
+      const touch = (event as TouchEvent).touches?.[0];
+      if (touch) {
+        return { x: touch.clientX, y: touch.clientY };
+      }
+    }
+
+    return null;
+  };
+
+  const resetGestureState = () => {
+    downTarget = null;
+    downPointerId = null;
+    downTouchId = null;
+    downCoords = null;
+  };
+
+  const onDown = (event: Event) => {
+    downTarget = (event as any).target ?? null;
+    downPointerId = extractPointerId(event);
+    downTouchId = extractTouchId(event);
+    downCoords = extractCoords(event);
 
     // Hard unlock INSIDE the earliest gesture turn
     unlockAudioSyncHard();
   };
 
-  const reemitClick = (upEvent: Event) => {
+  const resolveTarget = (upEvent: Event): HTMLElement | null => {
     const upTarget = (upEvent as any).target as HTMLElement | null;
-    const samePointer =
-      (upEvent as PointerEvent).pointerId != null &&
-      downPointerId != null &&
-      (upEvent as PointerEvent).pointerId === downPointerId;
-    const sameNode = upTarget && downTarget && upTarget === downTarget;
 
-    if (!samePointer && !sameNode) return;
+    if (upTarget && typeof upTarget.dispatchEvent === "function") {
+      // If the up target matches or contains the original target, prefer it.
+      if (
+        (downTarget instanceof Node && upTarget.contains(downTarget)) ||
+        upTarget === downTarget
+      ) {
+        return upTarget;
+      }
+    }
+
+    const original = downTarget as HTMLElement | null;
+    if (original && typeof original.dispatchEvent === "function") {
+      return original;
+    }
+
+    if (downCoords) {
+      const candidate = document.elementFromPoint(
+        downCoords.x,
+        downCoords.y
+      ) as HTMLElement | null;
+      if (candidate && typeof candidate.dispatchEvent === "function") {
+        return candidate;
+      }
+    }
+
+    return null;
+  };
+
+  const reemitClick = (upEvent: Event) => {
+    const pointerId = extractPointerId(upEvent);
+    const touchId = extractTouchId(upEvent);
+
+    const pointerMatches =
+      downPointerId != null && pointerId != null
+        ? pointerId === downPointerId
+        : downPointerId == null || pointerId == null;
+    const touchMatches =
+      downTouchId != null && touchId != null
+        ? touchId === downTouchId
+        : downTouchId == null || touchId == null;
+
+    if (!pointerMatches || !touchMatches) {
+      return;
+    }
+
+    const target = resolveTarget(upEvent);
+    if (!target) {
+      return;
+    }
 
     try {
-      const el = upTarget ?? (downTarget as HTMLElement | null);
-      if (el && typeof el.dispatchEvent === "function") {
-        const ev = new MouseEvent("click", {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-        });
-        el.dispatchEvent(ev);
-      }
+      const ev = new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      });
+      target.dispatchEvent(ev);
     } catch {}
   };
 
-  const onUp = (e: Event) => {
-    reemitClick(e);
-    downTarget = null;
-    downPointerId = null;
+  const onUp = (event: Event) => {
+    reemitClick(event);
+    resetGestureState();
 
     if (hasHardUnlocked()) {
       remove();
     }
   };
 
-  const add = () => {
-    document.addEventListener("pointerdown", onDown, {
-      capture: true,
-      passive: true,
-    });
-    document.addEventListener("touchstart", onDown, {
-      capture: true,
-      passive: true,
-    });
-    document.addEventListener("mousedown", onDown, {
-      capture: true,
-      passive: true,
-    });
+  const onCancel = () => {
+    resetGestureState();
+  };
 
-    document.addEventListener("pointerup", onUp, {
-      capture: true,
-      passive: true,
-    });
-    document.addEventListener("touchend", onUp, {
-      capture: true,
-      passive: true,
-    });
-    document.addEventListener("mouseup", onUp, {
-      capture: true,
-      passive: true,
-    });
+  const add = () => {
+    const options = { capture: true, passive: true } as const;
+    document.addEventListener("pointerdown", onDown, options);
+    document.addEventListener("touchstart", onDown, options);
+    document.addEventListener("mousedown", onDown, options);
+
+    document.addEventListener("pointerup", onUp, options);
+    document.addEventListener("touchend", onUp, options);
+    document.addEventListener("mouseup", onUp, options);
+
+    document.addEventListener("pointercancel", onCancel, options);
+    document.addEventListener("touchcancel", onCancel, options);
   };
 
   const remove = () => {
-    document.removeEventListener("pointerdown", onDown, {
-      capture: true,
-    } as any);
-    document.removeEventListener("touchstart", onDown, {
-      capture: true,
-    } as any);
-    document.removeEventListener("mousedown", onDown, {
-      capture: true,
-    } as any);
+    document.removeEventListener("pointerdown", onDown, true);
+    document.removeEventListener("touchstart", onDown, true);
+    document.removeEventListener("mousedown", onDown, true);
 
-    document.removeEventListener("pointerup", onUp, {
-      capture: true,
-    } as any);
-    document.removeEventListener("touchend", onUp, {
-      capture: true,
-    } as any);
-    document.removeEventListener("mouseup", onUp, {
-      capture: true,
-    } as any);
+    document.removeEventListener("pointerup", onUp, true);
+    document.removeEventListener("touchend", onUp, true);
+    document.removeEventListener("mouseup", onUp, true);
+
+    document.removeEventListener("pointercancel", onCancel, true);
+    document.removeEventListener("touchcancel", onCancel, true);
   };
 
   add();

--- a/src/utils/installFirstGestureGate.ts
+++ b/src/utils/installFirstGestureGate.ts
@@ -1,0 +1,108 @@
+import { unlockAudioSyncHard, hasHardUnlocked } from "./audioUnlock";
+
+/**
+ * Installs earliest-gesture unlock + click re-emit, once.
+ * Does NOT block events, does NOT change layout.
+ */
+let installed = false;
+
+export function installFirstGestureGate() {
+  if (installed) return;
+  installed = true;
+
+  let downTarget: EventTarget | null = null;
+  let downPointerId: number | null = null;
+
+  const onDown = (e: Event) => {
+    downTarget = (e as any).target ?? null;
+    downPointerId = (e as PointerEvent).pointerId ?? null;
+
+    // Hard unlock INSIDE the earliest gesture turn
+    unlockAudioSyncHard();
+  };
+
+  const reemitClick = (upEvent: Event) => {
+    const upTarget = (upEvent as any).target as HTMLElement | null;
+    const samePointer =
+      (upEvent as PointerEvent).pointerId != null &&
+      downPointerId != null &&
+      (upEvent as PointerEvent).pointerId === downPointerId;
+    const sameNode = upTarget && downTarget && upTarget === downTarget;
+
+    if (!samePointer && !sameNode) return;
+
+    try {
+      const el = upTarget ?? (downTarget as HTMLElement | null);
+      if (el && typeof el.dispatchEvent === "function") {
+        const ev = new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        });
+        el.dispatchEvent(ev);
+      }
+    } catch {}
+  };
+
+  const onUp = (e: Event) => {
+    reemitClick(e);
+    downTarget = null;
+    downPointerId = null;
+
+    if (hasHardUnlocked()) {
+      remove();
+    }
+  };
+
+  const add = () => {
+    document.addEventListener("pointerdown", onDown, {
+      capture: true,
+      passive: true,
+    });
+    document.addEventListener("touchstart", onDown, {
+      capture: true,
+      passive: true,
+    });
+    document.addEventListener("mousedown", onDown, {
+      capture: true,
+      passive: true,
+    });
+
+    document.addEventListener("pointerup", onUp, {
+      capture: true,
+      passive: true,
+    });
+    document.addEventListener("touchend", onUp, {
+      capture: true,
+      passive: true,
+    });
+    document.addEventListener("mouseup", onUp, {
+      capture: true,
+      passive: true,
+    });
+  };
+
+  const remove = () => {
+    document.removeEventListener("pointerdown", onDown, {
+      capture: true,
+    } as any);
+    document.removeEventListener("touchstart", onDown, {
+      capture: true,
+    } as any);
+    document.removeEventListener("mousedown", onDown, {
+      capture: true,
+    } as any);
+
+    document.removeEventListener("pointerup", onUp, {
+      capture: true,
+    } as any);
+    document.removeEventListener("touchend", onUp, {
+      capture: true,
+    } as any);
+    document.removeEventListener("mouseup", onUp, {
+      capture: true,
+    } as any);
+  };
+
+  add();
+}


### PR DESCRIPTION
## Summary
- replace the audio unlock helper to detect the new iOS 26 "interrupted" state, resume the raw context, and fall back to a silent buffer nudge
- add a lightweight AudioDebugHUD component to monitor the audio context state and trigger manual unlock attempts during development
- render the debug HUD in non-production builds to aid testing while keeping production builds unaffected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd92fcc18083288befeb1b43be3ed0