### PR TITLE
Improve tracks view navigation and loop controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { AddTrackModal } from "./AddTrackModal";
 import { Modal } from "./components/Modal";
 import { IconButton } from "./components/IconButton";
 import { SavedSongsList } from "./components/SavedSongsList";
+import { ViewHeader } from "./components/ViewHeader";
 import { getCharacterOptions } from "./addTrackOptions";
 import { InstrumentControlPanel } from "./InstrumentControlPanel";
 import { exportProjectAudio, exportProjectJson } from "./exporter";
@@ -103,7 +104,7 @@ const isPWARestore = () => {
 
 const createInitialPatternGroup = (): PatternGroup => ({
   id: createPatternGroupId(),
-  name: "sequence01",
+  name: "Loop 01",
   tracks: [],
 });
 
@@ -2895,120 +2896,43 @@ export default function App() {
         </div>
       ) : (
         <>
-          <div
-            style={{
-              padding: "16px 16px 0",
+          <ViewHeader
+            viewMode={viewMode}
+            onBack={handleReturnToSongSelection}
+            onSelectTrack={() => {
+              skipLoopDraftRestoreRef.current = false;
+              setViewMode("track");
             }}
-          >
-            <div
-              style={{
-                display: "flex",
-                gap: 8,
-                alignItems: "center",
-                flexWrap: "wrap",
-              }}
-            >
-              <button
-                type="button"
-                onClick={handleReturnToSongSelection}
-                style={{
-                  padding: "8px 12px",
-                  borderRadius: 8,
-                  border: "1px solid #333",
-                  background: "#111827",
-                  color: "#e6f2ff",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 6,
-                  fontSize: 13,
-                  fontWeight: 600,
-                  letterSpacing: 0.3,
-                  flexShrink: 0,
-                }}
-              >
-                <span
-                  className="material-symbols-outlined"
-                  aria-hidden="true"
-                  style={{ fontSize: 18 }}
-                >
-                  arrow_back
-                </span>
-                Back to Songs
-              </button>
-              <div
-                style={{
-                  display: "flex",
-                  gap: 8,
-                  flex: 1,
-                  minWidth: 0,
-                }}
-              >
-                <button
-                  onClick={() => {
-                    skipLoopDraftRestoreRef.current = false;
-                    setViewMode("track");
-                  }}
-                  style={{
-                    flex: 1,
-                    padding: "8px 0",
-                    borderRadius: 8,
-                    border: "1px solid #333",
-                    background: viewMode === "track" ? "#27E0B0" : "#1f2532",
-                    color: viewMode === "track" ? "#1F2532" : "#e6f2ff",
-                  }}
-                >
-                  Tracks
-                </button>
-                <button
-                  onClick={() => {
-                    setEditing(null);
-                    setViewMode("song");
-                  }}
-                  style={{
-                    flex: 1,
-                    padding: "8px 0",
-                    borderRadius: 8,
-                    border: "1px solid #333",
-                    background: viewMode === "song" ? "#27E0B0" : "#1f2532",
-                    color: viewMode === "song" ? "#1F2532" : "#e6f2ff",
-                  }}
-                >
-                  Song
-                </button>
-              </div>
-            </div>
-            {viewMode === "song" && !isSongInstrumentPanelOpen ? (
-              <div
-                style={{
-                  marginTop: 12,
-                  display: "flex",
-                  justifyContent: "flex-end",
-                  gap: 12,
-                  flexWrap: "wrap",
-                }}
-              >
-                <IconButton
-                  icon="save"
-                  label="Save song"
-                  onClick={openSaveProjectModal}
-                />
-                <IconButton
-                  icon="folder_open"
-                  label="Load song"
-                  onClick={openLoadProjectModal}
-                />
-                <IconButton
-                  icon="file_download"
-                  label="Open export options"
-                  onClick={() => {
-                    setAudioExportMessage("Preparing export…");
-                    setIsExportModalOpen(true);
-                  }}
-                  disabled={isAudioExporting}
-                />
-              </div>
-            ) : null}
-          </div>
+            onSelectSong={() => {
+              setEditing(null);
+              setViewMode("song");
+            }}
+            actions={
+              viewMode === "song" && !isSongInstrumentPanelOpen ? (
+                <>
+                  <IconButton
+                    icon="save"
+                    label="Save song"
+                    onClick={openSaveProjectModal}
+                  />
+                  <IconButton
+                    icon="folder_open"
+                    label="Load song"
+                    onClick={openLoadProjectModal}
+                  />
+                  <IconButton
+                    icon="file_download"
+                    label="Open export options"
+                    onClick={() => {
+                      setAudioExportMessage("Preparing export…");
+                      setIsExportModalOpen(true);
+                    }}
+                    disabled={isAudioExporting}
+                  />
+                </>
+              ) : undefined
+            }
+          />
           {viewMode === "track" && (
             <LoopStrip
               ref={loopStripRef}

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -24,6 +24,7 @@ import type {
 } from "./instruments/harmonia";
 import { isScaleName, type ScaleName } from "./music/scales";
 import { packs, type InstrumentDefinition } from "./packs";
+import { IconButton } from "./components/IconButton";
 import { StepModal } from "./StepModal";
 import type { PatternGroup } from "./song";
 import { createPatternGroupId } from "./song";
@@ -258,7 +259,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
     );
     let index = 1;
     while (true) {
-      const candidate = `sequence${String(index).padStart(2, "0")}`;
+      const candidate = `Loop ${String(index).padStart(2, "0")}`;
       if (!existingNames.has(candidate.toLowerCase())) {
         return candidate;
       }
@@ -656,6 +657,29 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
     });
   };
 
+  const handleCreateLoop = () => {
+    const newId = createPatternGroupId();
+    let created: PatternGroup | null = null;
+    setPatternGroups((groups) => {
+      const name = getNextGroupName(groups);
+      created = {
+        id: newId,
+        name,
+        tracks: [],
+      };
+      return [...groups, created];
+    });
+    setGroupEditor(null);
+    setIsLoopsLibraryOpen(false);
+    if (created) {
+      setSelectedGroupId(newId);
+      applyGroupTracks(created);
+    } else {
+      setSelectedGroupId(newId);
+      applyGroupTracks(null);
+    }
+  };
+
   const openEditGroup = () => {
     if (!selectedGroup) return;
     setGroupEditor({
@@ -757,7 +781,9 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
   const handleDeleteGroup = () => {
     if (!selectedGroupId) return;
     if (patternGroups.length <= 1) return;
-    const confirmed = window.confirm("Delete this sequence? This action cannot be undone.");
+    const confirmed = window.confirm(
+      "Delete this loop? This action cannot be undone."
+    );
     if (!confirmed) return;
     setPatternGroups((groups) => {
       const filtered = groups.filter((group) => group.id !== selectedGroupId);
@@ -848,67 +874,135 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
           marginBottom: 8,
         }}
       >
-        <button
-          type="button"
-          onClick={() =>
-            setIsLoopsLibraryOpen((open) => !open && patternGroups.length > 0)
-          }
-          disabled={patternGroups.length === 0}
+        <div
           style={{
-            padding: "6px 14px",
-            borderRadius: 999,
-            border: "1px solid #333",
-            background: "#1f2532",
-            color: patternGroups.length === 0 ? "#475569" : "#e6f2ff",
-            fontSize: 13,
-            fontWeight: 600,
-            letterSpacing: 0.3,
             display: "flex",
             alignItems: "center",
-            gap: 6,
-            cursor: patternGroups.length === 0 ? "not-allowed" : "pointer",
+            gap: 8,
+            flex: "1 1 260px",
+            minWidth: 0,
+            flexWrap: "wrap",
           }}
         >
-          <span>Loop: {selectedGroup?.name ?? "None"}</span>
-          <span aria-hidden="true" style={{ fontSize: 10 }}>
-            ▴
-          </span>
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            if (!addTrackEnabled) return;
-            onAddTrack();
-          }}
-          disabled={!addTrackEnabled}
+          <IconButton
+            icon="add"
+            label="Create new loop"
+            onClick={handleCreateLoop}
+            title="Create new loop"
+            style={{
+              minWidth: 40,
+              minHeight: 40,
+              borderRadius: 999,
+              background: "#1f2532",
+            }}
+          />
+          <select
+            aria-label="Current loop"
+            value={selectedGroupId ?? patternGroups[0]?.id ?? ""}
+            onChange={(event) => {
+              const value = event.target.value;
+              setSelectedGroupId(value || null);
+              setGroupEditor(null);
+              setIsLoopsLibraryOpen(false);
+            }}
+            style={{
+              flex: "1 1 160px",
+              minWidth: 0,
+              padding: 10,
+              borderRadius: 12,
+              border: "1px solid #2f384a",
+              background: "#111827",
+              color: "#e6f2ff",
+            }}
+          >
+            {patternGroups.map((group) => (
+              <option key={group.id} value={group.id}>
+                📼 {group.name}
+              </option>
+            ))}
+          </select>
+          <IconButton
+            icon="save"
+            label="Save loop"
+            onClick={handleSnapshotSelectedGroup}
+            title="Save loop"
+            disabled={!selectedGroup}
+            style={{
+              minWidth: 40,
+              minHeight: 40,
+              borderRadius: 999,
+              background: selectedGroup ? "#27E0B0" : "#1f2532",
+              border: selectedGroup ? "1px solid #27E0B0" : "1px solid #2f384a",
+              color: selectedGroup ? "#0b1220" : "#94a3b8",
+            }}
+          />
+          <IconButton
+            icon="more_horiz"
+            label="Open loop options"
+            onClick={() => setIsLoopsLibraryOpen(true)}
+            title="Loop options"
+            disabled={patternGroups.length === 0}
+            style={{
+              minWidth: 40,
+              minHeight: 40,
+              borderRadius: 999,
+              background: "#1f2532",
+            }}
+          />
+        </div>
+        <div
           style={{
-            padding: isHeroAddTrack ? "14px 28px" : "6px 16px",
-            borderRadius: 999,
-            border: isHeroAddTrack ? "none" : "1px solid #333",
-            background: addTrackEnabled
-              ? isHeroAddTrack
-                ? "linear-gradient(135deg, #27E0B0, #6AE0FF)"
-                : "#27E0B0"
-              : "#1f2532",
-            color: addTrackEnabled
-              ? isHeroAddTrack
-                ? "#0b1220"
-                : "#1F2532"
-              : "#475569",
-            fontSize: isHeroAddTrack ? 16 : 13,
-            fontWeight: 700,
-            letterSpacing: 0.3,
-            cursor: addTrackEnabled ? "pointer" : "not-allowed",
-            boxShadow: addTrackEnabled
-              ? isHeroAddTrack
-                ? "0 16px 30px rgba(39,224,176,0.35)"
-                : "0 2px 6px rgba(15, 20, 32, 0.35)"
-              : "none",
-            transition: "transform 0.2s ease, box-shadow 0.2s ease",
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            flex: "0 0 auto",
           }}
         >
-          + Track
-        </button>
+          <div
+            aria-hidden="true"
+            style={{
+              width: 1,
+              height: 32,
+              background: "#333",
+              opacity: 0.6,
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              if (!addTrackEnabled) return;
+              onAddTrack();
+            }}
+            disabled={!addTrackEnabled}
+            style={{
+              padding: isHeroAddTrack ? "14px 28px" : "6px 16px",
+              borderRadius: 999,
+              border: isHeroAddTrack ? "none" : "1px solid #333",
+              background: addTrackEnabled
+                ? isHeroAddTrack
+                  ? "linear-gradient(135deg, #27E0B0, #6AE0FF)"
+                  : "#27E0B0"
+                : "#1f2532",
+              color: addTrackEnabled
+                ? isHeroAddTrack
+                  ? "#0b1220"
+                  : "#1F2532"
+                : "#475569",
+              fontSize: isHeroAddTrack ? 16 : 13,
+              fontWeight: 700,
+              letterSpacing: 0.3,
+              cursor: addTrackEnabled ? "pointer" : "not-allowed",
+              boxShadow: addTrackEnabled
+                ? isHeroAddTrack
+                  ? "0 16px 30px rgba(39,224,176,0.35)"
+                  : "0 2px 6px rgba(15, 20, 32, 0.35)"
+                : "none",
+              transition: "transform 0.2s ease, box-shadow 0.2s ease",
+            }}
+          >
+            + Track
+          </button>
+        </div>
       </div>
       <div
         ref={trackAreaRef}
@@ -926,14 +1020,23 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
         {tracks.length === 0 && (
           <div
             style={{
-              padding: 16,
+              margin: "32px auto 16px",
+              padding: "20px 24px",
+              maxWidth: 440,
+              borderRadius: 16,
+              border: "1px dashed #334155",
+              background: "rgba(15,23,42,0.65)",
               textAlign: "center",
               fontSize: 14,
               color: "#94a3b8",
-              lineHeight: 1.5,
+              lineHeight: 1.6,
             }}
           >
-            No beats yet — add a track to get the groove started.
+            <strong style={{ display: "block", marginBottom: 6, color: "#e2e8f0" }}>
+              This loop is waiting for its first track.
+            </strong>
+            Use the green <em style={{ color: "#27E0B0", fontStyle: "normal" }}>+ Track</em>{" "}
+            button on the right to add an instrument and start building your beat.
           </div>
         )}
         {tracks.map((t) => {
@@ -1171,7 +1274,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                   color: "#e6f2ff",
                 }}
               >
-                Loops Library
+                Loop options
               </h3>
               <button
                 type="button"
@@ -1189,6 +1292,17 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 Close
               </button>
             </div>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 13,
+                lineHeight: 1.6,
+                color: "#94a3b8",
+              }}
+            >
+              Rename, duplicate, or remove loops. Use the plus button in Tracks view to
+              spin up new ideas quickly.
+            </p>
             <div
               style={{
                 display: "flex",
@@ -1259,8 +1373,8 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 type="button"
                 onClick={handleSnapshotSelectedGroup}
                 disabled={!selectedGroup}
-                aria-label="Save sequence"
-                title="Save sequence"
+                aria-label="Save loop"
+                title="Save loop"
                 style={{
                   flex: "1 1 100px",
                   minWidth: 0,
@@ -1284,7 +1398,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 type="button"
                 onClick={openEditGroup}
                 disabled={!selectedGroup}
-                aria-label="Edit sequence"
+                aria-label="Edit loop"
                 style={{
                   flex: "1 1 100px",
                   minWidth: 0,
@@ -1312,7 +1426,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                 type="button"
                 onClick={handleDuplicateGroup}
                 disabled={!selectedGroup}
-                aria-label="Duplicate sequence"
+                aria-label="Duplicate loop"
                 style={{
                   flex: "1 1 110px",
                   minWidth: 0,

--- a/src/components/ViewHeader.tsx
+++ b/src/components/ViewHeader.tsx
@@ -1,0 +1,131 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface ViewHeaderProps {
+  viewMode: "track" | "song";
+  onBack: () => void;
+  onSelectTrack: () => void;
+  onSelectSong: () => void;
+  actions?: ReactNode;
+}
+
+const headerWrapperStyle: CSSProperties = {
+  padding: "16px 16px 0",
+  position: "sticky",
+  top: 0,
+  zIndex: 30,
+  background: "linear-gradient(180deg, rgba(13,18,30,0.94), rgba(13,18,30,0.82))",
+  backdropFilter: "blur(12px)",
+};
+
+const navRowStyle: CSSProperties = {
+  display: "flex",
+  gap: 8,
+  alignItems: "center",
+  flexWrap: "wrap",
+};
+
+const tabGroupStyle: CSSProperties = {
+  display: "flex",
+  gap: 8,
+  flex: 1,
+  minWidth: 0,
+};
+
+const tabBaseStyle: CSSProperties = {
+  flex: 1,
+  padding: "8px 0",
+  borderRadius: 999,
+  border: "1px solid #333",
+  background: "#1f2532",
+  color: "#94a3b8",
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  cursor: "pointer",
+  transition: "background 0.2s ease, color 0.2s ease, border-color 0.2s ease",
+};
+
+const backButtonStyle: CSSProperties = {
+  padding: "8px 14px",
+  borderRadius: 999,
+  border: "1px solid #333",
+  background: "#111827",
+  color: "#e6f2ff",
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  fontSize: 13,
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  flexShrink: 0,
+  cursor: "pointer",
+};
+
+export function ViewHeader({
+  viewMode,
+  onBack,
+  onSelectTrack,
+  onSelectSong,
+  actions,
+}: ViewHeaderProps) {
+  const trackActive = viewMode === "track";
+  const songActive = viewMode === "song";
+
+  return (
+    <header style={headerWrapperStyle}>
+      <div style={navRowStyle}>
+        <button
+          type="button"
+          onClick={onBack}
+          style={backButtonStyle}
+          aria-label="Back to songs"
+          title="Back to songs"
+        >
+          <span style={{ fontSize: 13, fontWeight: 600 }}>{"< Back"}</span>
+        </button>
+        <div style={tabGroupStyle}>
+          <button
+            type="button"
+            onClick={onSelectTrack}
+            style={{
+              ...tabBaseStyle,
+              background: trackActive ? "#27E0B0" : "#1f2532",
+              color: trackActive ? "#0b1220" : "#94a3b8",
+              borderColor: trackActive ? "#27E0B0" : "#333",
+            }}
+            aria-pressed={trackActive}
+          >
+            Tracks
+          </button>
+          <button
+            type="button"
+            onClick={onSelectSong}
+            style={{
+              ...tabBaseStyle,
+              background: songActive ? "#27E0B0" : "#1f2532",
+              color: songActive ? "#0b1220" : "#94a3b8",
+              borderColor: songActive ? "#27E0B0" : "#333",
+            }}
+            aria-pressed={songActive}
+          >
+            Song
+          </button>
+        </div>
+      </div>
+      {actions ? (
+        <div
+          style={{
+            marginTop: 12,
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
+          {actions}
+        </div>
+      ) : null}
+    </header>
+  );
+}
+
+export default ViewHeader;


### PR DESCRIPTION
## Summary
- add a reusable header component to separate navigation from the tracks content and highlight the active tab
- rename automatically created loops to the new “Loop NN” format and streamline loop creation from the tracks toolbar
- refresh the tracks empty state, loop toolbar controls, and loop options dialog to guide users toward adding tracks faster

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddf684c1908328a3f1cf2b563fcdde