### PR TITLE
Enable scrolling on start screen

### DIFF
--- a/src/views/StartScreen.tsx
+++ b/src/views/StartScreen.tsx
@@ -34,7 +34,7 @@ export function StartScreen({
     >
       <TopBar left={topBarLeft} center={topBarCenter} right={topBarRight} />
       <div
-        className="flex-1 min-h-0 overflow-y-auto"
+        className="flex-1 min-h-0 overflow-y-auto scrollable"
         style={{
           flex: 1,
           minHeight: 0,


### PR DESCRIPTION
## Summary
- allow the start screen content area to use the existing scrollable styles so long pages can be scrolled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3f98fb41c83288d84b7c89a337046