### PR TITLE
Refine SongView layout to match design

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import {
 import { AddTrackModal } from "./AddTrackModal";
 import { Modal } from "./components/Modal";
 import { IconButton } from "./components/IconButton";
+import { OverflowMenuButton } from "./components/OverflowMenuButton";
 import { SavedSongsList } from "./components/SavedSongsList";
 import ViewHeader, {
   getViewHeaderSections,
@@ -2436,21 +2437,25 @@ export default function App() {
               <IconButton
                 icon="save"
                 label="Save song"
+                size="compact"
                 onClick={openSaveProjectModal}
               />
-              <IconButton
-                icon="folder_open"
-                label="Load song"
-                onClick={openLoadProjectModal}
-              />
-              <IconButton
-                icon="file_download"
-                label="Open export options"
-                onClick={() => {
-                  setAudioExportMessage("Preparing export…");
-                  setIsExportModalOpen(true);
-                }}
-                disabled={isAudioExporting}
+              <OverflowMenuButton
+                label="More song actions"
+                items={[
+                  {
+                    label: "Load song",
+                    onSelect: openLoadProjectModal,
+                  },
+                  {
+                    label: "Export",
+                    onSelect: () => {
+                      setAudioExportMessage("Preparing export…");
+                      setIsExportModalOpen(true);
+                    },
+                    disabled: isAudioExporting,
+                  },
+                ]}
               />
             </>
           )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2282,19 +2282,6 @@ export default function App() {
     };
   }, []);
 
-  const handleSelectLoopFromSongView = useCallback(
-    (groupId: string) => {
-      setSelectedGroupId(groupId);
-      setEditing(null);
-      if (viewMode !== "track") {
-        skipLoopDraftRestoreRef.current = true;
-        setViewMode("track");
-        setPendingLoopStripAction(null);
-      }
-    },
-    [setSelectedGroupId, setEditing, viewMode, setPendingLoopStripAction]
-  );
-
   const handleConfirmAddTrack = useCallback(() => {
     if (!addTrackModalState.instrumentId || !addTrackModalState.packId) {
       closeAddTrackModal();
@@ -3401,8 +3388,6 @@ export default function App() {
               bpm={bpm}
               setBpm={setBpm}
               onToggleTransport={handlePlayStop}
-              selectedGroupId={selectedGroupId}
-              onSelectLoop={handleSelectLoopFromSongView}
               performanceTracks={performanceTracks}
               triggers={triggers}
               onEnsurePerformanceRow={ensurePerformanceRow}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -422,8 +422,7 @@ export default function App() {
   const [songRows, setSongRows] = useState<SongRow[]>([
     createSongRow(),
   ]);
-  const [isSongInstrumentPanelOpen, setIsSongInstrumentPanelOpen] =
-    useState(false);
+  const [, setIsSongInstrumentPanelOpen] = useState(false);
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const loopStripRef = useRef<LoopStripHandle | null>(null);
   const currentLoopDraftRef = useRef<Track[] | null>(null);
@@ -2430,39 +2429,37 @@ export default function App() {
       setEditing(null);
       setViewMode("song");
     },
-    actions:
-      viewMode === "song" && !isSongInstrumentPanelOpen
-        ? (
-            <>
-              <IconButton
-                icon="save"
-                label="Save song"
-                size="compact"
-                onClick={openSaveProjectModal}
-              />
-              <OverflowMenuButton
-                label="More song actions"
-                items={[
-                  {
-                    label: "Load song",
-                    onSelect: openLoadProjectModal,
-                  },
-                  {
-                    label: "Export",
-                    onSelect: () => {
-                      setAudioExportMessage("Preparing export…");
-                      setIsExportModalOpen(true);
-                    },
-                    disabled: isAudioExporting,
-                  },
-                ]}
-              />
-            </>
-          )
-        : undefined,
   };
 
   const viewHeaderSections = getViewHeaderSections(viewHeaderProps);
+
+  const songTimelineActions = (
+    <>
+      <IconButton
+        icon="save"
+        label="Save song"
+        size="compact"
+        onClick={openSaveProjectModal}
+      />
+      <OverflowMenuButton
+        label="More song actions"
+        items={[
+          {
+            label: "Load song",
+            onSelect: openLoadProjectModal,
+          },
+          {
+            label: "Export",
+            onSelect: () => {
+              setAudioExportMessage("Preparing export…");
+              setIsExportModalOpen(true);
+            },
+            disabled: isAudioExporting,
+          },
+        ]}
+      />
+    </>
+  );
 
   const renderViewHeader = (
     variant: ViewHeaderProps["variant"] = "stacked"
@@ -3402,6 +3399,7 @@ export default function App() {
               onUpdatePerformanceTrack={updatePerformanceTrack}
               onRemovePerformanceTrack={removePerformanceTrack}
               onPlayInstrumentOpenChange={setIsSongInstrumentPanelOpen}
+              timelineActions={songTimelineActions}
             />
           </div>
         </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,10 @@ import { AddTrackModal } from "./AddTrackModal";
 import { Modal } from "./components/Modal";
 import { IconButton } from "./components/IconButton";
 import { SavedSongsList } from "./components/SavedSongsList";
-import { ViewHeader } from "./components/ViewHeader";
+import ViewHeader, {
+  getViewHeaderSections,
+  type ViewHeaderProps,
+} from "./components/ViewHeader";
 import { getCharacterOptions } from "./addTrackOptions";
 import { InstrumentControlPanel } from "./InstrumentControlPanel";
 import { exportProjectAudio, exportProjectJson } from "./exporter";
@@ -2428,45 +2431,50 @@ export default function App() {
     [tracks, addTrackModalState.mode, addTrackModalState.targetTrackId]
   );
 
-  const renderViewHeader = () => (
-    <ViewHeader
-      viewMode={viewMode}
-      onBack={handleReturnToSongSelection}
-      onSelectTrack={() => {
-        skipLoopDraftRestoreRef.current = false;
-        setViewMode("track");
-      }}
-      onSelectSong={() => {
-        setEditing(null);
-        setViewMode("song");
-      }}
-      actions={
-        viewMode === "song" && !isSongInstrumentPanelOpen ? (
-          <>
-            <IconButton
-              icon="save"
-              label="Save song"
-              onClick={openSaveProjectModal}
-            />
-            <IconButton
-              icon="folder_open"
-              label="Load song"
-              onClick={openLoadProjectModal}
-            />
-            <IconButton
-              icon="file_download"
-              label="Open export options"
-              onClick={() => {
-                setAudioExportMessage("Preparing export…");
-                setIsExportModalOpen(true);
-              }}
-              disabled={isAudioExporting}
-            />
-          </>
-        ) : undefined
-      }
-    />
-  );
+  const viewHeaderProps: ViewHeaderProps = {
+    viewMode,
+    onBack: handleReturnToSongSelection,
+    onSelectTrack: () => {
+      skipLoopDraftRestoreRef.current = false;
+      setViewMode("track");
+    },
+    onSelectSong: () => {
+      setEditing(null);
+      setViewMode("song");
+    },
+    actions:
+      viewMode === "song" && !isSongInstrumentPanelOpen
+        ? (
+            <>
+              <IconButton
+                icon="save"
+                label="Save song"
+                onClick={openSaveProjectModal}
+              />
+              <IconButton
+                icon="folder_open"
+                label="Load song"
+                onClick={openLoadProjectModal}
+              />
+              <IconButton
+                icon="file_download"
+                label="Open export options"
+                onClick={() => {
+                  setAudioExportMessage("Preparing export…");
+                  setIsExportModalOpen(true);
+                }}
+                disabled={isAudioExporting}
+              />
+            </>
+          )
+        : undefined,
+  };
+
+  const viewHeaderSections = getViewHeaderSections(viewHeaderProps);
+
+  const renderViewHeader = (
+    variant: ViewHeaderProps["variant"] = "stacked"
+  ) => <ViewHeader {...viewHeaderProps} variant={variant} />;
 
   const handleNewSongClick = () => {
     unlockAndRun(createNewProject);
@@ -3348,7 +3356,9 @@ export default function App() {
               </div>
             </>
           }
-          topBarCenter={renderViewHeader()}
+          topBarLeft={viewHeaderSections.left}
+          topBarCenter={viewHeaderSections.center}
+          topBarRight={viewHeaderSections.right ?? undefined}
           transport={renderLoopTransportControls()}
           controls={renderLoopInstrumentPanelContent()}
         >

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1096,11 +1096,8 @@ export function SongView({
   const slotGap = SLOT_CONTENT_GAP;
   const isTrackSelected = isPlayInstrumentOpen;
   const collapsedTimelineFlex = "0 0 45%";
-  const timelineFlex = isTrackSelected
-    ? isTimelineExpanded
-      ? "1 1 auto"
-      : collapsedTimelineFlex
-    : "1 1 auto";
+  const timelineFlex =
+    isTrackSelected && !isTimelineExpanded ? collapsedTimelineFlex : "1 1 auto";
   const instrumentFlex = isTrackSelected ? "1 1 auto" : "0 0 0";
   const panelInstrument = activePerformanceTrack?.instrument ?? playInstrument;
   const playInstrumentColor = useMemo(
@@ -2301,7 +2298,12 @@ export function SongView({
 
       </div>
 
-      <BottomDock>
+      <BottomDock
+        style={{
+          flex: "0 0 auto",
+          marginTop: "auto",
+        }}
+      >
         <div style={TRANSPORT_CONTAINER_STYLE}>
           <div style={{ display: "flex", alignItems: "center" }}>
             <button

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1101,6 +1101,7 @@ export function SongView({
       ? "1 1 auto"
       : collapsedTimelineFlex
     : "1 1 auto";
+  const instrumentFlex = isTrackSelected ? "1 1 auto" : "0 0 0";
   const panelInstrument = activePerformanceTrack?.instrument ?? playInstrument;
   const playInstrumentColor = useMemo(
     () => getInstrumentColor(panelInstrument),
@@ -1774,10 +1775,8 @@ export function SongView({
 
   return (
     <div
-      className="vh flex flex-col"
+      className="flex flex-col h-full"
       style={{
-        display: "flex",
-        flexDirection: "column",
         flex: 1,
         minHeight: 0,
       }}
@@ -1872,106 +1871,330 @@ export function SongView({
               </div>
             </div>
             <div
-              className="min-h-0 scroll-y"
+              className="min-h-0"
               style={{
-                flex: timelineFlex,
+                flex: 1,
                 minHeight: 0,
-                overflowY: "auto",
-                padding: 0,
-                transition: "flex 180ms ease",
+                display: "flex",
+                flexDirection: "column",
+                gap: 16,
               }}
             >
-              <div className="min-h-0" style={{ height: "100%" }}>
+              <div
+                className="min-h-0 scroll-y"
+                style={{
+                  flex: timelineFlex,
+                  minHeight: 0,
+                  overflowY: "auto",
+                  transition: "flex-basis 180ms ease",
+                }}
+              >
+                <div className="min-h-0" style={{ height: "100%" }}>
+                  <div
+                    className="scrollable"
+                    style={{
+                      overflowX: "auto",
+                      paddingBottom: 4,
+                      height: "100%",
+                      minHeight: "100%",
+                    }}
+                  >
+                    {sectionCount > 0 ? (
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          marginBottom: 8,
+                        }}
+                      >
+                        <div style={{ width: ROW_LABEL_WIDTH, flexShrink: 0 }} />
+                        <div style={{ flex: 1, overflow: "hidden" }}>
+                          <div
+                            style={{
+                              display: "grid",
+                              gridTemplateColumns: `repeat(${sectionCount}, ${SLOT_WIDTH}px)`,
+                              gap: SLOT_GAP,
+                              width: timelineWidthStyle,
+                              minWidth: timelineWidthStyle,
+                            }}
+                          >
+                            {timelineColumns
+                              .filter((column) => column.hasSection)
+                              .map((column) => (
+                                <button
+                                  key={`delete-column-${column.index}`}
+                                  type="button"
+                                  onClick={() => handleDeleteColumn(column.index)}
+                                  style={{
+                                    padding: "4px 8px",
+                                    borderRadius: 16,
+                                    border: "1px solid #2a3344",
+                                    background: "#111827",
+                                    color: "#e2e8f0",
+                                    fontSize: 11,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    gap: 4,
+                                    cursor: "pointer",
+                                  }}
+                                >
+                                  <span
+                                    className="material-symbols-outlined"
+                                    style={{ fontSize: 14 }}
+                                  >
+                                    delete
+                                  </span>
+                                  <span>Seq {column.index + 1}</span>
+                                </button>
+                              ))}
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
+                    <div
+                      style={{
+                        width: timelineWidthStyle,
+                        minWidth: timelineWidthStyle,
+                      }}
+                    >
+                      {showEmptyTimeline ? (
+                        <div
+                          style={{
+                            padding: 24,
+                            borderRadius: 8,
+                            border: "1px dashed #475569",
+                            color: "#94a3b8",
+                            fontSize: 13,
+                          }}
+                        >
+                          Add a sequence to start placing loops into the timeline.
+                        </div>
+                      ) : (
+                        <TimelineGrid
+                          rows={timelineRows}
+                          columns={timelineColumns}
+                          renderCell={renderTimelineCell}
+                          renderRow={(row, cols, cellRenderer) =>
+                            renderTimelineRow(row, cols, cellRenderer)
+                          }
+                        />
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="min-h-0"
+                style={{
+                  flex: instrumentFlex,
+                  minHeight: 0,
+                  overflowY: "auto",
+                  transition: "flex-basis 180ms ease",
+                  opacity: isTrackSelected ? 1 : 0,
+                  pointerEvents: isTrackSelected ? "auto" : "none",
+                }}
+                aria-hidden={!isTrackSelected}
+              >
                 <div
-                  className="scrollable"
                   style={{
-                    overflowX: "auto",
-                    paddingBottom: 4,
                     height: "100%",
-                    minHeight: "100%",
+                    padding: isTrackSelected ? "12px 16px 16px" : 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 12,
+                    boxSizing: "border-box",
+                    background: "#0b1220",
+                    borderTop: "1px solid #1f2937",
                   }}
                 >
-                  {sectionCount > 0 ? (
+                  <div
+                    className="scrollable"
+                    style={{
+                      flex: 1,
+                      minHeight: 0,
+                      borderRadius: 12,
+                      border: "1px solid #2a3344",
+                      background: "#111827",
+                      padding: 16,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 16,
+                      overflowY: "auto",
+                      opacity: isPlayInstrumentOpen ? 1 : 0,
+                      pointerEvents: isPlayInstrumentOpen ? "auto" : "none",
+                      transition: "opacity 180ms ease",
+                    }}
+                  >
                     <div
                       style={{
                         display: "flex",
                         alignItems: "center",
-                        marginBottom: 8,
+                        justifyContent: "space-between",
+                        flexWrap: "wrap",
+                        gap: 12,
                       }}
                     >
-                      <div style={{ width: ROW_LABEL_WIDTH, flexShrink: 0 }} />
-                      <div style={{ flex: 1, overflow: "hidden" }}>
-                        <div
+                      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                        <span
+                          aria-hidden="true"
                           style={{
-                            display: "grid",
-                            gridTemplateColumns: `repeat(${sectionCount}, ${SLOT_WIDTH}px)`,
-                            gap: SLOT_GAP,
-                            width: timelineWidthStyle,
-                            minWidth: timelineWidthStyle,
+                            width: 12,
+                            height: 12,
+                            borderRadius: 999,
+                            background: playInstrumentColor,
+                            boxShadow: `0 0 10px ${withAlpha(playInstrumentColor, 0.45)}`,
+                          }}
+                        />
+                        <span
+                          style={{
+                            fontSize: 14,
+                            fontWeight: 600,
+                            color: "#e6f2ff",
+                            letterSpacing: 0.2,
                           }}
                         >
-                          {timelineColumns
-                            .filter((column) => column.hasSection)
-                            .map((column) => (
-                              <button
-                                key={`delete-column-${column.index}`}
-                                type="button"
-                                onClick={() => handleDeleteColumn(column.index)}
-                                style={{
-                                  padding: "4px 8px",
-                                  borderRadius: 16,
-                                  border: "1px solid #2a3344",
-                                  background: "#111827",
-                                  color: "#e2e8f0",
-                                  fontSize: 11,
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  gap: 4,
-                                  cursor: "pointer",
-                                }}
-                              >
-                                <span
-                                  className="material-symbols-outlined"
-                                  style={{ fontSize: 14 }}
-                                >
-                                  delete
-                                </span>
-                                <span>Seq {column.index + 1}</span>
-                              </button>
-                            ))}
-                        </div>
+                          {formatInstrumentLabel(playInstrument)} Instrument
+                        </span>
                       </div>
-                    </div>
-                  ) : null}
-                  <div
-                    style={{
-                      width: timelineWidthStyle,
-                      minWidth: timelineWidthStyle,
-                    }}
-                  >
-                    {showEmptyTimeline ? (
                       <div
                         style={{
-                          padding: 24,
-                          borderRadius: 8,
-                          border: "1px dashed #475569",
-                          color: "#94a3b8",
-                          fontSize: 13,
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 8,
+                          flexWrap: "wrap",
+                          justifyContent: "flex-end",
                         }}
                       >
-                        Add a sequence to start placing loops into the timeline.
+                        <IconButton
+                          icon="close"
+                          label="Close"
+                          showLabel
+                          onClick={handleCloseInstrumentPanel}
+                        />
+                        <IconButton
+                          icon={recordingActive ? "stop" : "fiber_manual_record"}
+                          label={recordingActive ? "Stop" : "Record"}
+                          showLabel
+                          tone={recordingActive ? "danger" : "default"}
+                          onClick={() => setIsRecordEnabled((prev) => !prev)}
+                          disabled={!hasPerformanceTarget}
+                        />
+                        <IconButton
+                          icon="delete"
+                          label="Clear"
+                          showLabel
+                          tone="danger"
+                          onClick={handleClearRecording}
+                          disabled={!canClearRecording}
+                        />
                       </div>
-                    ) : (
-                      <TimelineGrid
-                        rows={timelineRows}
-                        columns={timelineColumns}
-                        renderCell={renderTimelineCell}
-                        renderRow={(row, cols, cellRenderer) =>
-                          renderTimelineRow(row, cols, cellRenderer)
+                    </div>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        flexWrap: "wrap",
+                        gap: 12,
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 10,
+                          flexWrap: "wrap",
+                        }}
+                      >
+                        {isRecordEnabled ? (
+                          <span
+                            style={{
+                              display: "inline-flex",
+                              alignItems: "center",
+                              gap: 6,
+                              padding: "4px 10px",
+                              borderRadius: 999,
+                              fontSize: 11,
+                              fontWeight: 700,
+                              letterSpacing: 0.6,
+                              textTransform: "uppercase",
+                              background: recordingActive
+                                ? "rgba(248, 113, 113, 0.24)"
+                                : "rgba(248, 113, 113, 0.14)",
+                              border: `1px solid ${
+                                recordingActive ? "#f87171" : "#fb7185"
+                              }`,
+                              color: "#fecdd3",
+                              boxShadow: recordingActive
+                                ? `0 0 12px ${withAlpha("#f87171", 0.35)}`
+                                : "none",
+                            }}
+                          >
+                            <span
+                              className="material-symbols-outlined"
+                              style={{ fontSize: 14 }}
+                              aria-hidden="true"
+                            >
+                              fiber_manual_record
+                            </span>
+                            {recordIndicatorLabel}
+                          </span>
+                        ) : null}
+                        <span style={{ fontSize: 12, color: "#94a3b8" }}>
+                          {liveRowMessage}
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setIsQuantizedRecording((prev) => !prev)}
+                        style={{
+                          padding: "6px 12px",
+                          borderRadius: 999,
+                          border: `1px solid ${
+                            isQuantizedRecording ? playInstrumentColor : "#2a3344"
+                          }`,
+                          background: isQuantizedRecording
+                            ? withAlpha(playInstrumentColor, 0.18)
+                            : "#0f172a",
+                          color: "#e6f2ff",
+                          fontSize: 11,
+                          fontWeight: 600,
+                          letterSpacing: 0.8,
+                          textTransform: "uppercase",
+                          cursor: "pointer",
+                        }}
+                        title={
+                          isQuantizedRecording
+                            ? "Quantized recording is on — notes snap to the grid."
+                            : "Quantized recording is off — capture free timing."
                         }
+                      >
+                        Quantize {isQuantizedRecording ? "On" : "Off"}
+                      </button>
+                    </div>
+                    <div
+                      style={{
+                        borderRadius: 12,
+                        border: "1px solid #1f2937",
+                        background: "#10192c",
+                        padding: 12,
+                        flex: 1,
+                        minHeight: 0,
+                      }}
+                    >
+                      <InstrumentControlPanel
+                        track={playInstrumentTrackForPanel}
+                        allTracks={[]}
+                        onUpdatePattern={handlePlayInstrumentPatternUpdate}
+                        trigger={playInstrumentTrigger}
+                        isRecording={recordingActive}
+                        onPerformanceNote={handlePerformanceNoteRecorded}
                       />
-                    )}
+                    </div>
+                    <span style={{ fontSize: 12, color: "#94a3b8" }}>
+                      Audition sounds or capture a new take for this performance row.
+                    </span>
                   </div>
                 </div>
               </div>
@@ -2140,220 +2363,6 @@ export function SongView({
         </div>
       </BottomDock>
 
-      <BottomDock
-        heightVar="var(--controls-h)"
-        show={isPlayInstrumentOpen}
-        inertWhenHidden
-        style={{
-          flex: isTrackSelected ? "1 1 auto" : "0 0 0",
-          height: isTrackSelected ? "auto" : 0,
-          minHeight: 0,
-          overflowY: "auto",
-          transition: "flex 180ms ease",
-        }}
-      >
-        <div
-          style={{
-            height: "100%",
-            padding: "12px 16px 16px",
-            display: "flex",
-            flexDirection: "column",
-            gap: 12,
-            boxSizing: "border-box",
-            background: "#0b1220",
-            borderTop: "1px solid #1f2937",
-          }}
-        >
-          <div
-            className="scrollable"
-            style={{
-              flex: 1,
-              minHeight: 0,
-              borderRadius: 12,
-          border: "1px solid #2a3344",
-          background: "#111827",
-          padding: 16,
-          display: "flex",
-          flexDirection: "column",
-          gap: 16,
-          overflowY: "auto",
-          opacity: isPlayInstrumentOpen ? 1 : 0,
-          pointerEvents: isPlayInstrumentOpen ? "auto" : "none",
-          transition: "opacity 180ms ease",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            flexWrap: "wrap",
-            gap: 12,
-          }}
-        >
-          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-            <span
-              aria-hidden="true"
-              style={{
-                width: 12,
-                height: 12,
-                borderRadius: 999,
-                background: playInstrumentColor,
-                boxShadow: `0 0 10px ${withAlpha(playInstrumentColor, 0.45)}`,
-              }}
-            />
-            <span
-              style={{
-                fontSize: 14,
-                fontWeight: 600,
-                color: "#e6f2ff",
-                letterSpacing: 0.2,
-              }}
-            >
-              {formatInstrumentLabel(playInstrument)} Instrument
-            </span>
-          </div>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              flexWrap: "wrap",
-              justifyContent: "flex-end",
-            }}
-          >
-            <IconButton
-              icon="close"
-              label="Close"
-              showLabel
-              onClick={handleCloseInstrumentPanel}
-            />
-            <IconButton
-              icon={recordingActive ? "stop" : "fiber_manual_record"}
-              label={recordingActive ? "Stop" : "Record"}
-              showLabel
-              tone={recordingActive ? "danger" : "default"}
-              onClick={() => setIsRecordEnabled((prev) => !prev)}
-              disabled={!hasPerformanceTarget}
-            />
-            <IconButton
-              icon="delete"
-              label="Clear"
-              showLabel
-              tone="danger"
-              onClick={handleClearRecording}
-              disabled={!canClearRecording}
-            />
-          </div>
-        </div>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            flexWrap: "wrap",
-            gap: 12,
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              flexWrap: "wrap",
-            }}
-          >
-            {isRecordEnabled ? (
-              <span
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 6,
-                  padding: "4px 10px",
-                  borderRadius: 999,
-                  fontSize: 11,
-                  fontWeight: 700,
-                  letterSpacing: 0.6,
-                  textTransform: "uppercase",
-                  background: recordingActive
-                    ? "rgba(248, 113, 113, 0.24)"
-                    : "rgba(248, 113, 113, 0.14)",
-                  border: `1px solid ${
-                    recordingActive ? "#f87171" : "#fb7185"
-                  }`,
-                  color: "#fecdd3",
-                  boxShadow: recordingActive
-                    ? `0 0 12px ${withAlpha("#f87171", 0.35)}`
-                    : "none",
-                }}
-              >
-                <span
-                  className="material-symbols-outlined"
-                  style={{ fontSize: 14 }}
-                  aria-hidden="true"
-                >
-                  fiber_manual_record
-                </span>
-                {recordIndicatorLabel}
-              </span>
-            ) : null}
-            <span style={{ fontSize: 12, color: "#94a3b8" }}>
-              {liveRowMessage}
-            </span>
-          </div>
-          <button
-            type="button"
-            onClick={() => setIsQuantizedRecording((prev) => !prev)}
-            style={{
-              padding: "6px 12px",
-              borderRadius: 999,
-              border: `1px solid ${
-                isQuantizedRecording ? playInstrumentColor : "#2a3344"
-              }`,
-              background: isQuantizedRecording
-                ? withAlpha(playInstrumentColor, 0.18)
-                : "#0f172a",
-              color: "#e6f2ff",
-              fontSize: 11,
-              fontWeight: 600,
-              letterSpacing: 0.8,
-              textTransform: "uppercase",
-              cursor: "pointer",
-            }}
-            title={
-              isQuantizedRecording
-                ? "Quantized recording is on — notes snap to the grid."
-                : "Quantized recording is off — capture free timing."
-            }
-          >
-            Quantize {isQuantizedRecording ? "On" : "Off"}
-          </button>
-        </div>
-        <div
-          style={{
-            borderRadius: 12,
-            border: "1px solid #1f2937",
-            background: "#10192c",
-            padding: 12,
-            flex: 1,
-            minHeight: 0,
-          }}
-        >
-          <InstrumentControlPanel
-            track={playInstrumentTrackForPanel}
-            allTracks={[]}
-            onUpdatePattern={handlePlayInstrumentPatternUpdate}
-            trigger={playInstrumentTrigger}
-            isRecording={recordingActive}
-            onPerformanceNote={handlePerformanceNoteRecorded}
-          />
-        </div>
-        <span style={{ fontSize: 12, color: "#94a3b8" }}>
-          Audition sounds or capture a new take for this performance row.
-        </span>
-      </div>
-    </div>
-  </BottomDock>
   </div>
   );
 }

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -41,8 +41,6 @@ interface SongViewProps {
   bpm: number;
   setBpm: Dispatch<SetStateAction<number>>;
   onToggleTransport: () => void;
-  selectedGroupId: string | null;
-  onSelectLoop: (groupId: string) => void;
   performanceTracks: PerformanceTrack[];
   triggers: TriggerMap;
   onEnsurePerformanceRow: (
@@ -649,8 +647,6 @@ export function SongView({
   bpm,
   setBpm,
   onToggleTransport,
-  selectedGroupId,
-  onSelectLoop,
   performanceTracks,
   triggers,
   onEnsurePerformanceRow,
@@ -2070,142 +2066,6 @@ export function SongView({
         ) : null}
       </Modal>
 
-      {!isPlayInstrumentOpen ? (
-        <div
-          className="scrollable"
-          style={{
-            flex: 1,
-            minHeight: 0,
-            overflowY: "auto",
-            paddingRight: 4,
-            display: "flex",
-            flexDirection: "column",
-            gap: 12,
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 4,
-            }}
-          >
-            <h3
-              style={{
-                margin: 0,
-                fontSize: 14,
-                fontWeight: 600,
-                color: "#e6f2ff",
-              }}
-            >
-              Loops Library
-            </h3>
-            <span
-              style={{
-                fontSize: 12,
-                color: "#94a3b8",
-              }}
-            >
-              Save and edit loops in Track view, then place them onto the song
-              timeline.
-            </span>
-          </div>
-          {patternGroups.length === 0 ? (
-            <div
-              style={{
-                padding: 16,
-                borderRadius: 8,
-                border: "1px dashed #475569",
-                color: "#94a3b8",
-                fontSize: 13,
-              }}
-            >
-              No loops yet. Create loops in Track view to start arranging
-              the song.
-            </div>
-          ) : (
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 12,
-              }}
-            >
-              {patternGroups.map((group) => {
-                const trackLabels = group.tracks
-                  .map((track) => track.name)
-                  .filter((name): name is string => Boolean(name));
-                const isActive = selectedGroupId === group.id;
-                return (
-                  <button
-                    key={group.id}
-                    type="button"
-                    onClick={() => onSelectLoop(group.id)}
-                    style={{
-                      borderRadius: 10,
-                      border: `1px solid ${isActive ? "#27E0B0" : "#333"}`,
-                      background: isActive
-                        ? "rgba(39, 224, 176, 0.12)"
-                        : "#121827",
-                      padding: 12,
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 8,
-                      textAlign: "left",
-                      cursor: "pointer",
-                      color: "#e6f2ff",
-                    }}
-                    title={`Open ${group.name} in Track view`}
-                  >
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 8,
-                      }}
-                    >
-                      <span aria-hidden="true" style={{ fontSize: 16 }}>
-                        📼
-                      </span>
-                      <span style={{ fontWeight: 600 }}>{group.name}</span>
-                      <div style={{ marginLeft: "auto" }} />
-                    </div>
-                    {trackLabels.length === 0 ? (
-                      <span style={{ fontSize: 12, color: "#94a3b8" }}>
-                        This loop is empty — add instruments in Tracks view
-                        first.
-                      </span>
-                    ) : (
-                      <div
-                        style={{
-                          display: "flex",
-                          flexWrap: "wrap",
-                          gap: 6,
-                        }}
-                      >
-                        {trackLabels.map((name) => (
-                          <span
-                            key={`${group.id}-${name}`}
-                            style={{
-                              padding: "4px 8px",
-                              borderRadius: 6,
-                              background: "#1f2532",
-                              border: "1px solid #333",
-                              fontSize: 12,
-                            }}
-                          >
-                            {name}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      ) : null}
     </div>
   </div>
 

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1805,15 +1805,12 @@ export function SongView({
         >
           <div
             style={{
-              border: "1px solid #333",
-              borderRadius: 12,
-              background: "#1b2130",
-              padding: "16px 0",
               display: "flex",
               flexDirection: "column",
               gap: 16,
               minHeight: 0,
               flex: 1,
+              padding: "16px 0",
             }}
           >
             <div

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1095,10 +1095,12 @@ export function SongView({
   const slotPadding = SLOT_PADDING;
   const slotGap = SLOT_CONTENT_GAP;
   const isTrackSelected = isPlayInstrumentOpen;
-  const timelineFlex =
-    isTrackSelected && !isTimelineExpanded
-      ? "0 0 var(--timeline-collapsed-h)"
-      : "1 1 auto";
+  const collapsedTimelineFlex = "0 0 45%";
+  const timelineFlex = isTrackSelected
+    ? isTimelineExpanded
+      ? "1 1 auto"
+      : collapsedTimelineFlex
+    : "1 1 auto";
   const panelInstrument = activePerformanceTrack?.instrument ?? playInstrument;
   const playInstrumentColor = useMemo(
     () => getInstrumentColor(panelInstrument),
@@ -1870,14 +1872,16 @@ export function SongView({
               </div>
             </div>
             <div
-              className="min-h-0"
+              className="min-h-0 scroll-y"
               style={{
                 flex: timelineFlex,
+                minHeight: 0,
+                overflowY: "auto",
                 padding: 0,
-                transition: "flex-basis 180ms ease",
+                transition: "flex 180ms ease",
               }}
             >
-              <div className="scroll-y min-h-0" style={{ height: "100%" }}>
+              <div className="min-h-0" style={{ height: "100%" }}>
                 <div
                   className="scrollable"
                   style={{
@@ -2140,6 +2144,13 @@ export function SongView({
         heightVar="var(--controls-h)"
         show={isPlayInstrumentOpen}
         inertWhenHidden
+        style={{
+          flex: isTrackSelected ? "1 1 auto" : "0 0 0",
+          height: isTrackSelected ? "auto" : 0,
+          minHeight: 0,
+          overflowY: "auto",
+          transition: "flex 180ms ease",
+        }}
       >
         <div
           style={{

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1819,7 +1819,7 @@ export function SongView({
               onClick={handleAddSection}
               style={buildSecondaryButtonStyle()}
             >
-              + Sequence
+              + Loop
             </button>
             {timelineActions ? (
               <div

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -2316,7 +2316,6 @@ export function SongView({
             flex: controlsRegionFlex,
             minHeight: 0,
             overflowY: "auto",
-            display: controlsRegionFlex === "0 0 0" ? "none" : "block",
             transition: "flex-basis 180ms ease",
           }}
         >
@@ -2324,56 +2323,68 @@ export function SongView({
         </div>
       </div>
 
-      <BottomDock heightVar="var(--transport-h)">
-        <div style={TRANSPORT_CONTAINER_STYLE}>
-          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-            <button
-              aria-label={transportLabel}
-              onPointerDown={handleToggleTransport}
-              onPointerUp={(event) => event.currentTarget.blur()}
-              style={buildTransportPlayButtonStyle(isPlaying)}
-            >
-              <span className="material-symbols-outlined" aria-hidden="true">
-                {transportIcon}
-              </span>
-            </button>
-            <div style={BPM_SELECT_WRAPPER_STYLE}>
-              <select
-                value={bpm}
-                onChange={(event) =>
-                  handleBpmChange(parseInt(event.target.value, 10))
-                }
-                style={BPM_SELECT_STYLE}
-                aria-label="Tempo (beats per minute)"
+      <div
+        id="bottom-dock-wrapper"
+        style={{
+          flex: "0 0 auto",
+          position: "sticky",
+          bottom: 0,
+          zIndex: 5,
+          background: "var(--color-bg)",
+          borderTop: "1px solid var(--color-border)",
+        }}
+      >
+        <BottomDock heightVar="var(--transport-h)">
+          <div style={TRANSPORT_CONTAINER_STYLE}>
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <button
+                aria-label={transportLabel}
+                onPointerDown={handleToggleTransport}
+                onPointerUp={(event) => event.currentTarget.blur()}
+                style={buildTransportPlayButtonStyle(isPlaying)}
               >
-                {[90, 100, 110, 120, 130].map((value) => (
-                  <option key={value} value={value}>
-                    {`${value} BPM`}
-                  </option>
-                ))}
-              </select>
-              <span
-                className="material-symbols-outlined"
-                style={BPM_SELECT_ICON_STYLE}
-                aria-hidden="true"
-              >
-                expand_more
-              </span>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  {transportIcon}
+                </span>
+              </button>
+              <div style={BPM_SELECT_WRAPPER_STYLE}>
+                <select
+                  value={bpm}
+                  onChange={(event) =>
+                    handleBpmChange(parseInt(event.target.value, 10))
+                  }
+                  style={BPM_SELECT_STYLE}
+                  aria-label="Tempo (beats per minute)"
+                >
+                  {[90, 100, 110, 120, 130].map((value) => (
+                    <option key={value} value={value}>
+                      {`${value} BPM`}
+                    </option>
+                  ))}
+                </select>
+                <span
+                  className="material-symbols-outlined"
+                  style={BPM_SELECT_ICON_STYLE}
+                  aria-hidden="true"
+                >
+                  expand_more
+                </span>
+              </div>
             </div>
+            <button
+              type="button"
+              onClick={handleAddPerformanceTrack}
+              disabled={!onAddPerformanceTrack}
+              style={buildAccentButtonStyle(
+                Boolean(onAddPerformanceTrack),
+                TRANSPORT_CONTROL_HEIGHT
+              )}
+            >
+              + Track
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={handleAddPerformanceTrack}
-            disabled={!onAddPerformanceTrack}
-            style={buildAccentButtonStyle(
-              Boolean(onAddPerformanceTrack),
-              TRANSPORT_CONTROL_HEIGHT
-            )}
-          >
-            + Track
-          </button>
-        </div>
-      </BottomDock>
+        </BottomDock>
+      </div>
 
       {rowSettingsModal}
     </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1877,7 +1877,7 @@ export function SongView({
                 minHeight: 0,
                 display: "flex",
                 flexDirection: "column",
-                gap: 16,
+                gap: isTrackSelected ? 16 : 0,
               }}
             >
               <div

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1876,7 +1876,7 @@ export function SongView({
               className="min-h-0"
               style={{
                 flex: timelineFlex,
-                padding: "0 var(--hpad)",
+                padding: 0,
                 transition: "flex-basis 180ms ease",
               }}
             >

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1883,7 +1883,6 @@ export function SongView({
                   style={{
                     overflowX: "auto",
                     paddingBottom: 4,
-                    paddingRight: 6,
                     height: "100%",
                     minHeight: "100%",
                   }}

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -60,6 +60,7 @@ interface SongViewProps {
   topBarLeft?: ReactNode;
   topBarCenter?: ReactNode;
   topBarRight?: ReactNode;
+  timelineActions?: ReactNode;
 }
 
 const SLOT_WIDTH = 150;
@@ -650,6 +651,7 @@ export function SongView({
   topBarLeft,
   topBarCenter,
   topBarRight,
+  timelineActions,
 }: SongViewProps) {
   const {
     editingSlot,
@@ -1807,14 +1809,6 @@ export function SongView({
           >
             <button
               type="button"
-              onClick={handleAddPerformanceTrack}
-              disabled={!onAddPerformanceTrack}
-              style={buildAccentButtonStyle(Boolean(onAddPerformanceTrack))}
-            >
-              + Track
-            </button>
-            <button
-              type="button"
               onClick={handleAddRow}
               style={buildSecondaryButtonStyle()}
             >
@@ -1827,6 +1821,17 @@ export function SongView({
             >
               + Sequence
             </button>
+            {timelineActions ? (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: TIMELINE_TOOLBAR_GAP,
+                }}
+              >
+                {timelineActions}
+              </div>
+            ) : null}
           </div>
         </div>
         <div

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -77,6 +77,13 @@ const TIMELINE_TOOLBAR_GAP = 12;
 const TIMELINE_CONTROL_HEIGHT = 36;
 const TRANSPORT_CONTROL_HEIGHT = 44;
 
+const TIMELINE_LABEL_STYLE: CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  color: "#e2e8f0",
+};
+
 const buildAccentButtonStyle = (
   enabled: boolean,
   height: number = TIMELINE_CONTROL_HEIGHT
@@ -118,23 +125,6 @@ const buildSecondaryButtonStyle = (
   whiteSpace: "nowrap",
   transition: "background 0.2s ease, border-color 0.2s ease, color 0.2s ease",
 });
-
-const TIMELINE_TOGGLE_BUTTON_STYLE: CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  gap: 8,
-  padding: "0 16px",
-  height: TIMELINE_CONTROL_HEIGHT,
-  borderRadius: 999,
-  border: "1px solid #1f2937",
-  background: "#0f172a",
-  color: "#e2e8f0",
-  fontSize: 14,
-  fontWeight: 600,
-  letterSpacing: 0.3,
-  cursor: "pointer",
-  transition: "background 0.2s ease, border-color 0.2s ease, color 0.2s ease",
-};
 
 const TRANSPORT_CONTAINER_STYLE: CSSProperties = {
   height: "100%",
@@ -667,7 +657,6 @@ export function SongView({
     rowSettingsIndex,
     setRowSettingsIndex,
     isTimelineExpanded,
-    setTimelineExpanded,
   } = useTimelineState();
 
   const {
@@ -1776,10 +1765,6 @@ export function SongView({
       renderPerformanceSlotPreview,
     ]
   );
-  const timelineToggleLabel = isTimelineExpanded
-    ? "Collapse timeline height"
-    : "Expand timeline height";
-
   const timelineSection = (
     <div
       className="safe-top"
@@ -1811,22 +1796,7 @@ export function SongView({
             padding: "0 var(--hpad)",
           }}
         >
-          <button
-            type="button"
-            style={TIMELINE_TOGGLE_BUTTON_STYLE}
-            onClick={() => setTimelineExpanded((previous) => !previous)}
-            aria-expanded={isTimelineExpanded}
-            aria-label={timelineToggleLabel}
-          >
-            <span style={{ fontSize: 14, fontWeight: 600 }}>Timeline</span>
-            <span
-              className="material-symbols-outlined"
-              style={{ fontSize: 18, lineHeight: 1 }}
-              aria-hidden="true"
-            >
-              {isTimelineExpanded ? "expand_less" : "expand_more"}
-            </span>
-          </button>
+          <span style={TIMELINE_LABEL_STYLE}>Timeline</span>
           <div
             style={{
               display: "flex",

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -69,10 +69,6 @@ const PERFORMANCE_DOT_SIZE = 5;
 const SLOT_MIN_HEIGHT = 52;
 const SLOT_CONTENT_GAP = 4;
 const SLOT_PADDING = "4px 10px";
-const APPROXIMATE_ROW_OFFSET = 28;
-const TIMELINE_VISIBLE_ROWS_COLLAPSED = 1.5;
-const TIMELINE_VISIBLE_ROWS_EXPANDED = 3;
-
 const TIMELINE_TOOLBAR_GAP = 12;
 const TIMELINE_CONTROL_HEIGHT = 36;
 const TRANSPORT_CONTROL_HEIGHT = 44;
@@ -1098,13 +1094,11 @@ export function SongView({
   const slotMinHeight = SLOT_MIN_HEIGHT;
   const slotPadding = SLOT_PADDING;
   const slotGap = SLOT_CONTENT_GAP;
-  const visibleRowTarget = isTimelineExpanded
-    ? TIMELINE_VISIBLE_ROWS_EXPANDED
-    : TIMELINE_VISIBLE_ROWS_COLLAPSED;
-  const timelineViewportHeight = Math.round(
-    visibleRowTarget * (slotMinHeight + APPROXIMATE_ROW_OFFSET)
-  );
-  const shouldEnableVerticalScroll = songRows.length > visibleRowTarget;
+  const isTrackSelected = isPlayInstrumentOpen;
+  const timelineFlex =
+    isTrackSelected && !isTimelineExpanded
+      ? "0 0 var(--timeline-collapsed-h)"
+      : "1 1 auto";
   const panelInstrument = activePerformanceTrack?.instrument ?? playInstrument;
   const playInstrumentColor = useMemo(
     () => getInstrumentColor(panelInstrument),
@@ -1787,17 +1781,20 @@ export function SongView({
       }}
     >
       <div
-        className="safe-top flex-1 min-h-0 overflow-hidden"
+        className="safe-top min-h-0"
         style={{
-          padding: 16,
           flex: 1,
           minHeight: 0,
-          overflow: "hidden",
           display: "flex",
           flexDirection: "column",
+          paddingTop: "calc(env(safe-area-inset-top) + 16px)",
+          paddingBottom: 16,
+          paddingLeft: "calc(var(--hpad) + env(safe-area-inset-left))",
+          paddingRight: "calc(var(--hpad) + env(safe-area-inset-right))",
         }}
       >
         <div
+          className="min-h-0"
           style={{
             display: "flex",
             flexDirection: "column",
@@ -1811,165 +1808,178 @@ export function SongView({
               border: "1px solid #333",
               borderRadius: 12,
               background: "#1b2130",
-              padding: 16,
+              padding: "16px 0",
               display: "flex",
               flexDirection: "column",
               gap: 16,
               minHeight: 0,
+              flex: 1,
             }}
           >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: TIMELINE_TOOLBAR_GAP,
-          }}
-        >
-          <button
-            type="button"
-            style={TIMELINE_TOGGLE_BUTTON_STYLE}
-            onClick={() => setTimelineExpanded((previous) => !previous)}
-            aria-expanded={isTimelineExpanded}
-            aria-label={timelineToggleLabel}
-          >
-            <span style={{ fontSize: 14, fontWeight: 600 }}>Timeline</span>
-            <span
-              className="material-symbols-outlined"
-              style={{ fontSize: 18, lineHeight: 1 }}
-              aria-hidden="true"
-            >
-              {isTimelineExpanded ? "expand_less" : "expand_more"}
-            </span>
-          </button>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: TIMELINE_TOOLBAR_GAP,
-              marginLeft: "auto",
-            }}
-          >
-            <button
-              type="button"
-              onClick={handleAddPerformanceTrack}
-              disabled={!onAddPerformanceTrack}
-              style={buildAccentButtonStyle(Boolean(onAddPerformanceTrack))}
-            >
-              + Track
-            </button>
-            <button
-              type="button"
-              onClick={handleAddRow}
-              style={buildSecondaryButtonStyle()}
-            >
-              + Row
-            </button>
-            <button
-              type="button"
-              onClick={handleAddSection}
-              style={buildSecondaryButtonStyle()}
-            >
-              + Sequence
-            </button>
-          </div>
-        </div>
-        <div
-          className="scrollable"
-          style={{
-            overflowX: "auto",
-            paddingBottom: 4,
-            minHeight: `${timelineViewportHeight}px`,
-            maxHeight: `${timelineViewportHeight}px`,
-          }}
-        >
-          {sectionCount > 0 ? (
             <div
               style={{
                 display: "flex",
                 alignItems: "center",
-                marginBottom: 8,
-                paddingRight: shouldEnableVerticalScroll ? 6 : 0,
+                gap: TIMELINE_TOOLBAR_GAP,
+                padding: "0 var(--hpad)",
               }}
             >
-              <div style={{ width: ROW_LABEL_WIDTH, flexShrink: 0 }} />
-              <div style={{ flex: 1, overflow: "hidden" }}>
+              <button
+                type="button"
+                style={TIMELINE_TOGGLE_BUTTON_STYLE}
+                onClick={() => setTimelineExpanded((previous) => !previous)}
+                aria-expanded={isTimelineExpanded}
+                aria-label={timelineToggleLabel}
+              >
+                <span style={{ fontSize: 14, fontWeight: 600 }}>Timeline</span>
+                <span
+                  className="material-symbols-outlined"
+                  style={{ fontSize: 18, lineHeight: 1 }}
+                  aria-hidden="true"
+                >
+                  {isTimelineExpanded ? "expand_less" : "expand_more"}
+                </span>
+              </button>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: TIMELINE_TOOLBAR_GAP,
+                  marginLeft: "auto",
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={handleAddPerformanceTrack}
+                  disabled={!onAddPerformanceTrack}
+                  style={buildAccentButtonStyle(Boolean(onAddPerformanceTrack))}
+                >
+                  + Track
+                </button>
+                <button
+                  type="button"
+                  onClick={handleAddRow}
+                  style={buildSecondaryButtonStyle()}
+                >
+                  + Row
+                </button>
+                <button
+                  type="button"
+                  onClick={handleAddSection}
+                  style={buildSecondaryButtonStyle()}
+                >
+                  + Sequence
+                </button>
+              </div>
+            </div>
+            <div
+              className="min-h-0"
+              style={{
+                flex: timelineFlex,
+                padding: "0 var(--hpad)",
+                transition: "flex-basis 180ms ease",
+              }}
+            >
+              <div className="scroll-y min-h-0" style={{ height: "100%" }}>
                 <div
+                  className="scrollable"
                   style={{
-                    display: "grid",
-                    gridTemplateColumns: `repeat(${sectionCount}, ${SLOT_WIDTH}px)`,
-                    gap: SLOT_GAP,
-                    width: timelineWidthStyle,
-                    minWidth: timelineWidthStyle,
+                    overflowX: "auto",
+                    paddingBottom: 4,
+                    paddingRight: 6,
+                    height: "100%",
+                    minHeight: "100%",
                   }}
                 >
-                  {timelineColumns
-                    .filter((column) => column.hasSection)
-                    .map((column) => (
-                      <button
-                        key={`delete-column-${column.index}`}
-                        type="button"
-                        onClick={() => handleDeleteColumn(column.index)}
+                  {sectionCount > 0 ? (
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        marginBottom: 8,
+                      }}
+                    >
+                      <div style={{ width: ROW_LABEL_WIDTH, flexShrink: 0 }} />
+                      <div style={{ flex: 1, overflow: "hidden" }}>
+                        <div
+                          style={{
+                            display: "grid",
+                            gridTemplateColumns: `repeat(${sectionCount}, ${SLOT_WIDTH}px)`,
+                            gap: SLOT_GAP,
+                            width: timelineWidthStyle,
+                            minWidth: timelineWidthStyle,
+                          }}
+                        >
+                          {timelineColumns
+                            .filter((column) => column.hasSection)
+                            .map((column) => (
+                              <button
+                                key={`delete-column-${column.index}`}
+                                type="button"
+                                onClick={() => handleDeleteColumn(column.index)}
+                                style={{
+                                  padding: "4px 8px",
+                                  borderRadius: 16,
+                                  border: "1px solid #2a3344",
+                                  background: "#111827",
+                                  color: "#e2e8f0",
+                                  fontSize: 11,
+                                  display: "flex",
+                                  alignItems: "center",
+                                  justifyContent: "center",
+                                  gap: 4,
+                                  cursor: "pointer",
+                                }}
+                              >
+                                <span
+                                  className="material-symbols-outlined"
+                                  style={{ fontSize: 14 }}
+                                >
+                                  delete
+                                </span>
+                                <span>Seq {column.index + 1}</span>
+                              </button>
+                            ))}
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
+                  <div
+                    style={{
+                      width: timelineWidthStyle,
+                      minWidth: timelineWidthStyle,
+                    }}
+                  >
+                    {showEmptyTimeline ? (
+                      <div
                         style={{
-                          padding: "4px 8px",
-                          borderRadius: 16,
-                          border: "1px solid #2a3344",
-                          background: "#111827",
-                          color: "#e2e8f0",
-                          fontSize: 11,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          gap: 4,
-                          cursor: "pointer",
+                          padding: 24,
+                          borderRadius: 8,
+                          border: "1px dashed #475569",
+                          color: "#94a3b8",
+                          fontSize: 13,
                         }}
                       >
-                        <span className="material-symbols-outlined" style={{ fontSize: 14 }}>
-                          delete
-                        </span>
-                        <span>Seq {column.index + 1}</span>
-                      </button>
-                    ))}
+                        Add a sequence to start placing loops into the timeline.
+                      </div>
+                    ) : (
+                      <TimelineGrid
+                        rows={timelineRows}
+                        columns={timelineColumns}
+                        renderCell={renderTimelineCell}
+                        renderRow={(row, cols, cellRenderer) =>
+                          renderTimelineRow(row, cols, cellRenderer)
+                        }
+                      />
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
-          ) : null}
-          <div
-            style={{
-              maxHeight: `${timelineViewportHeight}px`,
-              minHeight: `${timelineViewportHeight}px`,
-              overflowY: shouldEnableVerticalScroll ? "auto" : "visible",
-              paddingRight: shouldEnableVerticalScroll ? 6 : 0,
-              width: timelineWidthStyle,
-              minWidth: timelineWidthStyle,
-            }}
-          >
-            {showEmptyTimeline ? (
-              <div
-                style={{
-                  padding: 24,
-                  borderRadius: 8,
-                  border: "1px dashed #475569",
-                  color: "#94a3b8",
-                  fontSize: 13,
-                }}
-              >
-                Add a sequence to start placing loops into the timeline.
-              </div>
-            ) : (
-              <TimelineGrid
-                rows={timelineRows}
-                columns={timelineColumns}
-                renderCell={renderTimelineCell}
-                renderRow={(row, cols, cellRenderer) =>
-                  renderTimelineRow(row, cols, cellRenderer)
-                }
-              />
-            )}
-      </div>
-    </div>
-  </div>
+          </div>
+        </div>
 
-      <Modal
+        <Modal
         isOpen={hasRowSettings && Boolean(rowSettingsRow)}
         onClose={() => setRowSettingsIndex(null)}
         title="Row Settings"
@@ -2066,94 +2076,93 @@ export function SongView({
         ) : null}
       </Modal>
 
-    </div>
-  </div>
-
-  <BottomDock>
-    <div style={TRANSPORT_CONTAINER_STYLE}>
-      <div style={{ display: "flex", alignItems: "center" }}>
-        <button
-          aria-label={transportLabel}
-          onPointerDown={handleToggleTransport}
-          onPointerUp={(e) => e.currentTarget.blur()}
-          style={buildTransportPlayButtonStyle(isPlaying)}
-        >
-          <span className="material-symbols-outlined" aria-hidden="true">
-            {transportIcon}
-          </span>
-        </button>
       </div>
-      <div
-        style={{
-          flex: 1,
-          display: "flex",
-          justifyContent: "center",
-          minWidth: 0,
-        }}
-      >
-        <div style={BPM_SELECT_WRAPPER_STYLE}>
-          <select
-            value={bpm}
-            onChange={(event) =>
-              handleBpmChange(parseInt(event.target.value, 10))
-            }
-            style={BPM_SELECT_STYLE}
-            aria-label="Tempo (beats per minute)"
+
+      <BottomDock>
+        <div style={TRANSPORT_CONTAINER_STYLE}>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <button
+              aria-label={transportLabel}
+              onPointerDown={handleToggleTransport}
+              onPointerUp={(e) => e.currentTarget.blur()}
+              style={buildTransportPlayButtonStyle(isPlaying)}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                {transportIcon}
+              </span>
+            </button>
+          </div>
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              justifyContent: "center",
+              minWidth: 0,
+            }}
           >
-            {[90, 100, 110, 120, 130].map((value) => (
-              <option key={value} value={value}>
-                {`${value} BPM`}
-              </option>
-            ))}
-          </select>
-          <span
-            className="material-symbols-outlined"
-            style={BPM_SELECT_ICON_STYLE}
-            aria-hidden="true"
-          >
-            expand_more
-          </span>
+            <div style={BPM_SELECT_WRAPPER_STYLE}>
+              <select
+                value={bpm}
+                onChange={(event) =>
+                  handleBpmChange(parseInt(event.target.value, 10))
+                }
+                style={BPM_SELECT_STYLE}
+                aria-label="Tempo (beats per minute)"
+              >
+                {[90, 100, 110, 120, 130].map((value) => (
+                  <option key={value} value={value}>
+                    {`${value} BPM`}
+                  </option>
+                ))}
+              </select>
+              <span
+                className="material-symbols-outlined"
+                style={BPM_SELECT_ICON_STYLE}
+                aria-hidden="true"
+              >
+                expand_more
+              </span>
+            </div>
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              onClick={handleAddPerformanceTrack}
+              disabled={!onAddPerformanceTrack}
+              style={buildAccentButtonStyle(
+                Boolean(onAddPerformanceTrack),
+                TRANSPORT_CONTROL_HEIGHT
+              )}
+            >
+              + Track
+            </button>
+          </div>
         </div>
-      </div>
-      <div style={{ display: "flex", justifyContent: "flex-end" }}>
-        <button
-          type="button"
-          onClick={handleAddPerformanceTrack}
-          disabled={!onAddPerformanceTrack}
-          style={buildAccentButtonStyle(
-            Boolean(onAddPerformanceTrack),
-            TRANSPORT_CONTROL_HEIGHT
-          )}
-        >
-          + Track
-        </button>
-      </div>
-    </div>
-  </BottomDock>
+      </BottomDock>
 
-  <BottomDock
-    heightVar="var(--controls-h)"
-    show={isPlayInstrumentOpen}
-    inertWhenHidden
-  >
-    <div
-      style={{
-        height: "100%",
-        padding: "12px 16px 16px",
-        display: "flex",
-        flexDirection: "column",
-        gap: 12,
-        boxSizing: "border-box",
-        background: "#0b1220",
-        borderTop: "1px solid #1f2937",
-      }}
-    >
-      <div
-        className="scrollable"
-        style={{
-          flex: 1,
-          minHeight: 0,
-          borderRadius: 12,
+      <BottomDock
+        heightVar="var(--controls-h)"
+        show={isPlayInstrumentOpen}
+        inertWhenHidden
+      >
+        <div
+          style={{
+            height: "100%",
+            padding: "12px 16px 16px",
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            boxSizing: "border-box",
+            background: "#0b1220",
+            borderTop: "1px solid #1f2937",
+          }}
+        >
+          <div
+            className="scrollable"
+            style={{
+              flex: 1,
+              minHeight: 0,
+              borderRadius: 12,
           border: "1px solid #2a3344",
           background: "#111827",
           padding: 16,

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -75,6 +75,129 @@ const APPROXIMATE_ROW_OFFSET = 28;
 const TIMELINE_VISIBLE_ROWS_COLLAPSED = 1.5;
 const TIMELINE_VISIBLE_ROWS_EXPANDED = 3;
 
+const TIMELINE_TOOLBAR_GAP = 12;
+const TIMELINE_CONTROL_HEIGHT = 36;
+const TRANSPORT_CONTROL_HEIGHT = 44;
+
+const buildAccentButtonStyle = (
+  enabled: boolean,
+  height: number = TIMELINE_CONTROL_HEIGHT
+): CSSProperties => ({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "0 18px",
+  height,
+  borderRadius: 999,
+  border: `1px solid ${enabled ? "#27E0B0" : "#273041"}`,
+  background: enabled ? "#27E0B0" : "#273041",
+  color: enabled ? "#0b1220" : "#475569",
+  fontSize: 13,
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  cursor: enabled ? "pointer" : "not-allowed",
+  boxShadow: enabled ? "0 8px 24px rgba(39,224,176,0.35)" : "none",
+  whiteSpace: "nowrap",
+  transition: "background 0.2s ease, border-color 0.2s ease, color 0.2s ease",
+});
+
+const buildSecondaryButtonStyle = (
+  height: number = TIMELINE_CONTROL_HEIGHT
+): CSSProperties => ({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "0 16px",
+  height,
+  borderRadius: 999,
+  border: "1px solid #1f2937",
+  background: "#121a2c",
+  color: "#e2e8f0",
+  fontSize: 13,
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  cursor: "pointer",
+  whiteSpace: "nowrap",
+  transition: "background 0.2s ease, border-color 0.2s ease, color 0.2s ease",
+});
+
+const TIMELINE_TOGGLE_BUTTON_STYLE: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "0 16px",
+  height: TIMELINE_CONTROL_HEIGHT,
+  borderRadius: 999,
+  border: "1px solid #1f2937",
+  background: "#0f172a",
+  color: "#e2e8f0",
+  fontSize: 14,
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  cursor: "pointer",
+  transition: "background 0.2s ease, border-color 0.2s ease, color 0.2s ease",
+};
+
+const TRANSPORT_CONTAINER_STYLE: CSSProperties = {
+  height: "100%",
+  display: "flex",
+  alignItems: "center",
+  gap: 16,
+  paddingLeft: "calc(16px + env(safe-area-inset-left))",
+  paddingRight: "calc(16px + env(safe-area-inset-right))",
+  borderTop: "1px solid #1f2937",
+  background: "#0b1220",
+  boxSizing: "border-box",
+};
+
+const buildTransportPlayButtonStyle = (isPlaying: boolean): CSSProperties => ({
+  width: TRANSPORT_CONTROL_HEIGHT,
+  height: TRANSPORT_CONTROL_HEIGHT,
+  borderRadius: TRANSPORT_CONTROL_HEIGHT / 2,
+  border: "none",
+  background: isPlaying ? "#E02749" : "#27E0B0",
+  color: isPlaying ? "#ffe4e6" : "#0b1220",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: 26,
+  cursor: "pointer",
+  boxShadow: isPlaying
+    ? "0 8px 24px rgba(224,39,73,0.32)"
+    : "0 8px 24px rgba(39,224,176,0.32)",
+  transition: "background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease",
+});
+
+const BPM_SELECT_WRAPPER_STYLE: CSSProperties = {
+  position: "relative",
+  display: "inline-flex",
+  alignItems: "center",
+};
+
+const BPM_SELECT_STYLE: CSSProperties = {
+  appearance: "none",
+  WebkitAppearance: "none",
+  padding: "0 40px 0 18px",
+  height: TRANSPORT_CONTROL_HEIGHT,
+  borderRadius: 12,
+  border: "1px solid #1f2937",
+  background: "#111827",
+  color: "#e2e8f0",
+  fontSize: 14,
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  fontVariantNumeric: "tabular-nums",
+  cursor: "pointer",
+};
+
+const BPM_SELECT_ICON_STYLE: CSSProperties = {
+  position: "absolute",
+  right: 14,
+  pointerEvents: "none",
+  color: "#94a3b8",
+  fontSize: 20,
+};
+
 const TICKS_PER_QUARTER = Tone.Transport.PPQ;
 const TICKS_PER_SIXTEENTH = TICKS_PER_QUARTER / 4;
 const TICKS_PER_MEASURE = TICKS_PER_SIXTEENTH * 16;
@@ -1703,73 +1826,52 @@ export function SongView({
           style={{
             display: "flex",
             alignItems: "center",
-            gap: 12,
+            gap: TIMELINE_TOOLBAR_GAP,
           }}
         >
-          <h2
+          <button
+            type="button"
+            style={TIMELINE_TOGGLE_BUTTON_STYLE}
+            onClick={() => setTimelineExpanded((previous) => !previous)}
+            aria-expanded={isTimelineExpanded}
+            aria-label={timelineToggleLabel}
+          >
+            <span style={{ fontSize: 14, fontWeight: 600 }}>Timeline</span>
+            <span
+              className="material-symbols-outlined"
+              style={{ fontSize: 18, lineHeight: 1 }}
+              aria-hidden="true"
+            >
+              {isTimelineExpanded ? "expand_less" : "expand_more"}
+            </span>
+          </button>
+          <div
             style={{
-              margin: 0,
-              fontSize: 16,
-              fontWeight: 600,
-              color: "#e6f2ff",
+              display: "flex",
+              alignItems: "center",
+              gap: TIMELINE_TOOLBAR_GAP,
+              marginLeft: "auto",
             }}
           >
-            Timeline
-          </h2>
-          <div style={{ display: "flex", gap: 8, marginLeft: "auto" }}>
-            <IconButton
-              icon={isTimelineExpanded ? "unfold_less" : "unfold_more"}
-              label={timelineToggleLabel}
-              onClick={() => setTimelineExpanded((previous) => !previous)}
-              style={{ minWidth: 0 }}
-            />
             <button
+              type="button"
               onClick={handleAddPerformanceTrack}
               disabled={!onAddPerformanceTrack}
-              style={{
-                padding: "6px 14px",
-                borderRadius: 20,
-                border: "1px solid #27E0B0",
-                background: onAddPerformanceTrack ? "#27E0B0" : "#273041",
-                color: onAddPerformanceTrack ? "#0b1220" : "#475569",
-                fontSize: 12,
-                fontWeight: 600,
-                letterSpacing: 0.3,
-                whiteSpace: "nowrap",
-                cursor: onAddPerformanceTrack ? "pointer" : "not-allowed",
-                boxShadow: onAddPerformanceTrack
-                  ? "0 2px 8px rgba(39,224,176,0.35)"
-                  : "none",
-                transition: "background 0.2s ease, border 0.2s ease",
-              }}
+              style={buildAccentButtonStyle(Boolean(onAddPerformanceTrack))}
             >
               + Track
             </button>
             <button
+              type="button"
               onClick={handleAddRow}
-              style={{
-                padding: "6px 12px",
-                borderRadius: 20,
-                border: "1px solid #333",
-                background: "#273041",
-                color: "#e6f2ff",
-                fontSize: 12,
-                whiteSpace: "nowrap",
-              }}
+              style={buildSecondaryButtonStyle()}
             >
               + Row
             </button>
             <button
+              type="button"
               onClick={handleAddSection}
-              style={{
-                padding: "6px 12px",
-                borderRadius: 20,
-                border: "1px solid #333",
-                background: "#273041",
-                color: "#e6f2ff",
-                fontSize: 12,
-                whiteSpace: "nowrap",
-              }}
+              style={buildSecondaryButtonStyle()}
             >
               + Sequence
             </button>
@@ -2108,64 +2210,62 @@ export function SongView({
   </div>
 
   <BottomDock>
-    <div
-      style={{
-        height: "100%",
-        display: "flex",
-        alignItems: "center",
-        gap: 12,
-        padding: "0 16px",
-        borderTop: "1px solid #1f2937",
-        background: "#0b1220",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 12,
-        }}
-      >
-        <label>BPM</label>
-        <select
-          value={bpm}
-          onChange={(e) => handleBpmChange(parseInt(e.target.value, 10))}
-          style={{
-            padding: 8,
-            borderRadius: 8,
-            background: "#121827",
-            color: "white",
-          }}
-        >
-          {[90, 100, 110, 120, 130].map((value) => (
-            <option key={value} value={value}>
-              {value}
-            </option>
-          ))}
-        </select>
-      </div>
-      <div style={{ flex: 1 }} />
-      <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+    <div style={TRANSPORT_CONTAINER_STYLE}>
+      <div style={{ display: "flex", alignItems: "center" }}>
         <button
           aria-label={transportLabel}
           onPointerDown={handleToggleTransport}
           onPointerUp={(e) => e.currentTarget.blur()}
-          style={{
-            width: 44,
-            height: 44,
-            borderRadius: 8,
-            border: "1px solid #333",
-            background: isPlaying ? "#E02749" : "#27E0B0",
-            color: isPlaying ? "#ffe4e6" : "#1F2532",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontSize: 24,
-          }}
+          style={buildTransportPlayButtonStyle(isPlaying)}
         >
-          <span className="material-symbols-outlined">
+          <span className="material-symbols-outlined" aria-hidden="true">
             {transportIcon}
           </span>
+        </button>
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          justifyContent: "center",
+          minWidth: 0,
+        }}
+      >
+        <div style={BPM_SELECT_WRAPPER_STYLE}>
+          <select
+            value={bpm}
+            onChange={(event) =>
+              handleBpmChange(parseInt(event.target.value, 10))
+            }
+            style={BPM_SELECT_STYLE}
+            aria-label="Tempo (beats per minute)"
+          >
+            {[90, 100, 110, 120, 130].map((value) => (
+              <option key={value} value={value}>
+                {`${value} BPM`}
+              </option>
+            ))}
+          </select>
+          <span
+            className="material-symbols-outlined"
+            style={BPM_SELECT_ICON_STYLE}
+            aria-hidden="true"
+          >
+            expand_more
+          </span>
+        </div>
+      </div>
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <button
+          type="button"
+          onClick={handleAddPerformanceTrack}
+          disabled={!onAddPerformanceTrack}
+          style={buildAccentButtonStyle(
+            Boolean(onAddPerformanceTrack),
+            TRANSPORT_CONTROL_HEIGHT
+          )}
+        >
+          + Track
         </button>
       </div>
     </div>

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -5,6 +5,7 @@ import {
 } from "react";
 
 export type IconButtonTone = "default" | "accent" | "danger" | "ghost";
+export type IconButtonSize = "default" | "compact";
 
 interface IconButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
@@ -14,15 +15,13 @@ interface IconButtonProps
   iconSize?: number;
   showLabel?: boolean;
   description?: string;
+  size?: IconButtonSize;
 }
 
 const baseStyle: CSSProperties = {
-  minWidth: 44,
-  minHeight: 44,
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
-  borderRadius: 12,
   border: "1px solid #2f384a",
   background: "#111827",
   color: "#e2e8f0",
@@ -30,13 +29,33 @@ const baseStyle: CSSProperties = {
   transition: "background 0.2s ease, color 0.2s ease, border 0.2s ease",
   fontSize: 0,
   lineHeight: 0,
-  padding: 0,
   touchAction: "manipulation",
 };
 
-const iconOnlyStyle: CSSProperties = {
-  padding: baseStyle.padding,
-  gap: 0,
+const sizeStyles: Record<IconButtonSize, CSSProperties> = {
+  default: {
+    minWidth: 44,
+    minHeight: 44,
+    borderRadius: 12,
+  },
+  compact: {
+    width: 36,
+    height: 36,
+    minWidth: 36,
+    minHeight: 36,
+    borderRadius: 8,
+  },
+};
+
+const iconPaddingStyles: Record<IconButtonSize, CSSProperties> = {
+  default: {
+    padding: 0,
+    gap: 0,
+  },
+  compact: {
+    padding: 8,
+    gap: 0,
+  },
 };
 
 const iconWithLabelStyle: CSSProperties = {
@@ -77,6 +96,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       iconSize = 24,
       showLabel = false,
       description,
+      size = "default",
       style,
       disabled,
       title,
@@ -85,8 +105,12 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     ref
   ) {
     const hasTextContent = showLabel || Boolean(description);
+    const sizeStyle = sizeStyles[size] ?? sizeStyles.default;
+    const iconOnlyStyle = iconPaddingStyles[size] ?? iconPaddingStyles.default;
+
     const combinedStyle: CSSProperties = {
       ...baseStyle,
+      ...sizeStyle,
       ...(toneStyles[tone] ?? toneStyles.default),
       ...(hasTextContent ? iconWithLabelStyle : iconOnlyStyle),
       ...(style ?? {}),

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -43,7 +43,7 @@ const sizeStyles: Record<IconButtonSize, CSSProperties> = {
     height: 36,
     minWidth: 36,
     minHeight: 36,
-    borderRadius: 8,
+    borderRadius: 18,
   },
 };
 
@@ -53,7 +53,7 @@ const iconPaddingStyles: Record<IconButtonSize, CSSProperties> = {
     gap: 0,
   },
   compact: {
-    padding: 8,
+    padding: 0,
     gap: 0,
   },
 };

--- a/src/components/OverflowMenuButton.tsx
+++ b/src/components/OverflowMenuButton.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+
+import { IconButton } from "./IconButton";
+
+interface OverflowMenuItem {
+  label: string;
+  onSelect: () => void;
+  disabled?: boolean;
+}
+
+interface OverflowMenuButtonProps {
+  label: string;
+  items: OverflowMenuItem[];
+  icon?: string;
+}
+
+const MENU_CONTAINER_STYLE: CSSProperties = {
+  position: "absolute",
+  top: "calc(100% + 8px)",
+  right: 0,
+  minWidth: 180,
+  padding: 8,
+  borderRadius: 12,
+  border: "1px solid #1f2937",
+  background: "rgba(15, 23, 42, 0.95)",
+  boxShadow: "0 16px 32px rgba(2, 6, 14, 0.6)",
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+  zIndex: 100,
+};
+
+const MENU_ITEM_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-start",
+  padding: "8px 12px",
+  borderRadius: 8,
+  border: "1px solid transparent",
+  background: "transparent",
+  color: "#e2e8f0",
+  fontSize: 14,
+  fontWeight: 600,
+  textAlign: "left",
+  cursor: "pointer",
+  transition: "background 0.2s ease, border 0.2s ease, color 0.2s ease",
+};
+
+const MENU_ITEM_DISABLED_STYLE: CSSProperties = {
+  opacity: 0.5,
+  cursor: "not-allowed",
+};
+
+export function OverflowMenuButton({
+  label,
+  items,
+  icon = "more_vert",
+}: OverflowMenuButtonProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current) return;
+      if (event.target instanceof Node && containerRef.current.contains(event.target)) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const handleToggle = () => {
+    setOpen((prev) => !prev);
+  };
+
+  const handleSelect = (item: OverflowMenuItem) => {
+    if (item.disabled) return;
+    setOpen(false);
+    item.onSelect();
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: "relative", display: "inline-flex" }}>
+      <IconButton
+        icon={icon}
+        label={label}
+        size="compact"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={handleToggle}
+      />
+      {open ? (
+        <div role="menu" style={MENU_CONTAINER_STYLE}>
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              role="menuitem"
+              onClick={() => handleSelect(item)}
+              disabled={item.disabled}
+              style={{
+                ...MENU_ITEM_STYLE,
+                ...(item.disabled ? MENU_ITEM_DISABLED_STYLE : null),
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ViewHeader.tsx
+++ b/src/components/ViewHeader.tsx
@@ -1,129 +1,196 @@
 import type { CSSProperties, ReactNode } from "react";
 
-interface ViewHeaderProps {
+export interface ViewHeaderProps {
   viewMode: "track" | "song";
   onBack: () => void;
   onSelectTrack: () => void;
   onSelectSong: () => void;
   actions?: ReactNode;
+  variant?: "stacked" | "inline";
 }
 
-const headerWrapperStyle: CSSProperties = {
+export interface ViewHeaderSections {
+  left: ReactNode;
+  center: ReactNode;
+  right: ReactNode | null;
+}
+
+type ViewHeaderContentProps = Omit<ViewHeaderProps, "variant">;
+
+const SECTION_CONTAINER_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+};
+
+const STACKED_WRAPPER_STYLE: CSSProperties = {
   padding: "16px 16px 0",
   position: "sticky",
   top: 0,
   zIndex: 30,
-  background: "linear-gradient(180deg, rgba(13,18,30,0.94), rgba(13,18,30,0.82))",
-  backdropFilter: "blur(12px)",
+  background: "linear-gradient(180deg, rgba(12,18,32,0.9), rgba(12,18,32,0.75))",
+  backdropFilter: "blur(14px)",
+  boxSizing: "border-box",
 };
 
-const navRowStyle: CSSProperties = {
+const STACKED_ROW_STYLE: CSSProperties = {
   display: "flex",
-  gap: 8,
   alignItems: "center",
+  gap: 16,
   flexWrap: "wrap",
 };
 
-const tabGroupStyle: CSSProperties = {
-  display: "flex",
-  gap: 8,
-  flex: 1,
-  minWidth: 0,
-};
-
-const tabBaseStyle: CSSProperties = {
-  flex: 1,
-  padding: "8px 0",
-  borderRadius: 999,
-  border: "1px solid #333",
-  background: "#1f2532",
-  color: "#94a3b8",
-  fontWeight: 600,
-  letterSpacing: 0.3,
-  cursor: "pointer",
-  transition: "background 0.2s ease, color 0.2s ease, border-color 0.2s ease",
-};
-
-const backButtonStyle: CSSProperties = {
-  padding: "8px 14px",
-  borderRadius: 999,
-  border: "1px solid #333",
-  background: "#111827",
-  color: "#e6f2ff",
+const INLINE_WRAPPER_STYLE: CSSProperties = {
   display: "flex",
   alignItems: "center",
-  gap: 6,
+  gap: 16,
+};
+
+const BACK_BUTTON_STYLE: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "0 16px",
+  height: 40,
+  borderRadius: 999,
+  border: "1px solid #1f2937",
+  background: "#0f172a",
+  color: "#e2e8f0",
   fontSize: 13,
   fontWeight: 600,
   letterSpacing: 0.3,
-  flexShrink: 0,
   cursor: "pointer",
+  transition: "background 0.2s ease, border-color 0.2s ease",
 };
 
-export function ViewHeader({
+const SEGMENTED_WRAPPER_STYLE: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+  padding: 4,
+  borderRadius: 999,
+  border: "1px solid #1f2937",
+  background: "#0b1220",
+};
+
+const SEGMENT_BUTTON_STYLE: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: 96,
+  padding: "0 18px",
+  height: 32,
+  borderRadius: 999,
+  border: "1px solid transparent",
+  background: "transparent",
+  color: "#94a3b8",
+  fontSize: 13,
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  cursor: "pointer",
+  transition:
+    "background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease",
+};
+
+const ACTIONS_WRAPPER_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+};
+
+const SECTION_LEFT_STYLE: CSSProperties = {
+  ...SECTION_CONTAINER_STYLE,
+  flexShrink: 0,
+};
+
+const SECTION_CENTER_STYLE: CSSProperties = {
+  ...SECTION_CONTAINER_STYLE,
+  flex: 1,
+  justifyContent: "center",
+  minWidth: 0,
+};
+
+const SECTION_RIGHT_STYLE: CSSProperties = {
+  ...SECTION_CONTAINER_STYLE,
+  justifyContent: "flex-end",
+  flexShrink: 0,
+};
+
+const buildSegmentButtonStyle = (active: boolean): CSSProperties => ({
+  ...SEGMENT_BUTTON_STYLE,
+  background: active ? "#27E0B0" : "transparent",
+  color: active ? "#0b1220" : "#94a3b8",
+  borderColor: active ? "#27E0B0" : "transparent",
+  boxShadow: active ? "0 8px 24px rgba(39,224,176,0.22)" : "none",
+});
+
+export const getViewHeaderSections = ({
   viewMode,
   onBack,
   onSelectTrack,
   onSelectSong,
   actions,
-}: ViewHeaderProps) {
+}: ViewHeaderContentProps): ViewHeaderSections => {
   const trackActive = viewMode === "track";
   const songActive = viewMode === "song";
 
-  return (
-    <header style={headerWrapperStyle}>
-      <div style={navRowStyle}>
-        <button
-          type="button"
-          onClick={onBack}
-          style={backButtonStyle}
-          aria-label="Back to songs"
-          title="Back to songs"
-        >
-          <span style={{ fontSize: 13, fontWeight: 600 }}>{"< Back"}</span>
-        </button>
-        <div style={tabGroupStyle}>
-          <button
-            type="button"
-            onClick={onSelectTrack}
-            style={{
-              ...tabBaseStyle,
-              background: trackActive ? "#27E0B0" : "#1f2532",
-              color: trackActive ? "#0b1220" : "#94a3b8",
-              borderColor: trackActive ? "#27E0B0" : "#333",
-            }}
-            aria-pressed={trackActive}
-          >
-            Loops
-          </button>
-          <button
-            type="button"
-            onClick={onSelectSong}
-            style={{
-              ...tabBaseStyle,
-              background: songActive ? "#27E0B0" : "#1f2532",
-              color: songActive ? "#0b1220" : "#94a3b8",
-              borderColor: songActive ? "#27E0B0" : "#333",
-            }}
-            aria-pressed={songActive}
-          >
-            Song
-          </button>
-        </div>
+  const left = (
+    <button
+      type="button"
+      onClick={onBack}
+      style={BACK_BUTTON_STYLE}
+      aria-label="Back to song library"
+    >
+      <span style={{ fontWeight: 600, fontSize: 13 }}>{"< Back"}</span>
+    </button>
+  );
+
+  const center = (
+    <div style={SEGMENTED_WRAPPER_STYLE} role="tablist" aria-label="Select view">
+      <button
+        type="button"
+        onClick={onSelectTrack}
+        style={buildSegmentButtonStyle(trackActive)}
+        aria-pressed={trackActive}
+      >
+        Loops
+      </button>
+      <button
+        type="button"
+        onClick={onSelectSong}
+        style={buildSegmentButtonStyle(songActive)}
+        aria-pressed={songActive}
+      >
+        Song
+      </button>
+    </div>
+  );
+
+  const right = actions ? <div style={ACTIONS_WRAPPER_STYLE}>{actions}</div> : null;
+
+  return { left, center, right };
+};
+
+export function ViewHeader({ variant = "stacked", ...rest }: ViewHeaderProps) {
+  const { left, center, right } = getViewHeaderSections(rest);
+
+  if (variant === "inline") {
+    return (
+      <div style={INLINE_WRAPPER_STYLE}>
+        <div style={SECTION_LEFT_STYLE}>{left}</div>
+        <div style={SECTION_CENTER_STYLE}>{center}</div>
+        <div style={SECTION_RIGHT_STYLE}>{right}</div>
       </div>
-      {actions ? (
-        <div
-          style={{
-            marginTop: 12,
-            display: "flex",
-            justifyContent: "flex-end",
-            gap: 12,
-            flexWrap: "wrap",
-          }}
-        >
-          {actions}
-        </div>
-      ) : null}
+    );
+  }
+
+  return (
+    <header style={STACKED_WRAPPER_STYLE}>
+      <div style={STACKED_ROW_STYLE}>
+        <div style={SECTION_LEFT_STYLE}>{left}</div>
+        <div style={SECTION_CENTER_STYLE}>{center}</div>
+        <div style={SECTION_RIGHT_STYLE}>{right}</div>
+      </div>
     </header>
   );
 }

--- a/src/components/ViewHeader.tsx
+++ b/src/components/ViewHeader.tsx
@@ -20,7 +20,7 @@ type ViewHeaderContentProps = Omit<ViewHeaderProps, "variant">;
 const SECTION_CONTAINER_STYLE: CSSProperties = {
   display: "flex",
   alignItems: "center",
-  gap: 12,
+  gap: 8,
 };
 
 const STACKED_WRAPPER_STYLE: CSSProperties = {
@@ -50,9 +50,9 @@ const BACK_BUTTON_STYLE: CSSProperties = {
   display: "inline-flex",
   alignItems: "center",
   gap: 8,
-  padding: "0 16px",
-  height: 40,
-  borderRadius: 999,
+  padding: "0 14px",
+  height: 36,
+  borderRadius: 18,
   border: "1px solid #1f2937",
   background: "#0f172a",
   color: "#e2e8f0",
@@ -66,11 +66,13 @@ const BACK_BUTTON_STYLE: CSSProperties = {
 const SEGMENTED_WRAPPER_STYLE: CSSProperties = {
   display: "inline-flex",
   alignItems: "center",
-  gap: 6,
-  padding: 4,
-  borderRadius: 999,
+  gap: 8,
+  padding: "0 4px",
+  borderRadius: 20,
   border: "1px solid #1f2937",
-  background: "#0b1220",
+  background: "rgba(11, 18, 32, 0.88)",
+  height: 36,
+  boxSizing: "border-box",
 };
 
 const SEGMENT_BUTTON_STYLE: CSSProperties = {
@@ -79,12 +81,12 @@ const SEGMENT_BUTTON_STYLE: CSSProperties = {
   justifyContent: "center",
   minWidth: 96,
   padding: "0 18px",
-  height: 32,
-  borderRadius: 999,
+  height: "100%",
+  borderRadius: 18,
   border: "1px solid transparent",
   background: "transparent",
   color: "#94a3b8",
-  fontSize: 13,
+  fontSize: 14,
   fontWeight: 600,
   letterSpacing: 0.3,
   cursor: "pointer",
@@ -95,7 +97,7 @@ const SEGMENT_BUTTON_STYLE: CSSProperties = {
 const ACTIONS_WRAPPER_STYLE: CSSProperties = {
   display: "flex",
   alignItems: "center",
-  gap: 12,
+  gap: 8,
 };
 
 const SECTION_LEFT_STYLE: CSSProperties = {

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -5,15 +5,54 @@ type TopBarProps = {
   center?: ReactNode;
   right?: ReactNode;
 };
+
+const SECTION_STYLE = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+} as const;
+
 export function TopBar({ left, center, right }: TopBarProps) {
   return (
     <div
-      className="safe-top flex items-center justify-between px-3"
-      style={{ height: "var(--topbar-h)" }}
+      className="safe-top"
+      style={{
+        height: "calc(var(--topbar-h) + env(safe-area-inset-top))",
+        boxSizing: "border-box",
+      }}
     >
-      <div className="flex items-center gap-2">{left}</div>
-      <div className="flex-1 flex justify-center">{center}</div>
-      <div className="flex items-center gap-2">{right}</div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          height: "var(--topbar-h)",
+          paddingLeft: "calc(16px + env(safe-area-inset-left))",
+          paddingRight: "calc(16px + env(safe-area-inset-right))",
+          gap: 16,
+          boxSizing: "border-box",
+        }}
+      >
+        <div style={{ ...SECTION_STYLE, minWidth: 0 }}>{left}</div>
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          {center}
+        </div>
+        <div
+          style={{
+            ...SECTION_STYLE,
+            justifyContent: "flex-end",
+            minWidth: 0,
+          }}
+        >
+          {right}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2,9 +2,14 @@
   --topbar-h: 56px;
   --transport-h: 76px;
   --controls-h: clamp(220px, 38dvh, 420px);
+  --hpad: 16px;
+  --gap-sm: 8px;
+  --timeline-collapsed-h: clamp(180px, 42dvh, 420px);
 }
 @supports (height: 100dvh){
   .vh{ height: 100dvh; }
 }
 .safe-top{ padding-top: env(safe-area-inset-top); }
 .safe-bottom{ padding-bottom: env(safe-area-inset-bottom); }
+.scroll-y{ overflow-y: auto; -webkit-overflow-scrolling: touch; }
+.min-h-0{ min-height: 0; }

--- a/src/views/song/TimelineGrid.tsx
+++ b/src/views/song/TimelineGrid.tsx
@@ -40,35 +40,45 @@ export function TimelineGrid<
   renderRow,
 }: TimelineGridProps<Row, Column>) {
   return (
-    <div className="w-full h-full">
-      {(renderColHeader || onAddColumn) && (
-        <div className="flex items-center gap-2 mb-2">
-          {columns.map((c) => (
-            <div key={c.id} className="flex-1 min-w-[120px]">
-              {renderColHeader?.(c)}
-            </div>
-          ))}
-          {onAddColumn && <button onClick={onAddColumn}>+ Column</button>}
-        </div>
-      )}
-      <div className="flex flex-col gap-2">
-        {rows.map((r) =>
-          renderRow ? (
-            <div key={r.id} className="w-full">
-              {renderRow(r, columns, renderCell)}
-            </div>
-          ) : (
-            <div key={r.id} className="flex items-stretch gap-2">
-              {renderRowHeader?.(r)}
+    <div className="w-full bg-[color:var(--card-bg,#1a1d25)]">
+      <div
+        className="overflow-x-auto scroll-y"
+        style={{
+          paddingLeft: "var(--hpad)",
+          paddingRight: "var(--hpad)",
+        }}
+      >
+        <div className="w-full h-full">
+          {(renderColHeader || onAddColumn) && (
+            <div className="flex items-center gap-2 mb-2">
               {columns.map((c) => (
-                <div key={c.id} className="flex-1 min-w-[120px] bg-white/3">
-                  {renderCell(r, c)}
+                <div key={c.id} className="flex-1 min-w-[120px]">
+                  {renderColHeader?.(c)}
                 </div>
               ))}
+              {onAddColumn && <button onClick={onAddColumn}>+ Column</button>}
             </div>
-          )
-        )}
-        {onAddRow && <button onClick={onAddRow}>+ Row</button>}
+          )}
+          <div className="flex flex-col gap-2">
+            {rows.map((r) =>
+              renderRow ? (
+                <div key={r.id} className="w-full">
+                  {renderRow(r, columns, renderCell)}
+                </div>
+              ) : (
+                <div key={r.id} className="flex items-stretch gap-2">
+                  {renderRowHeader?.(r)}
+                  {columns.map((c) => (
+                    <div key={c.id} className="flex-1 min-w-[120px] bg-white/3">
+                      {renderCell(r, c)}
+                    </div>
+                  ))}
+                </div>
+              )
+            )}
+            {onAddRow && <button onClick={onAddRow}>+ Row</button>}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/views/song/TimelineGrid.tsx
+++ b/src/views/song/TimelineGrid.tsx
@@ -41,14 +41,14 @@ export function TimelineGrid<
 }: TimelineGridProps<Row, Column>) {
   return (
     <div
-      className="w-full bg-[color:var(--card-bg,#1a1d25)]"
+      className="w-full"
       style={{
         width: "100%",
         overflowX: "auto",
         WebkitOverflowScrolling: "touch",
-        paddingLeft: "var(--hpad)",
-        paddingRight: "var(--hpad)",
         boxSizing: "border-box",
+        background: "inherit",
+        margin: 0,
       }}
     >
       {(renderColHeader || onAddColumn) && (

--- a/src/views/song/TimelineGrid.tsx
+++ b/src/views/song/TimelineGrid.tsx
@@ -40,45 +40,45 @@ export function TimelineGrid<
   renderRow,
 }: TimelineGridProps<Row, Column>) {
   return (
-    <div className="w-full bg-[color:var(--card-bg,#1a1d25)]">
-      <div
-        className="overflow-x-auto scroll-y"
-        style={{
-          paddingLeft: "var(--hpad)",
-          paddingRight: "var(--hpad)",
-        }}
-      >
-        <div className="w-full h-full">
-          {(renderColHeader || onAddColumn) && (
-            <div className="flex items-center gap-2 mb-2">
+    <div
+      className="w-full bg-[color:var(--card-bg,#1a1d25)]"
+      style={{
+        width: "100%",
+        overflowX: "auto",
+        WebkitOverflowScrolling: "touch",
+        paddingLeft: "var(--hpad)",
+        paddingRight: "var(--hpad)",
+        boxSizing: "border-box",
+      }}
+    >
+      {(renderColHeader || onAddColumn) && (
+        <div className="flex items-center gap-2 mb-2">
+          {columns.map((c) => (
+            <div key={c.id} className="flex-1 min-w-[120px]">
+              {renderColHeader?.(c)}
+            </div>
+          ))}
+          {onAddColumn && <button onClick={onAddColumn}>+ Column</button>}
+        </div>
+      )}
+      <div className="flex flex-col gap-2">
+        {rows.map((r) =>
+          renderRow ? (
+            <div key={r.id} className="w-full">
+              {renderRow(r, columns, renderCell)}
+            </div>
+          ) : (
+            <div key={r.id} className="flex items-stretch gap-2">
+              {renderRowHeader?.(r)}
               {columns.map((c) => (
-                <div key={c.id} className="flex-1 min-w-[120px]">
-                  {renderColHeader?.(c)}
+                <div key={c.id} className="flex-1 min-w-[120px] bg-white/3">
+                  {renderCell(r, c)}
                 </div>
               ))}
-              {onAddColumn && <button onClick={onAddColumn}>+ Column</button>}
             </div>
-          )}
-          <div className="flex flex-col gap-2">
-            {rows.map((r) =>
-              renderRow ? (
-                <div key={r.id} className="w-full">
-                  {renderRow(r, columns, renderCell)}
-                </div>
-              ) : (
-                <div key={r.id} className="flex items-stretch gap-2">
-                  {renderRowHeader?.(r)}
-                  {columns.map((c) => (
-                    <div key={c.id} className="flex-1 min-w-[120px] bg-white/3">
-                      {renderCell(r, c)}
-                    </div>
-                  ))}
-                </div>
-              )
-            )}
-            {onAddRow && <button onClick={onAddRow}>+ Row</button>}
-          </div>
-        </div>
+          )
+        )}
+        {onAddRow && <button onClick={onAddRow}>+ Row</button>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- align the top bar layout with safe-area padding and reusable view header sections
- restyle the SongView timeline toolbar and transport dock to match mockup spacing and controls
- centralize button styling helpers for consistent SongView actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e06437e9d483289f7349ae9ee551c0