### PR TITLE
Add Pulse instrument modulation chain

### DIFF
--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -24,6 +24,10 @@ export interface Chunk {
   bitcrusher?: number;
   filter?: number;
   chorus?: number;
+  pulseRate?: string | number;
+  pulseDepth?: number;
+  pulseShape?: string;
+  pulseMode?: "amplitude" | "filter";
   timingMode?: "sync" | "free";
   tonalCenter?: string;
   scale?: string;

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -314,7 +314,10 @@ const createInstrumentInstance = (
   }
 
   if (instrumentId === "pulse") {
-    const pulseNodes = createPulseInstrument(tone, character);
+    const pulseNodes = createPulseInstrument(
+      tone as unknown as typeof Tone,
+      character
+    );
     pulseNodes.output.connect(tone.Destination);
     return { instrument: pulseNodes.synth as ToneInstrument, pulseNodes };
   }

--- a/src/instruments/pulse.ts
+++ b/src/instruments/pulse.ts
@@ -1,0 +1,229 @@
+import * as Tone from "tone";
+
+import type { EffectSpec, InstrumentCharacter } from "../packs";
+
+export type PulseModulationMode = "amplitude" | "filter";
+
+type ToneLike = typeof Tone;
+
+type PolyVoiceCtor = new (options?: Record<string, unknown>) => Tone.Synth;
+
+type PolyCtor = new (
+  voice?: PolyVoiceCtor,
+  options?: Record<string, unknown>
+) => Tone.PolySynth<Tone.Synth>;
+
+const DEFAULT_RATE: Tone.Unit.Frequency = "8n";
+const DEFAULT_DEPTH = 0.6;
+const DEFAULT_SHAPE: Tone.ToneOscillatorType = "sine";
+const DEFAULT_MODE: PulseModulationMode = "amplitude";
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const isFrequencyLike = (
+  value: unknown
+): value is Tone.Unit.Frequency =>
+  typeof value === "number" || typeof value === "string";
+
+const isOscillatorType = (
+  value: unknown
+): value is Tone.ToneOscillatorType => typeof value === "string";
+
+const isPulseMode = (value: unknown): value is PulseModulationMode =>
+  value === "amplitude" || value === "filter";
+
+const buildEffectChain = (
+  tone: ToneLike,
+  source: Tone.ToneAudioNode,
+  effects: EffectSpec[]
+): { tail: Tone.ToneAudioNode; nodes: Tone.ToneAudioNode[] } => {
+  if (!effects.length) {
+    return { tail: source, nodes: [] };
+  }
+  const nodes: Tone.ToneAudioNode[] = [];
+  let current = source;
+  effects.forEach((effect) => {
+    const EffectCtor = (
+      tone as unknown as Record<
+        string,
+        new (opts?: Record<string, unknown>) => Tone.ToneAudioNode
+      >
+    )[effect.type];
+    if (!EffectCtor) {
+      return;
+    }
+    const node = new EffectCtor(effect.options ?? {});
+    const maybeStart = node as unknown as { start?: () => void };
+    maybeStart.start?.();
+    current.connect(node);
+    nodes.push(node);
+    current = node;
+  });
+  return { tail: current, nodes };
+};
+
+export interface PulseNodes {
+  synth: Tone.PolySynth<Tone.Synth>;
+  tremolo: Tone.Tremolo;
+  autoFilter: Tone.AutoFilter;
+  output: Tone.Gain;
+  setRate: (rate: Tone.Unit.Frequency) => void;
+  setDepth: (depth: number) => void;
+  setShape: (shape: Tone.ToneOscillatorType) => void;
+  setMode: (mode: PulseModulationMode) => void;
+  getMode: () => PulseModulationMode;
+  dispose: () => void;
+}
+
+const resolvePolySynth = (
+  tone: ToneLike,
+  character?: InstrumentCharacter
+): Tone.PolySynth<Tone.Synth> => {
+  const options = (character?.options ?? {}) as {
+    voice?: string;
+    voiceOptions?: Record<string, unknown>;
+  } & Record<string, unknown>;
+  const { voice, voiceOptions, ...polyOptions } = options;
+  const settable = (values: Record<string, unknown>) => {
+    (synth as unknown as { set?: (payload: Record<string, unknown>) => void }).set?.(
+      values
+    );
+  };
+  let synth: Tone.PolySynth<Tone.Synth>;
+  if (voice && voice in tone) {
+    const VoiceCtor = (
+      tone as unknown as Record<string, PolyVoiceCtor>
+    )[voice] as PolyVoiceCtor;
+    const PolyCtorImpl = tone.PolySynth as unknown as PolyCtor;
+    synth = new PolyCtorImpl(VoiceCtor, voiceOptions ?? {});
+  } else {
+    synth = new tone.PolySynth();
+  }
+  if (Object.keys(polyOptions).length > 0) {
+    settable(polyOptions);
+  }
+  return synth;
+};
+
+const resolveDefaults = (
+  character?: InstrumentCharacter
+): {
+  rate: Tone.Unit.Frequency;
+  depth: number;
+  shape: Tone.ToneOscillatorType;
+  mode: PulseModulationMode;
+} => {
+  const defaults = character?.defaults ?? {};
+  const rate = isFrequencyLike(defaults.pulseRate)
+    ? (defaults.pulseRate as Tone.Unit.Frequency)
+    : DEFAULT_RATE;
+  const depth = clamp(
+    typeof defaults.pulseDepth === "number" ? defaults.pulseDepth : DEFAULT_DEPTH,
+    0,
+    1
+  );
+  const shape = isOscillatorType(defaults.pulseShape)
+    ? (defaults.pulseShape as Tone.ToneOscillatorType)
+    : DEFAULT_SHAPE;
+  const mode = isPulseMode(defaults.pulseMode)
+    ? (defaults.pulseMode as PulseModulationMode)
+    : DEFAULT_MODE;
+  return { rate, depth, shape, mode };
+};
+
+export const createPulseInstrument = (
+  tone: ToneLike = Tone,
+  character?: InstrumentCharacter
+): PulseNodes => {
+  const synth = resolvePolySynth(tone, character);
+  const effects = Array.isArray(character?.effects)
+    ? (character?.effects as EffectSpec[])
+    : [];
+  const { tail, nodes: effectNodes } = buildEffectChain(tone, synth, effects);
+
+  const tremolo = new tone.Tremolo({
+    frequency: DEFAULT_RATE,
+    depth: DEFAULT_DEPTH,
+    wet: 1,
+  }).start();
+  tremolo.sync();
+
+  const autoFilter = new tone.AutoFilter({
+    frequency: DEFAULT_RATE,
+    depth: DEFAULT_DEPTH,
+    wet: 0,
+  }).start();
+  autoFilter.sync();
+
+  tail.connect(tremolo);
+  tail.connect(autoFilter);
+
+  const output = new tone.Gain(1);
+  tremolo.connect(output);
+  autoFilter.connect(output);
+
+  let mode: PulseModulationMode = DEFAULT_MODE;
+
+  const setRate = (rate: Tone.Unit.Frequency) => {
+    if (!isFrequencyLike(rate)) return;
+    tremolo.frequency.value = rate;
+    autoFilter.frequency.value = rate;
+  };
+
+  const setDepth = (depth: number) => {
+    const clamped = clamp(depth, 0, 1);
+    tremolo.depth.rampTo(clamped, 0.05);
+    autoFilter.depth.rampTo(clamped, 0.05);
+  };
+
+  const setShape = (shape: Tone.ToneOscillatorType) => {
+    if (!isOscillatorType(shape)) return;
+    tremolo.type = shape;
+    autoFilter.type = shape;
+  };
+
+  const setMode = (nextMode: PulseModulationMode) => {
+    mode = nextMode;
+    if (mode === "filter") {
+      autoFilter.wet.rampTo(1, 0.05);
+      tremolo.wet.rampTo(0, 0.05);
+    } else {
+      autoFilter.wet.rampTo(0, 0.05);
+      tremolo.wet.rampTo(1, 0.05);
+    }
+  };
+
+  const getMode = () => mode;
+
+  const dispose = () => {
+    tremolo.unsync();
+    tremolo.stop();
+    tremolo.dispose();
+    autoFilter.unsync();
+    autoFilter.stop();
+    autoFilter.dispose();
+    effectNodes.forEach((node) => node.dispose());
+    output.dispose();
+  };
+
+  const defaults = resolveDefaults(character);
+  setRate(defaults.rate);
+  setDepth(defaults.depth);
+  setShape(defaults.shape);
+  setMode(defaults.mode);
+
+  return {
+    synth,
+    tremolo,
+    autoFilter,
+    output,
+    setRate,
+    setDepth,
+    setShape,
+    setMode,
+    getMode,
+    dispose,
+  };
+};
+

--- a/src/song.ts
+++ b/src/song.ts
@@ -60,6 +60,10 @@ export interface PerformanceTrackSettings {
   bitcrusher?: number;
   filter?: number;
   chorus?: number;
+  pulseRate?: string | number;
+  pulseDepth?: number;
+  pulseShape?: string;
+  pulseMode?: "amplitude" | "filter";
   pitchBend?: number;
   style?: string;
   mode?: string;
@@ -120,6 +124,10 @@ export const createPerformanceSettingsSnapshot = (
   bitcrusher: pattern.bitcrusher,
   filter: pattern.filter,
   chorus: pattern.chorus,
+  pulseRate: pattern.pulseRate,
+  pulseDepth: pattern.pulseDepth,
+  pulseShape: pattern.pulseShape,
+  pulseMode: pattern.pulseMode,
   pitchBend: pattern.pitchBend,
   style: pattern.style,
   mode: pattern.mode,
@@ -188,6 +196,10 @@ export const performanceSettingsToChunk = (
     chunk.bitcrusher = settings.bitcrusher;
   if (settings.filter !== undefined) chunk.filter = settings.filter;
   if (settings.chorus !== undefined) chunk.chorus = settings.chorus;
+  if (settings.pulseRate !== undefined) chunk.pulseRate = settings.pulseRate;
+  if (settings.pulseDepth !== undefined) chunk.pulseDepth = settings.pulseDepth;
+  if (settings.pulseShape !== undefined) chunk.pulseShape = settings.pulseShape;
+  if (settings.pulseMode !== undefined) chunk.pulseMode = settings.pulseMode;
   if (settings.pitchBend !== undefined) chunk.pitchBend = settings.pitchBend;
   if (settings.style !== undefined) chunk.style = settings.style;
   if (settings.mode !== undefined) chunk.mode = settings.mode;


### PR DESCRIPTION
## Summary
- add a Pulse instrument factory that routes a PolySynth through synced Tremolo/AutoFilter modulation and exposes setters for key parameters
- integrate the Pulse modulation nodes into the live app and offline exporter, applying chunk settings and disposing nodes with the instrument lifecycle
- extend chunk and performance setting models to persist Pulse modulation controls

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e59a70fd9483288394995a413e9cd1