### PR TITLE
Align Song view toolbar with Loops layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -416,8 +416,6 @@ export default function App() {
   const [songRows, setSongRows] = useState<SongRow[]>([
     createSongRow(),
   ]);
-  const [isSongInstrumentPanelOpen, setIsSongInstrumentPanelOpen] =
-    useState(false);
   const [isSongOptionsMenuOpen, setIsSongOptionsMenuOpen] = useState(false);
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const loopStripRef = useRef<LoopStripHandle | null>(null);
@@ -493,12 +491,6 @@ export default function App() {
   useEffect(() => {
     latestTracksRef.current = tracks;
   }, [tracks]);
-
-  useEffect(() => {
-    if (viewMode !== "song") {
-      setIsSongInstrumentPanelOpen(false);
-    }
-  }, [viewMode]);
 
   const loopStateSignature = useMemo(
     () =>
@@ -3351,7 +3343,6 @@ export default function App() {
                 onSelectPerformanceTrack={setActivePerformanceTrackId}
                 onUpdatePerformanceTrack={updatePerformanceTrack}
                 onRemovePerformanceTrack={removePerformanceTrack}
-                onPlayInstrumentOpenChange={setIsSongInstrumentPanelOpen}
                 onSaveSong={openSaveProjectModal}
                 onOpenSongOptions={openSongOptionsMenu}
               />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -418,6 +418,7 @@ export default function App() {
   ]);
   const [isSongInstrumentPanelOpen, setIsSongInstrumentPanelOpen] =
     useState(false);
+  const [isSongOptionsMenuOpen, setIsSongOptionsMenuOpen] = useState(false);
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const loopStripRef = useRef<LoopStripHandle | null>(null);
   const currentLoopDraftRef = useRef<Track[] | null>(null);
@@ -1717,6 +1718,25 @@ export default function App() {
     setProjectModalError(null);
   };
 
+  const openSongOptionsMenu = () => {
+    setIsSongOptionsMenuOpen(true);
+  };
+
+  const closeSongOptionsMenu = () => {
+    setIsSongOptionsMenuOpen(false);
+  };
+
+  const handleOpenLoadFromSongOptions = () => {
+    closeSongOptionsMenu();
+    openLoadProjectModal();
+  };
+
+  const handleOpenExportFromSongOptions = () => {
+    closeSongOptionsMenu();
+    setAudioExportMessage("Preparing export…");
+    setIsExportModalOpen(true);
+  };
+
   const closeProjectModal = () => {
     setProjectModalMode(null);
     setProjectNameInput("");
@@ -2497,6 +2517,38 @@ export default function App() {
         }
       />
 
+      {isSongOptionsMenuOpen ? (
+        <Modal
+          isOpen={isSongOptionsMenuOpen}
+          onClose={closeSongOptionsMenu}
+          title="Song options"
+          maxWidth={360}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+            }}
+          >
+            <IconButton
+              icon="folder_open"
+              label="Load song"
+              showLabel
+              tone="accent"
+              onClick={handleOpenLoadFromSongOptions}
+            />
+            <IconButton
+              icon="file_download"
+              label="Export song"
+              showLabel
+              onClick={handleOpenExportFromSongOptions}
+              disabled={isAudioExporting}
+            />
+          </div>
+        </Modal>
+      ) : null}
+
       {projectModalMode && (
         <Modal
           isOpen={projectModalMode !== null}
@@ -2936,31 +2988,6 @@ export default function App() {
               setEditing(null);
               setViewMode("song");
             }}
-            actions={
-              viewMode === "song" && !isSongInstrumentPanelOpen ? (
-                <>
-                  <IconButton
-                    icon="save"
-                    label="Save song"
-                    onClick={openSaveProjectModal}
-                  />
-                  <IconButton
-                    icon="folder_open"
-                    label="Load song"
-                    onClick={openLoadProjectModal}
-                  />
-                  <IconButton
-                    icon="file_download"
-                    label="Open export options"
-                    onClick={() => {
-                      setAudioExportMessage("Preparing export…");
-                      setIsExportModalOpen(true);
-                    }}
-                    disabled={isAudioExporting}
-                  />
-                </>
-              ) : undefined
-            }
           />
           {viewMode === "track" && (
             <LoopStrip
@@ -3325,6 +3352,8 @@ export default function App() {
                 onUpdatePerformanceTrack={updatePerformanceTrack}
                 onRemovePerformanceTrack={removePerformanceTrack}
                 onPlayInstrumentOpenChange={setIsSongInstrumentPanelOpen}
+                onSaveSong={openSaveProjectModal}
+                onOpenSongOptions={openSongOptionsMenu}
               />
             )}
           </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -50,7 +50,6 @@ interface SongViewProps {
   activePerformanceTrackId: string | null;
   onAddPerformanceTrack?: () => void;
   onSelectPerformanceTrack?: (trackId: string | null) => void;
-  onPlayInstrumentOpenChange?: (open: boolean) => void;
   onUpdatePerformanceTrack?: (
     trackId: string,
     updater: (track: PerformanceTrack) => PerformanceTrack
@@ -547,7 +546,6 @@ export function SongView({
   activePerformanceTrackId,
   onAddPerformanceTrack,
   onSelectPerformanceTrack,
-  onPlayInstrumentOpenChange,
   onUpdatePerformanceTrack,
   onRemovePerformanceTrack,
   onSaveSong,
@@ -591,10 +589,6 @@ export function SongView({
       ),
     [performanceTracks]
   );
-
-  useEffect(() => {
-    onPlayInstrumentOpenChange?.(isPlayInstrumentOpen);
-  }, [isPlayInstrumentOpen, onPlayInstrumentOpenChange]);
 
   const applyPerformanceSettings = useCallback(
     (pattern: Chunk) => {

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -56,6 +56,8 @@ interface SongViewProps {
     updater: (track: PerformanceTrack) => PerformanceTrack
   ) => void;
   onRemovePerformanceTrack?: (trackId: string) => void;
+  onSaveSong?: () => void;
+  onOpenSongOptions?: () => void;
 }
 
 const SLOT_WIDTH = 150;
@@ -72,6 +74,54 @@ const SLOT_PADDING = "4px 10px";
 const APPROXIMATE_ROW_OFFSET = 28;
 const TIMELINE_VISIBLE_ROWS_COLLAPSED = 1.5;
 const TIMELINE_VISIBLE_ROWS_EXPANDED = 3;
+
+const CONTROL_BUTTON_SIZE = 44;
+
+const controlButtonBaseStyle: CSSProperties = {
+  width: CONTROL_BUTTON_SIZE,
+  height: CONTROL_BUTTON_SIZE,
+  borderRadius: CONTROL_BUTTON_SIZE / 2,
+  border: "1px solid #333",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  cursor: "pointer",
+};
+
+const controlIconStyle: CSSProperties = {
+  fontSize: 24,
+};
+
+const transportDividerStyle: CSSProperties = {
+  width: 1,
+  height: 24,
+  background: "#333",
+};
+
+const bpmLabelStyle: CSSProperties = {
+  fontSize: 12,
+  letterSpacing: 0.2,
+  color: "#cbd5f5",
+  whiteSpace: "nowrap",
+};
+
+const bpmSelectStyle: CSSProperties = {
+  padding: 8,
+  borderRadius: 8,
+  background: "#121827",
+  color: "#e6f2ff",
+  width: "100%",
+  minWidth: 0,
+};
+
+const toolbarActionButtonBaseStyle: CSSProperties = {
+  minWidth: 40,
+  minHeight: 40,
+  borderRadius: 999,
+  border: "1px solid #2f384a",
+  background: "#1f2532",
+  color: "#94a3b8",
+};
 
 const TICKS_PER_QUARTER = Tone.Transport.PPQ;
 const TICKS_PER_SIXTEENTH = TICKS_PER_QUARTER / 4;
@@ -500,6 +550,8 @@ export function SongView({
   onPlayInstrumentOpenChange,
   onUpdatePerformanceTrack,
   onRemovePerformanceTrack,
+  onSaveSong,
+  onOpenSongOptions,
 }: SongViewProps) {
   const [editingSlot, setEditingSlot] = useState<
     { rowIndex: number; columnIndex: number } | null
@@ -2060,56 +2112,99 @@ export function SongView({
           display: "flex",
           alignItems: "center",
           gap: 12,
+          flexWrap: "nowrap",
         }}
       >
+        <span
+          style={{
+            fontSize: 16,
+            fontWeight: 600,
+            color: "#e6f2ff",
+          }}
+        >
+          Timeline
+        </span>
         <div
           style={{
             display: "flex",
             alignItems: "center",
             gap: 12,
+            flex: 1,
+            minWidth: 0,
+            flexWrap: "nowrap",
           }}
         >
-          <label>BPM</label>
-          <select
-            value={bpm}
-            onChange={(e) => setBpm(parseInt(e.target.value, 10))}
-            style={{
-              padding: 8,
-              borderRadius: 8,
-              background: "#121827",
-              color: "white",
-            }}
-          >
-            {[90, 100, 110, 120, 130].map((value) => (
-              <option key={value} value={value}>
-                {value}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div style={{ flex: 1 }} />
-        <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
           <button
             aria-label={isPlaying ? "Stop" : "Play"}
             onPointerDown={onToggleTransport}
             onPointerUp={(e) => e.currentTarget.blur()}
             style={{
-              width: 44,
-              height: 44,
-              borderRadius: 8,
-              border: "1px solid #333",
+              ...controlButtonBaseStyle,
               background: isPlaying ? "#E02749" : "#27E0B0",
               color: isPlaying ? "#ffe4e6" : "#1F2532",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
               fontSize: 24,
             }}
           >
-            <span className="material-symbols-outlined">
+            <span
+              className="material-symbols-outlined"
+              style={controlIconStyle}
+            >
               {isPlaying ? "stop" : "play_arrow"}
             </span>
           </button>
+          <div style={transportDividerStyle} />
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+              flex: "0 1 120px",
+              minWidth: 0,
+            }}
+          >
+            <label style={bpmLabelStyle}>BPM</label>
+            <select
+              value={bpm}
+              onChange={(e) => setBpm(parseInt(e.target.value, 10))}
+              style={bpmSelectStyle}
+            >
+              {[90, 100, 110, 120, 130].map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            alignItems: "center",
+            flexShrink: 0,
+          }}
+        >
+          <IconButton
+            icon="save"
+            label="Save song"
+            onClick={onSaveSong}
+            disabled={!onSaveSong}
+            style={{
+              ...toolbarActionButtonBaseStyle,
+              background: onSaveSong ? "#27E0B0" : "#1f2532",
+              border: `1px solid ${onSaveSong ? "#27E0B0" : "#2f384a"}`,
+              color: onSaveSong ? "#0b1220" : "#94a3b8",
+            }}
+            title="Save song"
+          />
+          <IconButton
+            icon="more_horiz"
+            label="Song options"
+            onClick={onOpenSongOptions}
+            disabled={!onOpenSongOptions}
+            style={toolbarActionButtonBaseStyle}
+            title="Song options"
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- restyle the Song view toolbar to mirror the Loops controls with timeline label, circular transport, BPM select, and save/overflow actions
- add a Song options modal that exposes load/export actions triggered from the overflow button and pass the callbacks through App

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68deee45e4b0832898367d4071031e63