### PR TITLE
Align Song view controls with loop interface

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2278,36 +2278,6 @@ export default function App() {
     };
   }, []);
 
-  const handleCreateLoopFromSongView = useCallback(() => {
-    const newId = createPatternGroupId();
-    setPatternGroups((groups) => {
-      const name = getNextPatternGroupName(groups);
-      return [
-        ...groups,
-        {
-          id: newId,
-          name,
-          tracks: [],
-        },
-      ];
-    });
-    setSelectedGroupId(newId);
-    setTracks([]);
-    latestTracksRef.current = [];
-    currentLoopDraftRef.current = [];
-    setEditing(null);
-    skipLoopDraftRestoreRef.current = true;
-    setViewMode("track");
-    setPendingLoopStripAction(null);
-  }, [
-    setPatternGroups,
-    setSelectedGroupId,
-    setTracks,
-    setEditing,
-    setViewMode,
-    setPendingLoopStripAction,
-  ]);
-
   const handleConfirmAddTrack = useCallback(() => {
     if (!addTrackModalState.instrumentId || !addTrackModalState.packId) {
       closeAddTrackModal();
@@ -3332,7 +3302,6 @@ export default function App() {
                 bpm={bpm}
                 setBpm={setBpm}
                 onToggleTransport={handlePlayStop}
-                onCreateLoop={handleCreateLoopFromSongView}
                 performanceTracks={performanceTracks}
                 triggers={triggers}
                 onEnsurePerformanceRow={ensurePerformanceRow}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2278,19 +2278,6 @@ export default function App() {
     };
   }, []);
 
-  const handleSelectLoopFromSongView = useCallback(
-    (groupId: string) => {
-      setSelectedGroupId(groupId);
-      setEditing(null);
-      if (viewMode !== "track") {
-        skipLoopDraftRestoreRef.current = true;
-        setViewMode("track");
-        setPendingLoopStripAction(null);
-      }
-    },
-    [setSelectedGroupId, setEditing, viewMode, setPendingLoopStripAction]
-  );
-
   const handleCreateLoopFromSongView = useCallback(() => {
     const newId = createPatternGroupId();
     setPatternGroups((groups) => {
@@ -3346,8 +3333,6 @@ export default function App() {
                 setBpm={setBpm}
                 onToggleTransport={handlePlayStop}
                 onCreateLoop={handleCreateLoopFromSongView}
-                selectedGroupId={selectedGroupId}
-                onSelectLoop={handleSelectLoopFromSongView}
                 performanceTracks={performanceTracks}
                 triggers={triggers}
                 onEnsurePerformanceRow={ensurePerformanceRow}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import {
   createPerformanceSettingsSnapshot,
   createPerformanceTrackId,
   createSongRow,
+  getNextPatternGroupName,
   getPerformanceTracksSpanMeasures,
 } from "./song";
 import { AddTrackModal } from "./AddTrackModal";
@@ -2290,6 +2291,36 @@ export default function App() {
     [setSelectedGroupId, setEditing, viewMode, setPendingLoopStripAction]
   );
 
+  const handleCreateLoopFromSongView = useCallback(() => {
+    const newId = createPatternGroupId();
+    setPatternGroups((groups) => {
+      const name = getNextPatternGroupName(groups);
+      return [
+        ...groups,
+        {
+          id: newId,
+          name,
+          tracks: [],
+        },
+      ];
+    });
+    setSelectedGroupId(newId);
+    setTracks([]);
+    latestTracksRef.current = [];
+    currentLoopDraftRef.current = [];
+    setEditing(null);
+    skipLoopDraftRestoreRef.current = true;
+    setViewMode("track");
+    setPendingLoopStripAction(null);
+  }, [
+    setPatternGroups,
+    setSelectedGroupId,
+    setTracks,
+    setEditing,
+    setViewMode,
+    setPendingLoopStripAction,
+  ]);
+
   const handleConfirmAddTrack = useCallback(() => {
     if (!addTrackModalState.instrumentId || !addTrackModalState.packId) {
       closeAddTrackModal();
@@ -3314,6 +3345,7 @@ export default function App() {
                 bpm={bpm}
                 setBpm={setBpm}
                 onToggleTransport={handlePlayStop}
+                onCreateLoop={handleCreateLoopFromSongView}
                 selectedGroupId={selectedGroupId}
                 onSelectLoop={handleSelectLoopFromSongView}
                 performanceTracks={performanceTracks}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,6 @@ import {
   createPerformanceSettingsSnapshot,
   createPerformanceTrackId,
   createSongRow,
-  getNextPatternGroupName,
   getPerformanceTracksSpanMeasures,
 } from "./song";
 import { AddTrackModal } from "./AddTrackModal";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3325,6 +3325,16 @@ export default function App() {
                 onUpdatePerformanceTrack={updatePerformanceTrack}
                 onRemovePerformanceTrack={removePerformanceTrack}
                 onPlayInstrumentOpenChange={setIsSongInstrumentPanelOpen}
+                onSaveSong={openSaveProjectModal}
+                onOpenLoadSong={openLoadProjectModal}
+                onOpenExportSong={
+                  isAudioExporting
+                    ? undefined
+                    : () => {
+                        setAudioExportMessage("Preparing export…");
+                        setIsExportModalOpen(true);
+                      }
+                }
               />
             )}
           </div>

--- a/src/LoopStrip.tsx
+++ b/src/LoopStrip.tsx
@@ -27,7 +27,7 @@ import { packs, type InstrumentDefinition } from "./packs";
 import { IconButton } from "./components/IconButton";
 import { StepModal } from "./StepModal";
 import type { PatternGroup } from "./song";
-import { createPatternGroupId } from "./song";
+import { createPatternGroupId, getNextPatternGroupName } from "./song";
 import { isUserPresetId, loadInstrumentPreset, stripUserPresetPrefix } from "./presets";
 import { resolveInstrumentCharacterId } from "./instrumentCharacters";
 import { isIOSPWA } from "./utils/audio";
@@ -249,20 +249,6 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
     if (!selectedGroupId) return null;
     return patternGroups.find((group) => group.id === selectedGroupId) ?? null;
   }, [patternGroups, selectedGroupId]);
-
-  const getNextGroupName = (groups: PatternGroup[] = patternGroups) => {
-    const existingNames = new Set(
-      groups.map((group) => group.name.toLowerCase())
-    );
-    let index = 1;
-    while (true) {
-      const candidate = `Loop ${String(index).padStart(2, "0")}`;
-      if (!existingNames.has(candidate.toLowerCase())) {
-        return candidate;
-      }
-      index += 1;
-    }
-  };
 
   const captureCurrentTracks = () => tracks.map((track) => cloneTrack(track));
 
@@ -650,7 +636,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
   const openCreateGroup = () => {
     setGroupEditor({
       mode: "create",
-      name: getNextGroupName(),
+      name: getNextPatternGroupName(patternGroups),
     });
   };
 
@@ -658,7 +644,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
     const newId = createPatternGroupId();
     let created: PatternGroup | null = null;
     setPatternGroups((groups) => {
-      const name = getNextGroupName(groups);
+      const name = getNextPatternGroupName(groups);
       created = {
         id: newId,
         name,
@@ -710,7 +696,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
     const trimmed = groupEditor.name.trim();
     let created: PatternGroup | null = null;
     setPatternGroups((groups) => {
-      const name = trimmed || getNextGroupName(groups);
+      const name = trimmed || getNextPatternGroupName(groups);
       created = {
         id: newId,
         name,
@@ -787,7 +773,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
       if (filtered.length === 0) {
         const fallbackGroup: PatternGroup = {
           id: createPatternGroupId(),
-          name: getNextGroupName([]),
+          name: getNextPatternGroupName([]),
           tracks: [],
         };
         setSelectedGroupId(fallbackGroup.id);
@@ -1454,7 +1440,7 @@ export const LoopStrip = forwardRef<LoopStripHandle, LoopStripProps>(
                   onChange={(event) =>
                     handleEditorNameChange(event.target.value)
                   }
-                  placeholder={getNextGroupName()}
+                  placeholder={getNextPatternGroupName(patternGroups)}
                   style={{
                     padding: 8,
                     borderRadius: 8,

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -39,6 +39,7 @@ interface SongViewProps {
   bpm: number;
   setBpm: Dispatch<SetStateAction<number>>;
   onToggleTransport: () => void;
+  onCreateLoop?: () => void;
   selectedGroupId: string | null;
   onSelectLoop: (groupId: string) => void;
   performanceTracks: PerformanceTrack[];
@@ -492,6 +493,7 @@ export function SongView({
   bpm,
   setBpm,
   onToggleTransport,
+  onCreateLoop,
   selectedGroupId,
   onSelectLoop,
   performanceTracks,
@@ -1260,9 +1262,10 @@ export function SongView({
           >
             <IconButton
               icon="add"
-              label="Add loop column"
-              onClick={handleAddLoopColumn}
-              title="Add loop column"
+              label="Create new loop"
+              onClick={() => onCreateLoop?.()}
+              title="Create new loop"
+              disabled={!onCreateLoop}
               style={{
                 minWidth: 40,
                 minHeight: 40,

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1336,7 +1336,7 @@ export function SongView({
             value={selectedGroupId ?? patternGroups[0]?.id ?? ""}
             onChange={(event) => {
               const value = event.target.value;
-              onSelectLoop(value || null);
+              onSelectLoop(value);
               setRowSettingsIndex(null);
               setEditingSlot(null);
             }}

--- a/src/song.ts
+++ b/src/song.ts
@@ -37,6 +37,20 @@ export interface SongRow {
 export const createPatternGroupId = () =>
   `pg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
+export const getNextPatternGroupName = (
+  groups: PatternGroup[]
+): string => {
+  const existing = new Set(groups.map((group) => group.name.toLowerCase()));
+  let index = 1;
+  while (true) {
+    const candidate = `Loop ${String(index).padStart(2, "0")}`;
+    if (!existing.has(candidate.toLowerCase())) {
+      return candidate;
+    }
+    index += 1;
+  }
+};
+
 export const createSongRow = (length = 0): SongRow => ({
   slots: Array.from({ length }, () => null),
   muted: false,


### PR DESCRIPTION
## Summary
- align the Song view toolbar with the Loops UI by adding the loop selector row with transport, save, and overflow controls
- add a timeline toolbar that supports + Loop/+ Row/+ Track actions, expand/collapse, and contextual performance track controls
- remove the embedded loop library and wire Song view to host song save/load/export actions via App callbacks

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68deae169ff083288908e33702fb8259