### PR TITLE
Add inline timeline controls

### DIFF
--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -196,6 +196,7 @@ interface TimelineColumn {
   id: string;
   index: number;
   hasSection: boolean;
+  isStarter: boolean;
 }
 
 interface TimelineRowItem {
@@ -1079,12 +1080,15 @@ export function SongView({
   }, [timelineRows, sectionCount]);
 
   const timelineColumns = useMemo<TimelineColumn[]>(
-    () =>
-      Array.from({ length: timelineColumnCount }, (_, index) => ({
+    () => {
+      const hasSections = sectionCount > 0;
+      return Array.from({ length: timelineColumnCount }, (_, index) => ({
         id: `timeline-column-${index}`,
         index,
         hasSection: index < sectionCount,
-      })),
+        isStarter: !hasSections && index === 0,
+      }));
+    },
     [timelineColumnCount, sectionCount]
   );
 
@@ -1900,44 +1904,65 @@ export function SongView({
                       <div
                         style={{
                           display: "grid",
-                          gridTemplateColumns: `repeat(${Math.max(
-                            1,
-                            sectionCount
-                          )}, ${SLOT_WIDTH}px)`,
+                          gridTemplateColumns: `repeat(${timelineColumns.length}, ${SLOT_WIDTH}px)`,
                           gap: SLOT_GAP,
                           width: "100%",
                         }}
                       >
-                        {timelineColumns
-                          .filter((column) => column.hasSection)
-                          .map((column) => (
-                            <button
-                              key={`delete-column-${column.index}`}
-                              type="button"
-                              onClick={() => handleDeleteColumn(column.index)}
-                              style={{
-                                padding: "4px 8px",
-                                borderRadius: 16,
-                                border: "1px solid #2a3344",
-                                background: "#111827",
-                                color: "#e2e8f0",
-                                fontSize: 11,
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                gap: 4,
-                                cursor: "pointer",
-                              }}
-                            >
-                              <span
-                                className="material-symbols-outlined"
-                                style={{ fontSize: 14 }}
+                        {timelineColumns.map((column) => {
+                          if (column.hasSection) {
+                            return (
+                              <button
+                                key={column.id}
+                                type="button"
+                                onClick={() => handleDeleteColumn(column.index)}
+                                style={{
+                                  padding: "4px 8px",
+                                  borderRadius: 16,
+                                  border: "1px solid #2a3344",
+                                  background: "#111827",
+                                  color: "#e2e8f0",
+                                  fontSize: 11,
+                                  display: "flex",
+                                  alignItems: "center",
+                                  justifyContent: "center",
+                                  gap: 4,
+                                  cursor: "pointer",
+                                }}
                               >
-                                delete
-                              </span>
-                              <span>Seq {column.index + 1}</span>
-                            </button>
-                          ))}
+                                <span
+                                  className="material-symbols-outlined"
+                                  style={{ fontSize: 14 }}
+                                >
+                                  delete
+                                </span>
+                                <span>Seq {column.index + 1}</span>
+                              </button>
+                            );
+                          }
+                          if (column.isStarter) {
+                            return (
+                              <div
+                                key={column.id}
+                                style={{
+                                  borderRadius: 8,
+                                  border: "1px solid #273041",
+                                  background: "#0b111d",
+                                  color: "#94a3b8",
+                                  display: "flex",
+                                  alignItems: "center",
+                                  justifyContent: "center",
+                                  fontSize: 12,
+                                  fontWeight: 600,
+                                  letterSpacing: 0.3,
+                                }}
+                              >
+                                Loop 1
+                              </div>
+                            );
+                          }
+                          return <div key={column.id} />;
+                        })}
                       </div>
                     </div>
                     <IconButton

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1093,22 +1093,27 @@ export function SongView({
   const slotPadding = SLOT_PADDING;
   const slotGap = SLOT_CONTENT_GAP;
   const isTrackSelected = isPlayInstrumentOpen;
-  const inlineActionButtonStyle: CSSProperties = {
+  const addLoopButtonStyle: CSSProperties = {
     width: SLOT_WIDTH,
+    minWidth: SLOT_WIDTH,
+    height: slotMinHeight,
     minHeight: slotMinHeight,
     borderRadius: 8,
-    border: "1px solid #1f2937",
+    border: "1px solid #273041",
     background: "#0b111d",
-    color: "#cbd5f5",
-    fontSize: 13,
-    fontWeight: 600,
-    letterSpacing: 0.2,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 6,
-    padding: slotPadding,
-    cursor: "pointer",
+    color: "#27E0B0",
+    boxShadow: "none",
+  };
+  const addRowButtonStyle: CSSProperties = {
+    width: ROW_LABEL_WIDTH,
+    minWidth: ROW_LABEL_WIDTH,
+    height: slotMinHeight,
+    minHeight: slotMinHeight,
+    borderRadius: 8,
+    border: "1px solid #273041",
+    background: "#0f172a",
+    color: "#27E0B0",
+    boxShadow: "none",
   };
   const timelineRegionFlex =
     isTrackSelected && !isTimelineExpanded
@@ -1935,18 +1940,16 @@ export function SongView({
                           ))}
                       </div>
                     </div>
-                    <button
-                      type="button"
+                    <IconButton
+                      icon="add"
+                      label="Add loop"
                       onClick={handleAddSection}
+                      size="compact"
                       style={{
-                        ...inlineActionButtonStyle,
+                        ...addLoopButtonStyle,
                         flexShrink: 0,
-                        color: "#27E0B0",
-                        border: "1px solid #273041",
                       }}
-                    >
-                      + Loop
-                    </button>
+                    />
                   </div>
                 </div>
               </div>
@@ -2059,46 +2062,41 @@ export function SongView({
                   />
                 )}
               </div>
-              <div
-                style={{
-                  marginTop: 8,
-                  marginLeft: ROW_LABEL_WIDTH,
-                }}
-              >
+              <div style={{ marginTop: 8 }}>
                 <div
                   style={{
-                    width: timelineWidthStyle,
-                    minWidth: timelineWidthStyle,
-                    borderRadius: 6,
-                    border: "1px solid #2a3344",
-                    background: "#161d2b",
-                    padding: slotPadding,
+                    display: "flex",
+                    alignItems: "stretch",
+                    gap: SLOT_GAP,
                   }}
                 >
                   <div
                     style={{
-                      display: "grid",
-                      gridTemplateColumns: `repeat(${Math.max(
-                        1,
-                        effectiveColumnCount
-                      )}, ${SLOT_WIDTH}px)`,
-                      gap: SLOT_GAP,
-                      width: "100%",
+                      width: ROW_LABEL_WIDTH,
+                      flexShrink: 0,
+                      display: "flex",
+                      justifyContent: "center",
+                      alignItems: "center",
                     }}
                   >
-                    <button
-                      type="button"
+                    <IconButton
+                      icon="add"
+                      label="Add row"
                       onClick={handleAddRow}
-                      style={{
-                        ...inlineActionButtonStyle,
-                        color: "#27E0B0",
-                        border: "1px solid #273041",
-                        justifySelf: "start",
-                      }}
-                    >
-                      + Row
-                    </button>
+                      size="compact"
+                      style={addRowButtonStyle}
+                    />
                   </div>
+                  <div
+                    style={{
+                      width: timelineWidthStyle,
+                      minWidth: timelineWidthStyle,
+                      borderRadius: 6,
+                      border: "1px solid #2a3344",
+                      background: "#161d2b",
+                      minHeight: slotMinHeight,
+                    }}
+                  />
                 </div>
               </div>
             </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -2199,6 +2199,7 @@ export function SongView({
                     display: "flex",
                     flexDirection: "column",
                     gap: SLOT_GAP,
+                    paddingBottom: STICKY_BOTTOM_BAR_HEIGHT,
                     ...(timelineBodyMinHeight
                       ? { minHeight: timelineBodyMinHeight }
                       : {}),

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -226,6 +226,7 @@ interface TimelineRowItem {
   performanceHighlightRange?: { start: number; end: number; color: string };
   combinedPerformanceNotes: PerformanceNote[];
   rowLabelTitle: string;
+  isPlaceholder?: boolean;
 }
 
 const toTicks = (value: string | number | undefined | null): number => {
@@ -1104,6 +1105,43 @@ export function SongView({
   );
 
   const showPlaceholderCell = songRows.length === 0 && sectionCount === 0;
+  const placeholderTimelineRow = useMemo(() => {
+    if (!showPlaceholderCell) {
+      return null;
+    }
+    return {
+      id: "timeline-row-placeholder",
+      row: createSongRow(1),
+      rowIndex: 0,
+      maxColumns: 1,
+      safeColumnCount: 1,
+      rowMuted: false,
+      rowSolo: false,
+      rowAccent: null,
+      labelBackground: "#111827",
+      rowSelected: false,
+      isPerformanceRow: false,
+      isRecordingRow: false,
+      isArmedRow: false,
+      rowGhostDisplayNotes: [],
+      rowGhostNoteSet: undefined,
+      performanceTrack: undefined,
+      performanceAccent: null,
+      performanceStatusLabel: null,
+      performanceInstrumentLabel: null,
+      performanceDescription: null,
+      performanceHasContent: false,
+      totalPerformanceNotes: 0,
+      performanceTextColor: "#94a3b8",
+      performanceHighlightRange: undefined,
+      combinedPerformanceNotes: [],
+      rowLabelTitle: "Tap the + button to add a row",
+      isPlaceholder: true,
+    } satisfies TimelineRowItem;
+  }, [showPlaceholderCell]);
+  const timelineDisplayRows = placeholderTimelineRow
+    ? [placeholderTimelineRow]
+    : timelineRows;
   const slotMinHeight = SLOT_MIN_HEIGHT;
   const slotPadding = SLOT_PADDING;
   const slotGap = SLOT_CONTENT_GAP;
@@ -1470,6 +1508,140 @@ export function SongView({
       columns: TimelineColumn[],
       renderCell: (row: TimelineRowItem, column: TimelineColumn) => ReactNode
     ) => {
+      if (timelineRow.isPlaceholder) {
+        const columnCount = Math.max(1, columns.length);
+        return (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+              marginBottom: 8,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "stretch",
+                borderRadius: 6,
+                overflow: "hidden",
+                border: "1px solid #2a3344",
+                background: "#111827",
+              }}
+            >
+              <div
+                style={{
+                  width: ROW_LABEL_WIDTH,
+                  flexShrink: 0,
+                  borderRight: "1px solid #2a3344",
+                  background: "#111827",
+                  color: "#f8fafc",
+                  fontSize: 11,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: 0.6,
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 4,
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: 999,
+                      background: "#334155",
+                    }}
+                  />
+                  <span>1</span>
+                </div>
+              </div>
+              <div
+                style={{
+                  flex: 1,
+                  background: "#161d2b",
+                  padding: slotPadding,
+                }}
+              >
+                <div
+                  style={{
+                    width: timelineWidthStyle,
+                    minWidth: timelineWidthStyle,
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: `repeat(${columnCount}, ${SLOT_WIDTH}px)`,
+                      gap: SLOT_GAP,
+                      width: "100%",
+                    }}
+                  >
+                    <button
+                      type="button"
+                      onClick={handleEmptyPlaceholderClick}
+                      style={{
+                        width: "100%",
+                        minHeight: slotMinHeight,
+                        borderRadius: 8,
+                        border: "1px solid #1f2937",
+                        background: "#0b111d",
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "stretch",
+                        justifyContent: "space-between",
+                        gap: slotGap,
+                        padding: slotPadding,
+                        color: "#94a3b8",
+                        cursor: "pointer",
+                        textAlign: "left",
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: 6,
+                        }}
+                      >
+                        <span
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 600,
+                            color: "#cbd5f5",
+                          }}
+                        >
+                          Empty
+                        </span>
+                        <div
+                          style={{
+                            height: 18,
+                            borderRadius: 999,
+                            border: "1px dashed #1f2937",
+                            background: "#10192c",
+                          }}
+                        />
+                      </div>
+                      <span style={{ fontSize: 11, color: "#64748b" }}>
+                        Tap to assign
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      }
       const {
         row,
         rowIndex,
@@ -1788,6 +1960,7 @@ export function SongView({
       );
     },
     [
+      handleEmptyPlaceholderClick,
       setEditingSlot,
       setRowSettingsIndex,
       handleToggleRowSolo,
@@ -1996,149 +2169,14 @@ export function SongView({
                   minWidth: timelineWidthStyle,
                 }}
               >
-                {showPlaceholderCell ? (
-                  <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 6,
-                      marginBottom: 8,
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "stretch",
-                        borderRadius: 6,
-                        overflow: "hidden",
-                        border: "1px solid #2a3344",
-                        background: "#111827",
-                      }}
-                    >
-                      <div
-                        style={{
-                          width: ROW_LABEL_WIDTH,
-                          flexShrink: 0,
-                          borderRight: "1px solid #2a3344",
-                          background: "#111827",
-                          color: "#f8fafc",
-                          fontSize: 11,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          fontWeight: 700,
-                          textTransform: "uppercase",
-                          letterSpacing: 0.6,
-                        }}
-                      >
-                        <div
-                          style={{
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            gap: 4,
-                          }}
-                        >
-                          <span
-                            aria-hidden="true"
-                            style={{
-                              width: 10,
-                              height: 10,
-                              borderRadius: 999,
-                              background: "#334155",
-                            }}
-                          />
-                          <span>1</span>
-                        </div>
-                      </div>
-                      <div
-                        style={{
-                          flex: 1,
-                          background: "#161d2b",
-                          padding: slotPadding,
-                        }}
-                      >
-                        <div
-                          style={{
-                            width: timelineWidthStyle,
-                            minWidth: timelineWidthStyle,
-                          }}
-                        >
-                          <div
-                            style={{
-                              display: "grid",
-                              gridTemplateColumns: `repeat(1, ${SLOT_WIDTH}px)`,
-                              gap: SLOT_GAP,
-                              width: "100%",
-                            }}
-                          >
-                            <button
-                              type="button"
-                              onClick={handleEmptyPlaceholderClick}
-                              style={{
-                                width: "100%",
-                                minHeight: slotMinHeight,
-                                borderRadius: 8,
-                                border: "1px solid #1f2937",
-                                background: "#0b111d",
-                                display: "flex",
-                                flexDirection: "column",
-                                alignItems: "stretch",
-                                justifyContent: "space-between",
-                                gap: slotGap,
-                                padding: slotPadding,
-                                color: "#94a3b8",
-                                cursor:
-                                  patternGroups.length > 0
-                                    ? "pointer"
-                                    : "not-allowed",
-                              }}
-                              disabled={patternGroups.length === 0}
-                            >
-                              <div
-                                style={{
-                                  display: "flex",
-                                  flexDirection: "column",
-                                  gap: 6,
-                                }}
-                              >
-                                <span
-                                  style={{
-                                    fontSize: 13,
-                                    fontWeight: 600,
-                                    color: "#cbd5f5",
-                                  }}
-                                >
-                                  Empty
-                                </span>
-                                <div
-                                  style={{
-                                    height: 18,
-                                    borderRadius: 999,
-                                    border: "1px dashed #1f2937",
-                                    background: "#10192c",
-                                  }}
-                                />
-                              </div>
-                              <span style={{ fontSize: 11, color: "#64748b" }}>
-                                Tap to assign
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <TimelineGrid
-                    rows={timelineRows}
-                    columns={timelineColumns}
-                    renderCell={renderTimelineCell}
-                    renderRow={(row, cols, cellRenderer) =>
-                      renderTimelineRow(row, cols, cellRenderer)
-                    }
-                  />
-                )}
+                <TimelineGrid
+                  rows={timelineDisplayRows}
+                  columns={timelineColumns}
+                  renderCell={renderTimelineCell}
+                  renderRow={(row, cols, cellRenderer) =>
+                    renderTimelineRow(row, cols, cellRenderer)
+                  }
+                />
               </div>
               <div style={{ marginTop: 8 }}>
                 <div

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -2241,16 +2241,6 @@ export function SongView({
                         style={addRowButtonStyle}
                       />
                     </div>
-                    <div
-                      style={{
-                        width: timelineWidthPx ?? "100%",
-                        minWidth: timelineWidthPx,
-                        borderRadius: 6,
-                        border: "1px solid #2a3344",
-                        background: "#161d2b",
-                        minHeight: slotMinHeight,
-                      }}
-                    />
                   </div>
                 </div>
               </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1204,19 +1204,9 @@ export function SongView({
     return `${timelineContentHeight}px`;
   }, [timelineContentHeight]);
 
-  const timelineScrollableHeight = useMemo(() => {
-    if (timelineContentHeight < 0) {
-      return undefined;
-    }
-    return timelineContentHeight + slotMinHeight + SLOT_GAP;
-  }, [timelineContentHeight, slotMinHeight]);
-
-  const timelineScrollHeightPx = useMemo(() => {
-    if (!timelineScrollableHeight || timelineScrollableHeight <= 0) {
-      return undefined;
-    }
-    return `${timelineScrollableHeight}px`;
-  }, [timelineScrollableHeight]);
+  const timelineScrollPaddingBottom = useMemo(() => {
+    return slotMinHeight + SLOT_GAP;
+  }, [slotMinHeight]);
 
   const isTrackSelected = isPlayInstrumentOpen;
   const addLoopButtonStyle: CSSProperties = {
@@ -2068,9 +2058,8 @@ export function SongView({
               className="scrollable"
               style={{
                 overflowX: "auto",
-                paddingBottom: 4,
+                paddingBottom: timelineScrollPaddingBottom,
                 height: "100%",
-                minHeight: timelineScrollHeightPx ?? "100%",
               }}
             >
               <div

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -77,6 +77,7 @@ const SLOT_PADDING = "4px 10px";
 const TIMELINE_TOOLBAR_GAP = 12;
 const TIMELINE_CONTROL_HEIGHT = 36;
 const TRANSPORT_CONTROL_HEIGHT = 44;
+const TIMELINE_ROW_MARGIN = 8;
 
 const TIMELINE_LABEL_STYLE: CSSProperties = {
   fontSize: 14,
@@ -1194,9 +1195,16 @@ export function SongView({
     const rowCount = Math.max(1, timelineDisplayRows.length);
     const totalRowHeight = rowCount * slotMinHeight;
     const totalRowGap = Math.max(0, rowCount - 1) * SLOT_GAP;
+    const totalRowMargin = rowCount * TIMELINE_ROW_MARGIN;
     const inlineAddRowHeight = slotMinHeight;
     const inlineAddRowGap = SLOT_GAP;
-    return totalRowHeight + totalRowGap + inlineAddRowGap + inlineAddRowHeight;
+    return (
+      totalRowHeight +
+      totalRowGap +
+      totalRowMargin +
+      inlineAddRowGap +
+      inlineAddRowHeight
+    );
   }, [timelineDisplayRows.length, slotMinHeight]);
 
   const timelineBodyMinHeight = useMemo(() => {

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -777,11 +777,11 @@ export function SongView({
     );
   }, [effectiveColumnCount]);
 
-  const timelineWidthStyle = useMemo(() => {
+  const timelineWidthPx = useMemo(() => {
     if (timelineContentWidth <= 0) {
-      return "100%";
+      return undefined;
     }
-    return `max(100%, ${timelineContentWidth}px)`;
+    return `${timelineContentWidth}px`;
   }, [timelineContentWidth]);
 
 
@@ -1810,8 +1810,8 @@ export function SongView({
             >
               <div
                 style={{
-                  width: timelineWidthStyle,
-                  minWidth: timelineWidthStyle,
+                  width: "100%",
+                  minWidth: timelineWidthPx,
                 }}
               >
                 <div
@@ -1938,7 +1938,7 @@ export function SongView({
       handleSelectPerformanceTrackRow,
       playInstrumentRowTrackId,
       slotPadding,
-      timelineWidthStyle,
+      timelineWidthPx,
       slotMinHeight,
       slotGap,
       withAlpha,
@@ -2046,13 +2046,13 @@ export function SongView({
                       alignItems: "center",
                       gap: SLOT_GAP,
                       width: "fit-content",
-                      minWidth: timelineWidthStyle,
+                      minWidth: timelineWidthPx,
                     }}
                   >
                     <div
                       style={{
-                        width: timelineWidthStyle,
-                        minWidth: timelineWidthStyle,
+                        width: timelineWidthPx ?? "100%",
+                        minWidth: timelineWidthPx,
                       }}
                     >
                       <div
@@ -2068,7 +2068,7 @@ export function SongView({
                             gridTemplateColumns: `repeat(${timelineColumns.length}, ${SLOT_WIDTH}px) ${SLOT_MIN_HEIGHT}px`,
                             gap: SLOT_GAP,
                             flex: "0 0 auto",
-                            minWidth: timelineWidthStyle,
+                            minWidth: timelineWidthPx,
                           }}
                         >
                           {timelineColumns.map((column) => {
@@ -2148,8 +2148,8 @@ export function SongView({
               </div>
               <div
                 style={{
-                  width: timelineWidthStyle,
-                  minWidth: timelineWidthStyle,
+                  width: timelineWidthPx ?? "100%",
+                  minWidth: timelineWidthPx,
                 }}
               >
                 <TimelineGrid
@@ -2191,8 +2191,8 @@ export function SongView({
                   </div>
                   <div
                     style={{
-                      width: timelineWidthStyle,
-                      minWidth: timelineWidthStyle,
+                      width: timelineWidthPx ?? "100%",
+                      minWidth: timelineWidthPx,
                       borderRadius: 6,
                       border: "1px solid #2a3344",
                       background: "#161d2b",

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1199,7 +1199,7 @@ export function SongView({
     return totalRowHeight + totalRowGap + inlineAddRowGap + inlineAddRowHeight;
   }, [timelineDisplayRows.length, slotMinHeight]);
 
-  const timelineHeightPx = useMemo(() => {
+  const timelineBodyMinHeight = useMemo(() => {
     if (timelineContentHeight <= 0) {
       return undefined;
     }
@@ -2082,7 +2082,6 @@ export function SongView({
                       style={{
                         width: timelineWidthPx ?? "100%",
                         minWidth: timelineWidthPx,
-                        minHeight: timelineHeightPx,
                       }}
                     >
                       <div
@@ -2182,53 +2181,63 @@ export function SongView({
                   minWidth: timelineWidthPx,
                 }}
               >
-                <TimelineGrid
-                  rows={timelineDisplayRows}
-                  columns={timelineColumns}
-                  renderCell={renderTimelineCell}
-                  renderRow={(row, cols, cellRenderer) =>
-                    renderTimelineRow(row, cols, cellRenderer)
-                  }
-                />
-              </div>
-              <div style={{ marginTop: 8 }}>
                 <div
                   style={{
                     display: "flex",
-                    alignItems: "stretch",
+                    flexDirection: "column",
                     gap: SLOT_GAP,
+                    ...(timelineBodyMinHeight
+                      ? { minHeight: timelineBodyMinHeight }
+                      : {}),
                   }}
                 >
+                  <TimelineGrid
+                    rows={timelineDisplayRows}
+                    columns={timelineColumns}
+                    renderCell={renderTimelineCell}
+                    renderRow={(row, cols, cellRenderer) =>
+                      renderTimelineRow(row, cols, cellRenderer)
+                    }
+                  />
                   <div
                     style={{
-                      width: ROW_LABEL_WIDTH,
-                      flexShrink: 0,
                       display: "flex",
-                      justifyContent: "center",
-                      alignItems: "center",
-                      borderRadius: 6,
-                      border: "1px solid #2a3344",
-                      background: "#111827",
+                      alignItems: "stretch",
+                      gap: SLOT_GAP,
+                      flexShrink: 0,
                     }}
                   >
-                    <IconButton
-                      icon="add"
-                      label="Add row"
-                      onClick={handleAddRow}
-                      size="compact"
-                      style={addRowButtonStyle}
+                    <div
+                      style={{
+                        width: ROW_LABEL_WIDTH,
+                        flexShrink: 0,
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        borderRadius: 6,
+                        border: "1px solid #2a3344",
+                        background: "#111827",
+                      }}
+                    >
+                      <IconButton
+                        icon="add"
+                        label="Add row"
+                        onClick={handleAddRow}
+                        size="compact"
+                        style={addRowButtonStyle}
+                      />
+                    </div>
+                    <div
+                      style={{
+                        width: timelineWidthPx ?? "100%",
+                        minWidth: timelineWidthPx,
+                        borderRadius: 6,
+                        border: "1px solid #2a3344",
+                        background: "#161d2b",
+                        minHeight: slotMinHeight,
+                      }}
                     />
                   </div>
-                  <div
-                    style={{
-                      width: timelineWidthPx ?? "100%",
-                      minWidth: timelineWidthPx,
-                      borderRadius: 6,
-                      border: "1px solid #2a3344",
-                      background: "#161d2b",
-                      minHeight: slotMinHeight,
-                    }}
-                  />
                 </div>
               </div>
             </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1098,8 +1098,8 @@ export function SongView({
   const slotGap = SLOT_CONTENT_GAP;
   const isTrackSelected = isPlayInstrumentOpen;
   const addLoopButtonStyle: CSSProperties = {
-    width: SLOT_WIDTH,
-    minWidth: SLOT_WIDTH,
+    width: slotMinHeight,
+    minWidth: slotMinHeight,
     height: slotMinHeight,
     minHeight: slotMinHeight,
     borderRadius: 8,
@@ -1957,7 +1957,7 @@ export function SongView({
                                   letterSpacing: 0.3,
                                 }}
                               >
-                                Loop 1
+                                Seq 1
                               </div>
                             );
                           }
@@ -1973,6 +1973,7 @@ export function SongView({
                       style={{
                         ...addLoopButtonStyle,
                         flexShrink: 0,
+                        marginLeft: SLOT_GAP,
                       }}
                     />
                   </div>
@@ -2008,18 +2009,36 @@ export function SongView({
                           width: ROW_LABEL_WIDTH,
                           flexShrink: 0,
                           borderRight: "1px solid #2a3344",
-                          background: "#0f172a",
-                          color: "#64748b",
+                          background: "#111827",
+                          color: "#f8fafc",
                           fontSize: 11,
-                          fontWeight: 700,
-                          letterSpacing: 0.6,
-                          textTransform: "uppercase",
                           display: "flex",
                           alignItems: "center",
                           justifyContent: "center",
+                          fontWeight: 700,
+                          textTransform: "uppercase",
+                          letterSpacing: 0.6,
                         }}
                       >
-                        Row 1
+                        <div
+                          style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            gap: 4,
+                          }}
+                        >
+                          <span
+                            aria-hidden="true"
+                            style={{
+                              width: 10,
+                              height: 10,
+                              borderRadius: 999,
+                              background: "#334155",
+                            }}
+                          />
+                          <span>1</span>
+                        </div>
                       </div>
                       <div
                         style={{
@@ -2051,22 +2070,38 @@ export function SongView({
                                 background: "#0b111d",
                                 display: "flex",
                                 flexDirection: "column",
-                                justifyContent: "center",
-                                alignItems: "flex-start",
-                                gap: 4,
+                                alignItems: "stretch",
+                                justifyContent: "space-between",
+                                gap: slotGap,
                                 padding: slotPadding,
                                 color: "#94a3b8",
                               }}
                             >
-                              <span
+                              <div
                                 style={{
-                                  fontSize: 13,
-                                  fontWeight: 600,
-                                  color: "#cbd5f5",
+                                  display: "flex",
+                                  flexDirection: "column",
+                                  gap: 6,
                                 }}
                               >
-                                Empty
-                              </span>
+                                <span
+                                  style={{
+                                    fontSize: 13,
+                                    fontWeight: 600,
+                                    color: "#cbd5f5",
+                                  }}
+                                >
+                                  Empty
+                                </span>
+                                <div
+                                  style={{
+                                    height: 18,
+                                    borderRadius: 999,
+                                    border: "1px dashed #1f2937",
+                                    background: "#10192c",
+                                  }}
+                                />
+                              </div>
                               <span style={{ fontSize: 11, color: "#64748b" }}>
                                 Tap to assign
                               </span>
@@ -2102,6 +2137,9 @@ export function SongView({
                       display: "flex",
                       justifyContent: "center",
                       alignItems: "center",
+                      borderRadius: 6,
+                      border: "1px solid #2a3344",
+                      background: "#111827",
                     }}
                   >
                     <IconButton

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1194,7 +1194,9 @@ export function SongView({
     const rowCount = Math.max(1, timelineDisplayRows.length);
     const totalRowHeight = rowCount * slotMinHeight;
     const totalRowGap = Math.max(0, rowCount - 1) * SLOT_GAP;
-    return totalRowHeight + totalRowGap;
+    const inlineAddRowHeight = slotMinHeight;
+    const inlineAddRowGap = SLOT_GAP;
+    return totalRowHeight + totalRowGap + inlineAddRowGap + inlineAddRowHeight;
   }, [timelineDisplayRows.length, slotMinHeight]);
 
   const timelineHeightPx = useMemo(() => {
@@ -1203,10 +1205,6 @@ export function SongView({
     }
     return `${timelineContentHeight}px`;
   }, [timelineContentHeight]);
-
-  const timelineScrollPaddingBottom = useMemo(() => {
-    return slotMinHeight + SLOT_GAP;
-  }, [slotMinHeight]);
 
   const isTrackSelected = isPlayInstrumentOpen;
   const addLoopButtonStyle: CSSProperties = {
@@ -2058,7 +2056,6 @@ export function SongView({
               className="scrollable"
               style={{
                 overflowX: "auto",
-                paddingBottom: timelineScrollPaddingBottom,
                 height: "100%",
               }}
             >

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -2061,9 +2061,10 @@ export function SongView({
                         <div
                           style={{
                             display: "grid",
-                            gridTemplateColumns: `repeat(${timelineColumns.length}, ${SLOT_WIDTH}px)`,
+                            gridTemplateColumns: `repeat(${timelineColumns.length}, ${SLOT_WIDTH}px) ${SLOT_MIN_HEIGHT}px`,
                             gap: SLOT_GAP,
-                            flex: "1 1 auto",
+                            flex: "0 0 auto",
+                            minWidth: timelineWidthStyle,
                           }}
                         >
                           {timelineColumns.map((column) => {
@@ -2123,18 +2124,19 @@ export function SongView({
                             }
                             return <div key={column.id} />;
                           })}
+                          <IconButton
+                            key="timeline-add-loop"
+                            icon="add"
+                            label="Add loop"
+                            onClick={handleAddSection}
+                            size="compact"
+                            style={{
+                              ...addLoopButtonStyle,
+                              justifySelf: "center",
+                              alignSelf: "stretch",
+                            }}
+                          />
                         </div>
-                        <IconButton
-                          icon="add"
-                          label="Add loop"
-                          onClick={handleAddSection}
-                          size="compact"
-                          style={{
-                            ...addLoopButtonStyle,
-                            flexShrink: 0,
-                            marginLeft: SLOT_GAP,
-                          }}
-                        />
                       </div>
                     </div>
                   </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -826,7 +826,7 @@ export function SongView({
     [setSongRows, setEditingSlot]
   );
 
-  const handleAddRow = () => {
+  const handleAddRow = useCallback(() => {
     setSongRows((rows) => {
       const maxColumns = rows.reduce(
         (max, row) => Math.max(max, row.slots.length),
@@ -838,7 +838,18 @@ export function SongView({
       }
       return [...rows, newRow];
     });
-  };
+  }, [setSongRows]);
+
+  const handleEmptyPlaceholderClick = useCallback(() => {
+    if (songRows.length > 0) return;
+    handleAddRow();
+    if (typeof window !== "undefined") {
+      window.setTimeout(() => {
+        if (patternGroups.length === 0) return;
+        setEditingSlot({ rowIndex: 0, columnIndex: 0 });
+      }, 0);
+    }
+  }, [handleAddRow, patternGroups.length, setEditingSlot, songRows.length]);
 
   const handleAssignSlot = (
     rowIndex: number,
@@ -2061,7 +2072,9 @@ export function SongView({
                               width: "100%",
                             }}
                           >
-                            <div
+                            <button
+                              type="button"
+                              onClick={handleEmptyPlaceholderClick}
                               style={{
                                 width: "100%",
                                 minHeight: slotMinHeight,
@@ -2075,7 +2088,12 @@ export function SongView({
                                 gap: slotGap,
                                 padding: slotPadding,
                                 color: "#94a3b8",
+                                cursor:
+                                  patternGroups.length > 0
+                                    ? "pointer"
+                                    : "not-allowed",
                               }}
+                              disabled={patternGroups.length === 0}
                             >
                               <div
                                 style={{
@@ -2105,7 +2123,7 @@ export function SongView({
                               <span style={{ fontSize: 11, color: "#64748b" }}>
                                 Tap to assign
                               </span>
-                            </div>
+                            </button>
                           </div>
                         </div>
                       </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1088,12 +1088,28 @@ export function SongView({
     [timelineColumnCount, sectionCount]
   );
 
-  const hasPerformanceRow = songRows.some((row) => Boolean(row.performanceTrackId));
-  const showEmptyTimeline = sectionCount === 0 && !hasPerformanceRow;
+  const showPlaceholderCell = songRows.length === 0 && sectionCount === 0;
   const slotMinHeight = SLOT_MIN_HEIGHT;
   const slotPadding = SLOT_PADDING;
   const slotGap = SLOT_CONTENT_GAP;
   const isTrackSelected = isPlayInstrumentOpen;
+  const inlineActionButtonStyle: CSSProperties = {
+    width: SLOT_WIDTH,
+    minHeight: slotMinHeight,
+    borderRadius: 8,
+    border: "1px solid #1f2937",
+    background: "#0b111d",
+    color: "#cbd5f5",
+    fontSize: 13,
+    fontWeight: 600,
+    letterSpacing: 0.2,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    padding: slotPadding,
+    cursor: "pointer",
+  };
   const timelineRegionFlex =
     isTrackSelected && !isTimelineExpanded
       ? "0 0 var(--timeline-collapsed-h)"
@@ -1852,76 +1868,185 @@ export function SongView({
                 minHeight: "100%",
               }}
             >
-              {sectionCount > 0 ? (
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    marginBottom: 8,
-                  }}
-                >
-                  <div style={{ width: ROW_LABEL_WIDTH, flexShrink: 0 }} />
-                  <div style={{ flex: 1, overflow: "hidden" }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  marginBottom: 8,
+                }}
+              >
+                <div style={{ width: ROW_LABEL_WIDTH, flexShrink: 0 }} />
+                <div style={{ flex: 1, overflow: "hidden" }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: SLOT_GAP,
+                      width: "fit-content",
+                      minWidth: timelineWidthStyle,
+                    }}
+                  >
                     <div
                       style={{
-                        display: "grid",
-                        gridTemplateColumns: `repeat(${sectionCount}, ${SLOT_WIDTH}px)`,
-                        gap: SLOT_GAP,
                         width: timelineWidthStyle,
                         minWidth: timelineWidthStyle,
                       }}
                     >
-                      {timelineColumns
-                        .filter((column) => column.hasSection)
-                        .map((column) => (
-                          <button
-                            key={`delete-column-${column.index}`}
-                            type="button"
-                            onClick={() => handleDeleteColumn(column.index)}
-                            style={{
-                              padding: "4px 8px",
-                              borderRadius: 16,
-                              border: "1px solid #2a3344",
-                              background: "#111827",
-                              color: "#e2e8f0",
-                              fontSize: 11,
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                              gap: 4,
-                              cursor: "pointer",
-                            }}
-                          >
-                            <span
-                              className="material-symbols-outlined"
-                              style={{ fontSize: 14 }}
+                      <div
+                        style={{
+                          display: "grid",
+                          gridTemplateColumns: `repeat(${Math.max(
+                            1,
+                            sectionCount
+                          )}, ${SLOT_WIDTH}px)`,
+                          gap: SLOT_GAP,
+                          width: "100%",
+                        }}
+                      >
+                        {timelineColumns
+                          .filter((column) => column.hasSection)
+                          .map((column) => (
+                            <button
+                              key={`delete-column-${column.index}`}
+                              type="button"
+                              onClick={() => handleDeleteColumn(column.index)}
+                              style={{
+                                padding: "4px 8px",
+                                borderRadius: 16,
+                                border: "1px solid #2a3344",
+                                background: "#111827",
+                                color: "#e2e8f0",
+                                fontSize: 11,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                gap: 4,
+                                cursor: "pointer",
+                              }}
                             >
-                              delete
-                            </span>
-                            <span>Seq {column.index + 1}</span>
-                          </button>
-                        ))}
+                              <span
+                                className="material-symbols-outlined"
+                                style={{ fontSize: 14 }}
+                              >
+                                delete
+                              </span>
+                              <span>Seq {column.index + 1}</span>
+                            </button>
+                          ))}
+                      </div>
                     </div>
+                    <button
+                      type="button"
+                      onClick={handleAddSection}
+                      style={{
+                        ...inlineActionButtonStyle,
+                        flexShrink: 0,
+                        color: "#27E0B0",
+                        border: "1px solid #273041",
+                      }}
+                    >
+                      + Loop
+                    </button>
                   </div>
                 </div>
-              ) : null}
+              </div>
               <div
                 style={{
                   width: timelineWidthStyle,
                   minWidth: timelineWidthStyle,
                 }}
               >
-                {showEmptyTimeline ? (
+                {showPlaceholderCell ? (
                   <div
                     style={{
-                      padding: 24,
-                      borderRadius: 8,
-                      border: "1px dashed #475569",
-                      color: "#94a3b8",
-                      fontSize: 13,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 6,
+                      marginBottom: 8,
                     }}
                   >
-                    Add a sequence to start placing loops into the timeline.
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "stretch",
+                        borderRadius: 6,
+                        overflow: "hidden",
+                        border: "1px solid #2a3344",
+                        background: "#111827",
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: ROW_LABEL_WIDTH,
+                          flexShrink: 0,
+                          borderRight: "1px solid #2a3344",
+                          background: "#0f172a",
+                          color: "#64748b",
+                          fontSize: 11,
+                          fontWeight: 700,
+                          letterSpacing: 0.6,
+                          textTransform: "uppercase",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        Row 1
+                      </div>
+                      <div
+                        style={{
+                          flex: 1,
+                          background: "#161d2b",
+                          padding: slotPadding,
+                        }}
+                      >
+                        <div
+                          style={{
+                            width: timelineWidthStyle,
+                            minWidth: timelineWidthStyle,
+                          }}
+                        >
+                          <div
+                            style={{
+                              display: "grid",
+                              gridTemplateColumns: `repeat(1, ${SLOT_WIDTH}px)`,
+                              gap: SLOT_GAP,
+                              width: "100%",
+                            }}
+                          >
+                            <div
+                              style={{
+                                width: "100%",
+                                minHeight: slotMinHeight,
+                                borderRadius: 8,
+                                border: "1px solid #1f2937",
+                                background: "#0b111d",
+                                display: "flex",
+                                flexDirection: "column",
+                                justifyContent: "center",
+                                alignItems: "flex-start",
+                                gap: 4,
+                                padding: slotPadding,
+                                color: "#94a3b8",
+                              }}
+                            >
+                              <span
+                                style={{
+                                  fontSize: 13,
+                                  fontWeight: 600,
+                                  color: "#cbd5f5",
+                                }}
+                              >
+                                Empty
+                              </span>
+                              <span style={{ fontSize: 11, color: "#64748b" }}>
+                                Tap to assign
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 ) : (
                   <TimelineGrid
@@ -1933,6 +2058,48 @@ export function SongView({
                     }
                   />
                 )}
+              </div>
+              <div
+                style={{
+                  marginTop: 8,
+                  marginLeft: ROW_LABEL_WIDTH,
+                }}
+              >
+                <div
+                  style={{
+                    width: timelineWidthStyle,
+                    minWidth: timelineWidthStyle,
+                    borderRadius: 6,
+                    border: "1px solid #2a3344",
+                    background: "#161d2b",
+                    padding: slotPadding,
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: `repeat(${Math.max(
+                        1,
+                        effectiveColumnCount
+                      )}, ${SLOT_WIDTH}px)`,
+                      gap: SLOT_GAP,
+                      width: "100%",
+                    }}
+                  >
+                    <button
+                      type="button"
+                      onClick={handleAddRow}
+                      style={{
+                        ...inlineActionButtonStyle,
+                        color: "#27E0B0",
+                        border: "1px solid #273041",
+                        justifySelf: "start",
+                      }}
+                    >
+                      + Row
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -766,26 +766,6 @@ export function SongView({
     ghostColumnCount
   );
 
-  const timelineContentWidth = useMemo(() => {
-    const columns = Math.max(1, effectiveColumnCount);
-    const totalSlotWidth = columns * SLOT_WIDTH;
-    const totalGapWidth = Math.max(0, columns - 1) * SLOT_GAP;
-    const addLoopColumnWidth = SLOT_MIN_HEIGHT;
-    const addLoopGapWidth = SLOT_GAP;
-    return (
-      totalSlotWidth + totalGapWidth + addLoopColumnWidth + addLoopGapWidth
-    );
-  }, [effectiveColumnCount]);
-
-  const timelineWidthPx = useMemo(() => {
-    if (timelineContentWidth <= 0) {
-      return undefined;
-    }
-    return `${timelineContentWidth}px`;
-  }, [timelineContentWidth]);
-
-
-
   useEffect(() => {
     if (!editingSlot) return;
     if (patternGroups.length === 0) {
@@ -1135,6 +1115,39 @@ export function SongView({
     [timelineColumnCount, sectionCount]
   );
 
+  const timelineContentWidth = useMemo(() => {
+    const columnCount = Math.max(1, timelineColumns.length);
+    const totalSlotWidth = columnCount * SLOT_WIDTH;
+    const totalGapWidth = Math.max(0, columnCount - 1) * SLOT_GAP;
+    const addLoopColumnWidth = SLOT_MIN_HEIGHT;
+    const addLoopGapWidth = SLOT_GAP;
+    return (
+      totalSlotWidth + totalGapWidth + addLoopColumnWidth + addLoopGapWidth
+    );
+  }, [timelineColumns.length]);
+
+  const timelineWidthPx = useMemo(() => {
+    if (timelineContentWidth <= 0) {
+      return undefined;
+    }
+    return `${timelineContentWidth}px`;
+  }, [timelineContentWidth]);
+
+  const timelineHeaderScrollableWidth = useMemo(() => {
+    if (timelineContentWidth <= 0) {
+      return undefined;
+    }
+    const labelColumnGap = SLOT_GAP;
+    return ROW_LABEL_WIDTH + labelColumnGap + timelineContentWidth;
+  }, [timelineContentWidth]);
+
+  const timelineHeaderWidthPx = useMemo(() => {
+    if (!timelineHeaderScrollableWidth || timelineHeaderScrollableWidth <= 0) {
+      return undefined;
+    }
+    return `${timelineHeaderScrollableWidth}px`;
+  }, [timelineHeaderScrollableWidth]);
+
   const showPlaceholderCell = songRows.length === 0 && sectionCount === 0;
   const placeholderTimelineRow = useMemo(() => {
     if (!showPlaceholderCell) {
@@ -1176,6 +1189,35 @@ export function SongView({
   const slotMinHeight = SLOT_MIN_HEIGHT;
   const slotPadding = SLOT_PADDING;
   const slotGap = SLOT_CONTENT_GAP;
+
+  const timelineContentHeight = useMemo(() => {
+    const rowCount = Math.max(1, timelineDisplayRows.length);
+    const totalRowHeight = rowCount * slotMinHeight;
+    const totalRowGap = Math.max(0, rowCount - 1) * SLOT_GAP;
+    return totalRowHeight + totalRowGap;
+  }, [timelineDisplayRows.length, slotMinHeight]);
+
+  const timelineHeightPx = useMemo(() => {
+    if (timelineContentHeight <= 0) {
+      return undefined;
+    }
+    return `${timelineContentHeight}px`;
+  }, [timelineContentHeight]);
+
+  const timelineScrollableHeight = useMemo(() => {
+    if (timelineContentHeight < 0) {
+      return undefined;
+    }
+    return timelineContentHeight + slotMinHeight + SLOT_GAP;
+  }, [timelineContentHeight, slotMinHeight]);
+
+  const timelineScrollHeightPx = useMemo(() => {
+    if (!timelineScrollableHeight || timelineScrollableHeight <= 0) {
+      return undefined;
+    }
+    return `${timelineScrollableHeight}px`;
+  }, [timelineScrollableHeight]);
+
   const isTrackSelected = isPlayInstrumentOpen;
   const addLoopButtonStyle: CSSProperties = {
     width: slotMinHeight,
@@ -2028,7 +2070,7 @@ export function SongView({
                 overflowX: "auto",
                 paddingBottom: 4,
                 height: "100%",
-                minHeight: "100%",
+                minHeight: timelineScrollHeightPx ?? "100%",
               }}
             >
               <div
@@ -2036,6 +2078,7 @@ export function SongView({
                   display: "flex",
                   alignItems: "center",
                   marginBottom: 8,
+                  minWidth: timelineHeaderWidthPx,
                 }}
               >
                 <div style={{ width: ROW_LABEL_WIDTH, flexShrink: 0 }} />
@@ -2053,6 +2096,7 @@ export function SongView({
                       style={{
                         width: timelineWidthPx ?? "100%",
                         minWidth: timelineWidthPx,
+                        minHeight: timelineHeightPx,
                       }}
                     >
                       <div

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -1304,9 +1304,60 @@ export function SongView({
 
   const renderTimelineCell = useCallback(
     (timelineRow: TimelineRowItem, column: TimelineColumn) => {
+      const columnIndex = column.index;
+      const rowIndex = timelineRow.rowIndex;
+
+      if (timelineRow.isPlaceholder) {
+        if (columnIndex !== 0) {
+          return <div key={`slot-${rowIndex}-${columnIndex}`} />;
+        }
+
+        return (
+          <div key={`slot-${rowIndex}-${columnIndex}`}>
+            <button
+              type="button"
+              onClick={handleEmptyPlaceholderClick}
+              style={{
+                width: "100%",
+                minHeight: slotMinHeight,
+                borderRadius: 8,
+                border: "1px solid #1f2937",
+                background: "#0b111d",
+                color: "#94a3b8",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "stretch",
+                justifyContent: "space-between",
+                gap: slotGap,
+                padding: slotPadding,
+                textAlign: "left",
+                cursor: "pointer",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+              >
+                <span style={{ fontWeight: 600, color: "#cbd5f5" }}>
+                  Empty
+                </span>
+              </div>
+              <div style={{ width: "100%" }}>
+                {renderLoopSlotPreview(undefined)}
+              </div>
+              <span style={{ fontSize: 11, color: "#64748b" }}>
+                Tap to assign
+              </span>
+            </button>
+          </div>
+        );
+      }
+
       const {
         row,
-        rowIndex,
         rowMuted,
         rowAccent,
         rowGhostDisplayNotes,
@@ -1316,7 +1367,6 @@ export function SongView({
         combinedPerformanceNotes,
         isRecordingRow,
       } = timelineRow;
-      const columnIndex = column.index;
       const groupId =
         columnIndex < row.slots.length ? row.slots[columnIndex] : null;
       const group = groupId ? patternGroupMap.get(groupId) : undefined;
@@ -1499,6 +1549,7 @@ export function SongView({
       handleAssignSlot,
       setEditingSlot,
       setRowSettingsIndex,
+      handleEmptyPlaceholderClick,
     ]
   );
 
@@ -1508,140 +1559,6 @@ export function SongView({
       columns: TimelineColumn[],
       renderCell: (row: TimelineRowItem, column: TimelineColumn) => ReactNode
     ) => {
-      if (timelineRow.isPlaceholder) {
-        const columnCount = Math.max(1, columns.length);
-        return (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-              marginBottom: 8,
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "stretch",
-                borderRadius: 6,
-                overflow: "hidden",
-                border: "1px solid #2a3344",
-                background: "#111827",
-              }}
-            >
-              <div
-                style={{
-                  width: ROW_LABEL_WIDTH,
-                  flexShrink: 0,
-                  borderRight: "1px solid #2a3344",
-                  background: "#111827",
-                  color: "#f8fafc",
-                  fontSize: 11,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontWeight: 700,
-                  textTransform: "uppercase",
-                  letterSpacing: 0.6,
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    gap: 4,
-                  }}
-                >
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      width: 10,
-                      height: 10,
-                      borderRadius: 999,
-                      background: "#334155",
-                    }}
-                  />
-                  <span>1</span>
-                </div>
-              </div>
-              <div
-                style={{
-                  flex: 1,
-                  background: "#161d2b",
-                  padding: slotPadding,
-                }}
-              >
-                <div
-                  style={{
-                    width: timelineWidthStyle,
-                    minWidth: timelineWidthStyle,
-                  }}
-                >
-                  <div
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: `repeat(${columnCount}, ${SLOT_WIDTH}px)`,
-                      gap: SLOT_GAP,
-                      width: "100%",
-                    }}
-                  >
-                    <button
-                      type="button"
-                      onClick={handleEmptyPlaceholderClick}
-                      style={{
-                        width: "100%",
-                        minHeight: slotMinHeight,
-                        borderRadius: 8,
-                        border: "1px solid #1f2937",
-                        background: "#0b111d",
-                        display: "flex",
-                        flexDirection: "column",
-                        alignItems: "stretch",
-                        justifyContent: "space-between",
-                        gap: slotGap,
-                        padding: slotPadding,
-                        color: "#94a3b8",
-                        cursor: "pointer",
-                        textAlign: "left",
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: "flex",
-                          flexDirection: "column",
-                          gap: 6,
-                        }}
-                      >
-                        <span
-                          style={{
-                            fontSize: 13,
-                            fontWeight: 600,
-                            color: "#cbd5f5",
-                          }}
-                        >
-                          Empty
-                        </span>
-                        <div
-                          style={{
-                            height: 18,
-                            borderRadius: 999,
-                            border: "1px dashed #1f2937",
-                            background: "#10192c",
-                          }}
-                        />
-                      </div>
-                      <span style={{ fontSize: 11, color: "#64748b" }}>
-                        Tap to assign
-                      </span>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      }
       const {
         row,
         rowIndex,
@@ -1666,7 +1583,31 @@ export function SongView({
         safeColumnCount,
         maxColumns,
         rowLabelTitle,
+        isPlaceholder,
       } = timelineRow;
+
+      const displayColumnCount = isPlaceholder
+        ? Math.max(1, columns.length)
+        : safeColumnCount;
+      let displayColumns: TimelineColumn[];
+      if (isPlaceholder) {
+        if (columns.length >= displayColumnCount) {
+          displayColumns = columns.slice(0, displayColumnCount);
+        } else {
+          const extraColumns = Array.from(
+            { length: displayColumnCount - columns.length },
+            (_, index) => ({
+              id: `timeline-placeholder-column-${index}`,
+              index: columns.length + index,
+              hasSection: false,
+              isStarter: index === 0,
+            }) satisfies TimelineColumn
+          );
+          displayColumns = [...columns.slice(0, displayColumnCount), ...extraColumns];
+        }
+      } else {
+        displayColumns = columns.slice(0, maxColumns);
+      }
 
       let labelTimer: number | null = null;
       let longPressTriggered = false;
@@ -1714,15 +1655,19 @@ export function SongView({
           style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 8 }}
         >
           <div
-            onPointerDown={() => {
-              if (isPerformanceRow) {
-                handleSelectPerformanceTrackRow(
-                  row.performanceTrackId ?? null
-                );
-              } else if (playInstrumentRowTrackId) {
-                handleSelectPerformanceTrackRow(null);
-              }
-            }}
+            onPointerDown={
+              isPlaceholder
+                ? undefined
+                : () => {
+                    if (isPerformanceRow) {
+                      handleSelectPerformanceTrackRow(
+                        row.performanceTrackId ?? null
+                      );
+                    } else if (playInstrumentRowTrackId) {
+                      handleSelectPerformanceTrackRow(null);
+                    }
+                  }
+            }
             style={{
               display: "flex",
               alignItems: "stretch",
@@ -1735,28 +1680,38 @@ export function SongView({
             }}
           >
             <div
-              onPointerDown={handleLabelPointerDown}
-              onPointerUp={handleLabelPointerUp}
-              onPointerLeave={handleLabelPointerLeave}
-              onPointerCancel={handleLabelPointerLeave}
+              onPointerDown={
+                isPlaceholder ? undefined : handleLabelPointerDown
+              }
+              onPointerUp={isPlaceholder ? undefined : handleLabelPointerUp}
+              onPointerLeave={
+                isPlaceholder ? undefined : handleLabelPointerLeave
+              }
+              onPointerCancel={
+                isPlaceholder ? undefined : handleLabelPointerLeave
+              }
               style={{
                 width: ROW_LABEL_WIDTH,
                 flexShrink: 0,
                 borderRight: "1px solid #2a3344",
                 background: labelBackground,
-                color: rowMuted ? "#475569" : "#f8fafc",
+                color: isPlaceholder
+                  ? "#f8fafc"
+                  : rowMuted
+                  ? "#475569"
+                  : "#f8fafc",
                 fontSize: 11,
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
                 fontWeight: 700,
                 textTransform: "uppercase",
-                cursor: "pointer",
+                cursor: isPlaceholder ? "default" : "pointer",
                 userSelect: "none",
                 letterSpacing: 0.6,
                 position: "relative",
               }}
-              title={rowLabelTitle}
+              title={isPlaceholder ? undefined : rowLabelTitle}
             >
               <div
                 style={{
@@ -1779,7 +1734,7 @@ export function SongView({
                   }}
                 />
                 <span>{rowIndex + 1}</span>
-                {rowSolo ? (
+                {rowSolo && !isPlaceholder ? (
                   <span
                     style={{
                       fontSize: 9,
@@ -1791,7 +1746,7 @@ export function SongView({
                     SOLO
                   </span>
                 ) : null}
-                {isPerformanceRow && (isRecordingRow || isArmedRow) ? (
+                {isPerformanceRow && (isRecordingRow || isArmedRow) && !isPlaceholder ? (
                   <span
                     style={{
                       fontSize: 9,
@@ -1812,7 +1767,7 @@ export function SongView({
                   </span>
                 ) : null}
               </div>
-              {rowSelected && (
+              {rowSelected && !isPlaceholder && (
                 <span
                   className="material-symbols-outlined"
                   style={{
@@ -1846,7 +1801,7 @@ export function SongView({
                 <div
                   style={{
                     display: "grid",
-                    gridTemplateColumns: `repeat(${safeColumnCount}, ${SLOT_WIDTH}px)`,
+                    gridTemplateColumns: `repeat(${displayColumnCount}, ${SLOT_WIDTH}px)`,
                     gap: SLOT_GAP,
                     width: "100%",
                   }}
@@ -1854,7 +1809,7 @@ export function SongView({
                   {isPerformanceRow ? (
                     <div
                       key={`performance-span-${rowIndex}`}
-                      style={{ gridColumn: `1 / span ${safeColumnCount}` }}
+                      style={{ gridColumn: `1 / span ${displayColumnCount}` }}
                     >
                       <div
                         style={{
@@ -1925,7 +1880,7 @@ export function SongView({
                           {renderPerformanceSlotPreview(
                             performanceTrack,
                             0,
-                            safeColumnCount,
+                            displayColumnCount,
                             performanceAccent ?? rowAccent,
                             rowGhostDisplayNotes,
                             rowGhostNoteSet,
@@ -1948,9 +1903,9 @@ export function SongView({
                       </div>
                     </div>
                   ) : (
-                    columns
-                      .slice(0, maxColumns)
-                      .map((column) => renderCell(timelineRow, column))
+                    displayColumns.map((column) =>
+                      renderCell(timelineRow, column)
+                    )
                   )}
                 </div>
               </div>
@@ -1960,7 +1915,6 @@ export function SongView({
       );
     },
     [
-      handleEmptyPlaceholderClick,
       setEditingSlot,
       setRowSettingsIndex,
       handleToggleRowSolo,

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -2053,79 +2053,90 @@ export function SongView({
                     >
                       <div
                         style={{
-                          display: "grid",
-                          gridTemplateColumns: `repeat(${timelineColumns.length}, ${SLOT_WIDTH}px)`,
-                          gap: SLOT_GAP,
+                          display: "flex",
+                          alignItems: "stretch",
                           width: "100%",
                         }}
                       >
-                        {timelineColumns.map((column) => {
-                          if (column.hasSection) {
-                            return (
-                              <button
-                                key={column.id}
-                                type="button"
-                                onClick={() => handleDeleteColumn(column.index)}
-                                style={{
-                                  padding: "4px 8px",
-                                  borderRadius: 16,
-                                  border: "1px solid #2a3344",
-                                  background: "#111827",
-                                  color: "#e2e8f0",
-                                  fontSize: 11,
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  gap: 4,
-                                  cursor: "pointer",
-                                }}
-                              >
-                                <span
-                                  className="material-symbols-outlined"
-                                  style={{ fontSize: 14 }}
+                        <div
+                          style={{
+                            display: "grid",
+                            gridTemplateColumns: `repeat(${timelineColumns.length}, ${SLOT_WIDTH}px)`,
+                            gap: SLOT_GAP,
+                            flex: "1 1 auto",
+                          }}
+                        >
+                          {timelineColumns.map((column) => {
+                            const loopLabel = `Loop ${String(
+                              column.index + 1
+                            ).padStart(2, "0")}`;
+                            if (column.hasSection) {
+                              return (
+                                <button
+                                  key={column.id}
+                                  type="button"
+                                  onClick={() => handleDeleteColumn(column.index)}
+                                  style={{
+                                    padding: "4px 8px",
+                                    borderRadius: 16,
+                                    border: "1px solid #2a3344",
+                                    background: "#111827",
+                                    color: "#e2e8f0",
+                                    fontSize: 11,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    gap: 4,
+                                    cursor: "pointer",
+                                  }}
                                 >
-                                  delete
-                                </span>
-                                <span>Seq {column.index + 1}</span>
-                              </button>
-                            );
-                          }
-                          if (column.isStarter) {
-                            return (
-                              <div
-                                key={column.id}
-                                style={{
-                                  borderRadius: 8,
-                                  border: "1px solid #273041",
-                                  background: "#0b111d",
-                                  color: "#94a3b8",
-                                  display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  fontSize: 12,
-                                  fontWeight: 600,
-                                  letterSpacing: 0.3,
-                                }}
-                              >
-                                Seq 1
-                              </div>
-                            );
-                          }
-                          return <div key={column.id} />;
-                        })}
+                                  <span
+                                    className="material-symbols-outlined"
+                                    style={{ fontSize: 14 }}
+                                  >
+                                    delete
+                                  </span>
+                                  <span>{loopLabel}</span>
+                                </button>
+                              );
+                            }
+                            if (column.isStarter) {
+                              return (
+                                <div
+                                  key={column.id}
+                                  style={{
+                                    borderRadius: 8,
+                                    border: "1px solid #273041",
+                                    background: "#0b111d",
+                                    color: "#94a3b8",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    fontSize: 12,
+                                    fontWeight: 600,
+                                    letterSpacing: 0.3,
+                                  }}
+                                >
+                                  Loop 01
+                                </div>
+                              );
+                            }
+                            return <div key={column.id} />;
+                          })}
+                        </div>
+                        <IconButton
+                          icon="add"
+                          label="Add loop"
+                          onClick={handleAddSection}
+                          size="compact"
+                          style={{
+                            ...addLoopButtonStyle,
+                            flexShrink: 0,
+                            marginLeft: SLOT_GAP,
+                          }}
+                        />
                       </div>
                     </div>
-                    <IconButton
-                      icon="add"
-                      label="Add loop"
-                      onClick={handleAddSection}
-                      size="compact"
-                      style={{
-                        ...addLoopButtonStyle,
-                        flexShrink: 0,
-                        marginLeft: SLOT_GAP,
-                      }}
-                    />
                   </div>
                 </div>
               </div>

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -770,7 +770,11 @@ export function SongView({
     const columns = Math.max(1, effectiveColumnCount);
     const totalSlotWidth = columns * SLOT_WIDTH;
     const totalGapWidth = Math.max(0, columns - 1) * SLOT_GAP;
-    return totalSlotWidth + totalGapWidth;
+    const addLoopColumnWidth = SLOT_MIN_HEIGHT;
+    const addLoopGapWidth = SLOT_GAP;
+    return (
+      totalSlotWidth + totalGapWidth + addLoopColumnWidth + addLoopGapWidth
+    );
   }, [effectiveColumnCount]);
 
   const timelineWidthStyle = useMemo(() => {

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -78,6 +78,9 @@ const TIMELINE_TOOLBAR_GAP = 12;
 const TIMELINE_CONTROL_HEIGHT = 36;
 const TRANSPORT_CONTROL_HEIGHT = 44;
 const TIMELINE_ROW_MARGIN = 8;
+// Matches --transport-h defined in src/styles/layout.css so the scroll height
+// reserves space for the sticky transport controls.
+const STICKY_BOTTOM_BAR_HEIGHT = 76;
 
 const TIMELINE_LABEL_STYLE: CSSProperties = {
   fontSize: 14,
@@ -1198,12 +1201,14 @@ export function SongView({
     const totalRowMargin = rowCount * TIMELINE_ROW_MARGIN;
     const inlineAddRowHeight = slotMinHeight;
     const inlineAddRowGap = SLOT_GAP;
+    const stickyBottomBarBuffer = STICKY_BOTTOM_BAR_HEIGHT;
     return (
       totalRowHeight +
       totalRowGap +
       totalRowMargin +
       inlineAddRowGap +
-      inlineAddRowHeight
+      inlineAddRowHeight +
+      stickyBottomBarBuffer
     );
   }, [timelineDisplayRows.length, slotMinHeight]);
 


### PR DESCRIPTION
## Summary
- add inline +Loop button inside the timeline header that reuses the existing add sequence logic
- render an inline +Row control aligned with the grid and provide an empty-state placeholder cell
- maintain existing toolbar buttons while updating grid styling helpers for the new controls

## Testing
- npm run lint *(fails: existing lint rule violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1af35b3c48328941df760e1a215be