### PR TITLE
Improve loop track editing workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3108,6 +3108,28 @@ export default function App() {
                             cleaning_services
                           </span>
                         </button>
+                        <button
+                          aria-label="Edit track settings"
+                          onClick={() =>
+                            selectedTrack && handleRequestTrackModal(selectedTrack)
+                          }
+                          disabled={!selectedTrack}
+                          style={{
+                            ...controlButtonBaseStyle,
+                            background: "#111827",
+                            border: "1px solid #333",
+                            color: selectedTrack ? "#38bdf8" : "#475569",
+                            cursor: selectedTrack ? "pointer" : "not-allowed",
+                            opacity: selectedTrack ? 1 : 0.6,
+                          }}
+                        >
+                          <span
+                            className="material-symbols-outlined"
+                            style={controlIconStyle}
+                          >
+                            tune
+                          </span>
+                        </button>
                       </div>
                       <div style={transportDividerStyle} />
                     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1614,18 +1614,6 @@ export default function App() {
     clearTrackPattern(selectedTrack.id);
   }, [selectedTrack, canClearSelectedTrack, clearTrackPattern]);
 
-  const handleDeleteSelectedTrack = useCallback(() => {
-    if (!selectedTrack) return;
-    const trackName = selectedTrack.name?.trim();
-    const message = trackName
-      ? `Delete track "${trackName}"? This action cannot be undone.`
-      : "Delete this track? This action cannot be undone.";
-    if (!window.confirm(message)) {
-      return;
-    }
-    loopStripRef.current?.removeTrack(selectedTrack.id);
-  }, [selectedTrack]);
-
   const buildProjectSnapshot = useCallback((): StoredProjectData => ({
     packIndex,
     bpm,
@@ -3043,26 +3031,6 @@ export default function App() {
                           minWidth: 0,
                         }}
                       >
-                        <button
-                          aria-label="Delete track"
-                          onClick={handleDeleteSelectedTrack}
-                          disabled={!selectedTrack}
-                          style={{
-                            ...controlButtonBaseStyle,
-                            background: "#111827",
-                            border: "1px solid #333",
-                            color: selectedTrack ? "#f87171" : "#475569",
-                            cursor: selectedTrack ? "pointer" : "not-allowed",
-                            opacity: selectedTrack ? 1 : 0.6,
-                          }}
-                        >
-                          <span
-                            className="material-symbols-outlined"
-                            style={controlIconStyle}
-                          >
-                            delete
-                          </span>
-                        </button>
                         {selectedTrack && canRecordSelectedTrack ? (
                           <button
                             aria-label={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1614,6 +1614,18 @@ export default function App() {
     clearTrackPattern(selectedTrack.id);
   }, [selectedTrack, canClearSelectedTrack, clearTrackPattern]);
 
+  const handleDeleteSelectedTrack = useCallback(() => {
+    if (!selectedTrack) return;
+    const trackName = selectedTrack.name?.trim();
+    const message = trackName
+      ? `Delete track "${trackName}"? This action cannot be undone.`
+      : "Delete this track? This action cannot be undone.";
+    if (!window.confirm(message)) {
+      return;
+    }
+    loopStripRef.current?.removeTrack(selectedTrack.id);
+  }, [selectedTrack]);
+
   const buildProjectSnapshot = useCallback((): StoredProjectData => ({
     packIndex,
     bpm,
@@ -3032,19 +3044,23 @@ export default function App() {
                         }}
                       >
                         <button
-                          aria-label="Done editing"
-                          onClick={() => setEditing(null)}
+                          aria-label="Delete track"
+                          onClick={handleDeleteSelectedTrack}
+                          disabled={!selectedTrack}
                           style={{
                             ...controlButtonBaseStyle,
-                            background: "#27E0B0",
-                            color: "#1F2532",
+                            background: "#111827",
+                            border: "1px solid #333",
+                            color: selectedTrack ? "#f87171" : "#475569",
+                            cursor: selectedTrack ? "pointer" : "not-allowed",
+                            opacity: selectedTrack ? 1 : 0.6,
                           }}
                         >
                           <span
                             className="material-symbols-outlined"
                             style={controlIconStyle}
                           >
-                            check
+                            delete
                           </span>
                         </button>
                         {selectedTrack && canRecordSelectedTrack ? (

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -951,6 +951,25 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
       <div
         ref={trackAreaRef}
         className="scrollable"
+        onPointerDownCapture={(event) => {
+          if (editing === null) return;
+          const target = event.target as HTMLElement;
+          const trackElement = target.closest("[data-track-id]") as
+            | HTMLElement
+            | null;
+          if (!trackElement) {
+            setEditing(null);
+            return;
+          }
+          const trackId = Number(trackElement.dataset.trackId ?? "");
+          if (!Number.isFinite(trackId)) {
+            setEditing(null);
+            return;
+          }
+          if (trackId !== editing) {
+            setEditing(trackId);
+          }
+        }}
         style={{
           flex: 1,
           position: "relative",
@@ -1026,6 +1045,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
               style={{ display: "flex", flexDirection: "column", gap: 8 }}
             >
               <div
+                data-track-id={t.id}
                 onPointerDown={(event) => {
                   swipeRef.current = event.clientX;
                 }}
@@ -1048,8 +1068,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                   border: isEditing ? "2px solid #27E0B0" : "1px solid #555",
                   background: "#111827",
                   opacity: editing !== null && !isEditing ? 0.4 : 1,
-                  pointerEvents:
-                    editing !== null && !isEditing ? "none" : "auto",
+                  pointerEvents: "auto",
                   transition: "opacity 0.2s ease, border 0.2s ease",
                 }}
               >


### PR DESCRIPTION
## Summary
- dismiss loop track editing when clicking outside the active row or switching to another track
- replace the done button with a delete control that confirms removal before deleting the track

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de94010b0883289afa8f5d041430dc