### PR TITLE
Add Pulse instrument signal chain

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,14 @@ import {
   type TrackInstrument,
   type TriggerMap,
 } from "./tracks";
-import type { Chunk } from "./chunks";
+import {
+  DEFAULT_PULSE_DEPTH,
+  DEFAULT_PULSE_FILTER,
+  DEFAULT_PULSE_RATE,
+  DEFAULT_PULSE_SHAPE,
+  type Chunk,
+  type PulseShape,
+} from "./chunks";
 import { packs, type InstrumentCharacter, type Pack } from "./packs";
 import {
   createHarmoniaNodes,
@@ -1203,17 +1210,32 @@ export default function App() {
             });
             return;
           }
-        const settable = inst as unknown as {
-          set?: (values: Record<string, unknown>) => void;
-        };
-          if (chunk?.attack !== undefined || chunk?.sustain !== undefined) {
-          const envelope: Record<string, unknown> = {};
-          if (chunk.attack !== undefined) envelope.attack = chunk.attack;
-          if (chunk.sustain !== undefined) envelope.release = chunk.sustain;
-          if (Object.keys(envelope).length > 0) {
-            settable.set?.({ envelope });
+
+          if (instrumentId === "pulse") {
+            const nodes = pulseNodesRef.current[key];
+            if (nodes) {
+              const rate = chunk?.pulseRate ?? DEFAULT_PULSE_RATE;
+              const depth = chunk?.pulseDepth ?? DEFAULT_PULSE_DEPTH;
+              const shape = (chunk?.pulseShape ?? DEFAULT_PULSE_SHAPE) as PulseShape;
+              const filterEnabled = chunk?.pulseFilter ?? DEFAULT_PULSE_FILTER;
+              nodes.setRate(rate);
+              nodes.setDepth(depth);
+              nodes.setShape(shape);
+              nodes.setFilterEnabled(Boolean(filterEnabled));
+            }
           }
-        }
+
+          const settable = inst as unknown as {
+            set?: (values: Record<string, unknown>) => void;
+          };
+          if (chunk?.attack !== undefined || chunk?.sustain !== undefined) {
+            const envelope: Record<string, unknown> = {};
+            if (chunk.attack !== undefined) envelope.attack = chunk.attack;
+            if (chunk.sustain !== undefined) envelope.release = chunk.sustain;
+            if (Object.keys(envelope).length > 0) {
+              settable.set?.({ envelope });
+            }
+          }
         if (chunk?.glide !== undefined) {
           settable.set?.({ portamento: chunk.glide });
         }

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -8,7 +8,7 @@ import type {
   SetStateAction,
 } from "react";
 
-import { ensurePulseDefaults, type Chunk } from "./chunks";
+import { applyPulseCharacterDefaults, ensurePulseDefaults, type Chunk } from "./chunks";
 import type {
   PatternGroup,
   PerformanceNote,
@@ -325,8 +325,8 @@ const getColumnTickBounds = (columnIndex: number) => ({
 const createPerformancePattern = (
   instrument: TrackInstrument,
   timingMode: "sync" | "free" = "sync"
-): Chunk =>
-  ensurePulseDefaults({
+): Chunk => {
+  let pattern = ensurePulseDefaults({
     id: `live-${instrument}-${Math.random().toString(36).slice(2, 8)}`,
     name: `${instrument}-performance`,
     instrument,
@@ -339,7 +339,28 @@ const createPerformancePattern = (
     noteEvents: [],
   });
 
-const resolveInstrumentSource = (instrument: TrackInstrument) => {
+  if (instrument === "pulse") {
+    const source = resolveInstrumentSource(instrument);
+    if (source?.packId) {
+      const pack = packs.find((candidate) => candidate.id === source.packId);
+      const instrumentDefinition = pack?.instruments?.pulse;
+      if (instrumentDefinition) {
+        const character = instrumentDefinition.characters.find(
+          (candidate) => candidate.id === (source.characterId ?? instrumentDefinition.defaultCharacterId)
+        );
+        pattern = {
+          ...pattern,
+          characterId: source.characterId ?? instrumentDefinition.defaultCharacterId ?? pattern.characterId,
+        };
+        pattern = applyPulseCharacterDefaults(pattern, character?.defaults ?? null);
+      }
+    }
+  }
+
+  return pattern;
+};
+
+function resolveInstrumentSource(instrument: TrackInstrument) {
   if (!instrument) return null;
   for (const pack of packs) {
     const definition = pack.instruments?.[instrument];
@@ -353,7 +374,7 @@ const resolveInstrumentSource = (instrument: TrackInstrument) => {
     };
   }
   return null;
-};
+}
 
 const formatInstrumentLabel = (instrument: string | null | undefined) =>
   instrument ? instrument.charAt(0).toUpperCase() + instrument.slice(1) : "";

--- a/src/SongView.tsx
+++ b/src/SongView.tsx
@@ -8,7 +8,7 @@ import type {
   SetStateAction,
 } from "react";
 
-import type { Chunk } from "./chunks";
+import { ensurePulseDefaults, type Chunk } from "./chunks";
 import type {
   PatternGroup,
   PerformanceNote,
@@ -325,18 +325,19 @@ const getColumnTickBounds = (columnIndex: number) => ({
 const createPerformancePattern = (
   instrument: TrackInstrument,
   timingMode: "sync" | "free" = "sync"
-): Chunk => ({
-  id: `live-${instrument}-${Math.random().toString(36).slice(2, 8)}`,
-  name: `${instrument}-performance`,
-  instrument,
-  steps: Array(16).fill(0),
-  velocities: Array(16).fill(0),
-  note: "C4",
-  sustain: 0.8,
-  velocityFactor: 1,
-  timingMode,
-  noteEvents: [],
-});
+): Chunk =>
+  ensurePulseDefaults({
+    id: `live-${instrument}-${Math.random().toString(36).slice(2, 8)}`,
+    name: `${instrument}-performance`,
+    instrument,
+    steps: Array(16).fill(0),
+    velocities: Array(16).fill(0),
+    note: "C4",
+    sustain: 0.8,
+    velocityFactor: 1,
+    timingMode,
+    noteEvents: [],
+  });
 
 const resolveInstrumentSource = (instrument: TrackInstrument) => {
   if (!instrument) return null;

--- a/src/chunk.schema.json
+++ b/src/chunk.schema.json
@@ -110,6 +110,25 @@
       "minimum": 0,
       "maximum": 1
     },
+    "pulseRate": {
+      "type": "string",
+      "description": "Pulse modulation rate synced to transport"
+    },
+    "pulseDepth": {
+      "type": "number",
+      "description": "Pulse modulation depth",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "pulseShape": {
+      "type": "string",
+      "description": "Pulse modulation waveform",
+      "enum": ["sine", "square", "triangle"]
+    },
+    "pulseFilter": {
+      "type": "boolean",
+      "description": "Whether Pulse uses filter-based gating"
+    },
     "timingMode": {
       "type": "string",
       "description": "Whether the pattern follows BPM sync or free timing",

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -5,6 +5,13 @@ export const DEFAULT_PULSE_DEPTH = 0.9;
 export const DEFAULT_PULSE_SHAPE: PulseShape = "square";
 export const DEFAULT_PULSE_FILTER = false;
 
+export interface PulseChunkSettings {
+  pulseRate?: string;
+  pulseDepth?: number;
+  pulseShape?: PulseShape;
+  pulseFilter?: boolean;
+}
+
 export interface NoteEvent {
   time: number;
   duration: number;
@@ -93,5 +100,35 @@ export const ensurePulseDefaults = (chunk: Chunk): Chunk => {
   }
 
   return changed ? { ...chunk, ...next } : chunk;
+};
+
+const isPulseShape = (value: unknown): value is PulseShape =>
+  value === "sine" || value === "square" || value === "triangle";
+
+export const applyPulseCharacterDefaults = (
+  chunk: Chunk,
+  defaults?: PulseChunkSettings | Record<string, unknown> | null
+): Chunk => {
+  if (chunk.instrument !== "pulse" || !defaults) {
+    return chunk;
+  }
+
+  const source = defaults as PulseChunkSettings;
+  const next: Partial<Chunk> = {};
+
+  if (typeof source.pulseRate === "string") {
+    next.pulseRate = source.pulseRate;
+  }
+  if (typeof source.pulseDepth === "number" && Number.isFinite(source.pulseDepth)) {
+    next.pulseDepth = source.pulseDepth;
+  }
+  if (isPulseShape(source.pulseShape)) {
+    next.pulseShape = source.pulseShape;
+  }
+  if (typeof source.pulseFilter === "boolean") {
+    next.pulseFilter = source.pulseFilter;
+  }
+
+  return Object.keys(next).length > 0 ? { ...chunk, ...next } : chunk;
 };
 

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -1,3 +1,10 @@
+export type PulseShape = "sine" | "square" | "triangle";
+
+export const DEFAULT_PULSE_RATE = "8n";
+export const DEFAULT_PULSE_DEPTH = 0.9;
+export const DEFAULT_PULSE_SHAPE: PulseShape = "square";
+export const DEFAULT_PULSE_FILTER = false;
+
 export interface NoteEvent {
   time: number;
   duration: number;
@@ -46,6 +53,10 @@ export interface Chunk {
   autopilot?: boolean;
   noteEvents?: NoteEvent[];
   noteLoopLength?: number;
+  pulseRate?: string;
+  pulseDepth?: number;
+  pulseShape?: PulseShape;
+  pulseFilter?: boolean;
   harmoniaComplexity?: "simple" | "extended" | "lush";
   harmoniaTone?: number;
   harmoniaDynamics?: number;
@@ -55,4 +66,32 @@ export interface Chunk {
   harmoniaBorrowedLabel?: string;
   harmoniaStepDegrees?: (number | null)[];
 }
+
+export const ensurePulseDefaults = (chunk: Chunk): Chunk => {
+  if (chunk.instrument !== "pulse") {
+    return chunk;
+  }
+
+  let changed = false;
+  const next: Partial<Chunk> = {};
+
+  if (chunk.pulseRate === undefined) {
+    next.pulseRate = DEFAULT_PULSE_RATE;
+    changed = true;
+  }
+  if (chunk.pulseDepth === undefined) {
+    next.pulseDepth = DEFAULT_PULSE_DEPTH;
+    changed = true;
+  }
+  if (chunk.pulseShape === undefined) {
+    next.pulseShape = DEFAULT_PULSE_SHAPE;
+    changed = true;
+  }
+  if (chunk.pulseFilter === undefined) {
+    next.pulseFilter = DEFAULT_PULSE_FILTER;
+    changed = true;
+  }
+
+  return changed ? { ...chunk, ...next } : chunk;
+};
 

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -3,7 +3,14 @@ import { getContext } from "tone";
 import { fromContext } from "tone/build/esm/fromContext";
 import type { TransportClass } from "tone/build/esm/core/clock/Transport";
 
-import type { Chunk } from "./chunks";
+import {
+  DEFAULT_PULSE_DEPTH,
+  DEFAULT_PULSE_FILTER,
+  DEFAULT_PULSE_RATE,
+  DEFAULT_PULSE_SHAPE,
+  type Chunk,
+  type PulseShape,
+} from "./chunks";
 import type { InstrumentCharacter, Pack } from "./packs";
 import type { StoredProjectData } from "./storage";
 import { createStoredProjectPayload } from "./storage";
@@ -487,6 +494,20 @@ const createOfflineTriggerMap = (
           characterId: character.id,
         });
         return;
+      }
+
+      if (instrumentId === "pulse") {
+        const nodes = pulseNodesRefs[key];
+        if (nodes) {
+          const rate = chunk?.pulseRate ?? DEFAULT_PULSE_RATE;
+          const depth = chunk?.pulseDepth ?? DEFAULT_PULSE_DEPTH;
+          const shape = (chunk?.pulseShape ?? DEFAULT_PULSE_SHAPE) as PulseShape;
+          const filterEnabled = chunk?.pulseFilter ?? DEFAULT_PULSE_FILTER;
+          nodes.setRate(rate);
+          nodes.setDepth(depth);
+          nodes.setShape(shape);
+          nodes.setFilterEnabled(Boolean(filterEnabled));
+        }
       }
 
       const settable = inst as unknown as {

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -17,6 +17,10 @@ import {
   type HarmoniaNodes,
 } from "./instruments/harmonia";
 import { createKick } from "./instruments/kickInstrument";
+import {
+  createPulseInstrument,
+  type PulseInstrumentNodes,
+} from "./instruments/pulse";
 
 interface KeyboardFxNodes {
   reverb: Tone.Reverb;
@@ -281,6 +285,7 @@ const createInstrumentInstance = (
 ): {
   instrument: ToneInstrument;
   keyboardFx?: KeyboardFxNodes;
+  pulseNodes?: PulseInstrumentNodes;
   harmoniaNodes?: HarmoniaNodes;
 } => {
   if (instrumentId === "kick") {
@@ -305,6 +310,11 @@ const createInstrumentInstance = (
     const nodes = createHarmoniaNodes(tone, character);
     nodes.volume.connect(tone.Destination);
     return { instrument: nodes.synth as ToneInstrument, harmoniaNodes: nodes };
+  }
+
+  if (instrumentId === "pulse") {
+    const nodes = createPulseInstrument(tone, undefined, character);
+    return { instrument: nodes.instrument as ToneInstrument, pulseNodes: nodes };
   }
 
   if (!character.type) {
@@ -414,6 +424,7 @@ const createOfflineTriggerMap = (
 ): { triggerMap: TriggerMap; dispose: () => void } => {
   const instrumentRefs: Record<string, ToneInstrument> = {};
   const keyboardFxRefs: Record<string, KeyboardFxNodes> = {};
+  const pulseNodesRefs: Record<string, PulseInstrumentNodes> = {};
   const harmoniaFxRefs: Record<string, HarmoniaNodes> = {};
 
   const triggerMap: TriggerMap = {};
@@ -442,6 +453,9 @@ const createOfflineTriggerMap = (
         instrumentRefs[key] = inst;
         if (created.keyboardFx) {
           keyboardFxRefs[key] = created.keyboardFx;
+        }
+        if (created.pulseNodes) {
+          pulseNodesRefs[key] = created.pulseNodes;
         }
         if (created.harmoniaNodes) {
           harmoniaFxRefs[key] = created.harmoniaNodes;
@@ -549,6 +563,9 @@ const createOfflineTriggerMap = (
       fx.chorus.dispose();
       fx.tremolo.dispose();
       fx.filter.dispose();
+    });
+    Object.values(pulseNodesRefs).forEach((nodes) => {
+      nodes.dispose();
     });
     Object.values(harmoniaFxRefs).forEach((nodes) => {
       disposeHarmoniaNodes(nodes);

--- a/src/instruments/pulse.ts
+++ b/src/instruments/pulse.ts
@@ -1,0 +1,216 @@
+import * as Tone from "tone";
+
+import type { InstrumentCharacter } from "../packs";
+
+export type PulseShape = "sine" | "square" | "triangle";
+
+export interface PulseSettings {
+  rate: Tone.Unit.Frequency;
+  depth: number;
+  shape: PulseShape;
+  filter?: boolean;
+}
+
+export const DEFAULT_PULSE_SETTINGS: PulseSettings = {
+  rate: "8n",
+  depth: 0.9,
+  shape: "square",
+  filter: false,
+};
+
+type ToneLike = Pick<
+  typeof Tone,
+  | "PolySynth"
+  | "Synth"
+  | "Tremolo"
+  | "AutoFilter"
+  | "Gain"
+  | "Destination"
+  | "Transport"
+> &
+  Record<string, unknown>;
+
+export interface PulseInstrumentNodes {
+  instrument: Tone.PolySynth;
+  tremolo: Tone.Tremolo;
+  filter: Tone.AutoFilter;
+  output: Tone.Gain;
+  effects: Tone.ToneAudioNode[];
+  isFilterEnabled: () => boolean;
+  setRate: (value: Tone.Unit.Frequency) => void;
+  setDepth: (value: number) => void;
+  setShape: (value: PulseShape) => void;
+  setFilterEnabled: (enabled: boolean) => void;
+  dispose: () => void;
+}
+
+const clampDepth = (value: number) => Math.max(0, Math.min(1, value));
+
+const createPolySynth = (
+  tone: ToneLike,
+  character?: InstrumentCharacter
+): Tone.PolySynth => {
+  const rawOptions = (character?.options ?? {}) as {
+    voice?: string;
+    voiceOptions?: Record<string, unknown>;
+  } & Record<string, unknown>;
+  const { voice, voiceOptions, ...polyOptions } = rawOptions;
+
+  if (voice && voice in tone) {
+    const VoiceCtor = (
+      tone as unknown as Record<
+        string,
+        new (opts?: Record<string, unknown>) => Tone.Synth
+      >
+    )[voice];
+    if (VoiceCtor) {
+      const PolyCtor = tone.PolySynth as unknown as new (
+        voice?: new (opts?: Record<string, unknown>) => Tone.Synth,
+        options?: Record<string, unknown>
+      ) => Tone.PolySynth;
+      const synth = new PolyCtor(VoiceCtor, voiceOptions ?? {});
+      (synth as unknown as { set?: (values: Record<string, unknown>) => void }).set?.(
+        polyOptions
+      );
+      return synth;
+    }
+  }
+
+  const synth = new tone.PolySynth(tone.Synth);
+  (synth as unknown as { set?: (values: Record<string, unknown>) => void }).set?.(
+    rawOptions
+  );
+  return synth;
+};
+
+const createEffectNodes = (
+  tone: ToneLike,
+  character?: InstrumentCharacter
+): Tone.ToneAudioNode[] => {
+  if (!Array.isArray(character?.effects)) {
+    return [];
+  }
+  const nodes: Tone.ToneAudioNode[] = [];
+  (character?.effects ?? []).forEach((effect) => {
+    const EffectCtor = (
+      tone as unknown as Record<
+        string,
+        new (opts?: Record<string, unknown>) => Tone.ToneAudioNode
+      >
+    )[effect.type];
+    if (!EffectCtor) {
+      return;
+    }
+    const node = new EffectCtor(effect.options ?? {});
+    (node as unknown as { start?: () => void }).start?.();
+    nodes.push(node);
+  });
+  return nodes;
+};
+
+const reconnectChain = (
+  params: {
+    synth: Tone.PolySynth;
+    tremolo: Tone.Tremolo;
+    filter: Tone.AutoFilter;
+    effects: Tone.ToneAudioNode[];
+    output: Tone.Gain;
+  },
+  useFilter: boolean
+) => {
+  const { synth, tremolo, filter, effects, output } = params;
+  synth.disconnect();
+  tremolo.disconnect();
+  filter.disconnect();
+  effects.forEach((node) => node.disconnect());
+
+  let current: Tone.ToneAudioNode;
+  if (useFilter) {
+    synth.connect(filter);
+    current = filter;
+  } else {
+    synth.connect(tremolo);
+    current = tremolo;
+  }
+
+  effects.forEach((node) => {
+    current.connect(node);
+    current = node;
+  });
+
+  current.connect(output);
+};
+
+export const createPulseInstrument = (
+  tone: ToneLike = Tone as ToneLike,
+  settings: Partial<PulseSettings> = {},
+  character?: InstrumentCharacter
+): PulseInstrumentNodes => {
+  const resolved: PulseSettings = {
+    ...DEFAULT_PULSE_SETTINGS,
+    ...settings,
+  };
+
+  const synth = createPolySynth(tone, character);
+  const tremolo = new tone.Tremolo(resolved.rate, resolved.depth);
+  tremolo.type = resolved.shape;
+  tremolo.start();
+  tremolo.sync();
+
+  const filter = new tone.AutoFilter(resolved.rate);
+  filter.type = resolved.shape;
+  filter.depth.value = clampDepth(resolved.depth);
+  filter.start();
+  filter.sync();
+
+  const output = new tone.Gain(1);
+  output.connect(tone.Destination);
+
+  const effects = createEffectNodes(tone, character);
+
+  let useFilter = Boolean(resolved.filter);
+  reconnectChain({ synth, tremolo, filter, effects, output }, useFilter);
+
+  const setRate = (value: Tone.Unit.Frequency) => {
+    tremolo.set({ frequency: value });
+    filter.set({ frequency: value });
+  };
+
+  const setDepth = (value: number) => {
+    const depth = clampDepth(value);
+    tremolo.set({ depth });
+    filter.depth.value = depth;
+  };
+
+  const setShape = (value: PulseShape) => {
+    tremolo.type = value;
+    filter.type = value;
+  };
+
+  const setFilterEnabled = (enabled: boolean) => {
+    if (useFilter === enabled) return;
+    useFilter = enabled;
+    reconnectChain({ synth, tremolo, filter, effects, output }, useFilter);
+  };
+
+  const dispose = () => {
+    tremolo.dispose();
+    filter.dispose();
+    effects.forEach((node) => node.dispose());
+    output.dispose();
+  };
+
+  return {
+    instrument: synth,
+    tremolo,
+    filter,
+    output,
+    effects,
+    isFilterEnabled: () => useFilter,
+    setRate,
+    setDepth,
+    setShape,
+    setFilterEnabled,
+    dispose,
+  };
+};

--- a/src/instruments/pulse.ts
+++ b/src/instruments/pulse.ts
@@ -1,8 +1,15 @@
 import * as Tone from "tone";
 
+import {
+  DEFAULT_PULSE_DEPTH,
+  DEFAULT_PULSE_FILTER,
+  DEFAULT_PULSE_RATE,
+  DEFAULT_PULSE_SHAPE,
+  type PulseShape,
+} from "../chunks";
 import type { InstrumentCharacter } from "../packs";
 
-export type PulseShape = "sine" | "square" | "triangle";
+export type { PulseShape };
 
 export interface PulseSettings {
   rate: Tone.Unit.Frequency;
@@ -12,10 +19,10 @@ export interface PulseSettings {
 }
 
 export const DEFAULT_PULSE_SETTINGS: PulseSettings = {
-  rate: "8n",
-  depth: 0.9,
-  shape: "square",
-  filter: false,
+  rate: DEFAULT_PULSE_RATE,
+  depth: DEFAULT_PULSE_DEPTH,
+  shape: DEFAULT_PULSE_SHAPE,
+  filter: DEFAULT_PULSE_FILTER,
 };
 
 type ToneLike = Pick<

--- a/src/packs/chiptune.json
+++ b/src/packs/chiptune.json
@@ -197,6 +197,61 @@
         }
       ]
     },
+    "pulse": {
+      "defaultCharacterId": "chip-pulse-chop",
+      "characters": [
+        {
+          "id": "chip-pulse-chop",
+          "name": "Pulse Chop",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "square" },
+              "envelope": {
+                "attack": 0.01,
+                "decay": 0.2,
+                "sustain": 0.6,
+                "release": 0.4
+              }
+            }
+          },
+          "defaults": {
+            "pulseRate": "8n",
+            "pulseDepth": 0.9,
+            "pulseShape": "square",
+            "pulseFilter": false
+          }
+        },
+        {
+          "id": "chip-pulse-wash",
+          "name": "Pulse Wash",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "triangle" },
+              "envelope": {
+                "attack": 0.02,
+                "decay": 0.25,
+                "sustain": 0.7,
+                "release": 0.8
+              }
+            }
+          },
+          "defaults": {
+            "pulseRate": "16n",
+            "pulseDepth": 0.8,
+            "pulseShape": "triangle",
+            "pulseFilter": true
+          }
+        }
+      ]
+    },
     "keyboard": {
       "defaultCharacterId": "pulse-keys",
       "characters": [

--- a/src/packs/early-2000s-edm.json
+++ b/src/packs/early-2000s-edm.json
@@ -281,6 +281,67 @@
         }
       ]
     },
+    "pulse": {
+      "defaultCharacterId": "edm-pulse-chop",
+      "characters": [
+        {
+          "id": "edm-pulse-chop",
+          "name": "Trance Chop",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 8,
+            "voiceOptions": {
+              "oscillator": { "type": "sawtooth" },
+              "envelope": {
+                "attack": 0.02,
+                "decay": 0.25,
+                "sustain": 0.5,
+                "release": 0.6
+              }
+            }
+          },
+          "effects": [
+            { "type": "FeedbackDelay", "options": { "delayTime": 0.18, "feedback": 0.35, "wet": 0.28 } }
+          ],
+          "defaults": {
+            "pulseRate": "16n",
+            "pulseDepth": 0.95,
+            "pulseShape": "square",
+            "pulseFilter": false
+          }
+        },
+        {
+          "id": "edm-pulse-sweep",
+          "name": "Filter Sweep",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "AMSynth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "envelope": {
+                "attack": 0.05,
+                "decay": 0.3,
+                "sustain": 0.6,
+                "release": 1
+              },
+              "oscillator": { "type": "triangle" }
+            }
+          },
+          "effects": [
+            { "type": "Chorus", "options": { "frequency": 1.8, "delayTime": 2.8, "depth": 0.45, "wet": 0.32 } }
+          ],
+          "defaults": {
+            "pulseRate": "8n",
+            "pulseDepth": 0.85,
+            "pulseShape": "sine",
+            "pulseFilter": true
+          }
+        }
+      ]
+    },
     "keyboard": {
       "defaultCharacterId": "saw-pad",
       "characters": [

--- a/src/packs/kraftwerk.json
+++ b/src/packs/kraftwerk.json
@@ -199,6 +199,64 @@
         }
       ]
     },
+    "pulse": {
+      "defaultCharacterId": "kraft-pulse-grid",
+      "characters": [
+        {
+          "id": "kraft-pulse-grid",
+          "name": "Pulse Grid",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 4,
+            "voiceOptions": {
+              "oscillator": { "type": "square" },
+              "envelope": {
+                "attack": 0.01,
+                "decay": 0.2,
+                "sustain": 0.55,
+                "release": 0.5
+              }
+            }
+          },
+          "defaults": {
+            "pulseRate": "8n",
+            "pulseDepth": 0.9,
+            "pulseShape": "square",
+            "pulseFilter": false
+          }
+        },
+        {
+          "id": "kraft-pulse-scan",
+          "name": "Filter Scanner",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 4,
+            "voiceOptions": {
+              "oscillator": { "type": "sawtooth" },
+              "envelope": {
+                "attack": 0.03,
+                "decay": 0.28,
+                "sustain": 0.6,
+                "release": 0.7
+              }
+            }
+          },
+          "effects": [
+            { "type": "Phaser", "options": { "frequency": 0.6, "octaves": 1.5, "baseFrequency": 400, "wet": 0.3 } }
+          ],
+          "defaults": {
+            "pulseRate": "8t",
+            "pulseDepth": 0.8,
+            "pulseShape": "triangle",
+            "pulseFilter": true
+          }
+        }
+      ]
+    },
     "keyboard": {
       "defaultCharacterId": "organ-pad",
       "characters": [

--- a/src/packs/phonk.json
+++ b/src/packs/phonk.json
@@ -230,6 +230,67 @@
         }
       ]
     },
+    "pulse": {
+      "defaultCharacterId": "phonk-pulse-tape",
+      "characters": [
+        {
+          "id": "phonk-pulse-tape",
+          "name": "Tape Gate",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 5,
+            "voiceOptions": {
+              "oscillator": { "type": "triangle" },
+              "envelope": {
+                "attack": 0.03,
+                "decay": 0.4,
+                "sustain": 0.6,
+                "release": 0.9
+              }
+            }
+          },
+          "effects": [
+            { "type": "BitCrusher", "options": { "bits": 6, "wet": 0.2 } }
+          ],
+          "defaults": {
+            "pulseRate": "16n",
+            "pulseDepth": 0.92,
+            "pulseShape": "square",
+            "pulseFilter": false
+          }
+        },
+        {
+          "id": "phonk-pulse-wah",
+          "name": "Night Wah",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "AMSynth",
+            "maxPolyphony": 4,
+            "voiceOptions": {
+              "envelope": {
+                "attack": 0.05,
+                "decay": 0.35,
+                "sustain": 0.5,
+                "release": 1.1
+              },
+              "oscillator": { "type": "sawtooth" }
+            }
+          },
+          "effects": [
+            { "type": "Chorus", "options": { "frequency": 0.8, "delayTime": 3, "depth": 0.5, "wet": 0.35 } }
+          ],
+          "defaults": {
+            "pulseRate": "8n",
+            "pulseDepth": 0.8,
+            "pulseShape": "sine",
+            "pulseFilter": true
+          }
+        }
+      ]
+    },
     "keyboard": {
       "defaultCharacterId": "dusty-keys",
       "characters": [

--- a/src/packs/trap.json
+++ b/src/packs/trap.json
@@ -211,6 +211,64 @@
         }
       ]
     },
+    "pulse": {
+      "defaultCharacterId": "trap-pulse-strobe",
+      "characters": [
+        {
+          "id": "trap-pulse-strobe",
+          "name": "Strobe Gate",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 6,
+            "voiceOptions": {
+              "oscillator": { "type": "sawtooth" },
+              "envelope": {
+                "attack": 0.01,
+                "decay": 0.2,
+                "sustain": 0.45,
+                "release": 0.5
+              }
+            }
+          },
+          "defaults": {
+            "pulseRate": "16n",
+            "pulseDepth": 0.97,
+            "pulseShape": "square",
+            "pulseFilter": false
+          }
+        },
+        {
+          "id": "trap-pulse-swell",
+          "name": "Filter Swell",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "AMSynth",
+            "maxPolyphony": 5,
+            "voiceOptions": {
+              "envelope": {
+                "attack": 0.04,
+                "decay": 0.3,
+                "sustain": 0.55,
+                "release": 0.8
+              },
+              "oscillator": { "type": "triangle" }
+            }
+          },
+          "effects": [
+            { "type": "Reverb", "options": { "decay": 2, "wet": 0.28 } }
+          ],
+          "defaults": {
+            "pulseRate": "8n",
+            "pulseDepth": 0.82,
+            "pulseShape": "sine",
+            "pulseFilter": true
+          }
+        }
+      ]
+    },
     "keyboard": {
       "defaultCharacterId": "pluck-keys",
       "characters": [

--- a/src/packs/triphop.json
+++ b/src/packs/triphop.json
@@ -213,6 +213,67 @@
         }
       ]
     },
+    "pulse": {
+      "defaultCharacterId": "trip-pulse-dust",
+      "characters": [
+        {
+          "id": "trip-pulse-dust",
+          "name": "Dust Gate",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "Synth",
+            "maxPolyphony": 5,
+            "voiceOptions": {
+              "oscillator": { "type": "triangle" },
+              "envelope": {
+                "attack": 0.04,
+                "decay": 0.5,
+                "sustain": 0.7,
+                "release": 1.2
+              }
+            }
+          },
+          "effects": [
+            { "type": "BitCrusher", "options": { "bits": 5, "wet": 0.25 } }
+          ],
+          "defaults": {
+            "pulseRate": "8n",
+            "pulseDepth": 0.88,
+            "pulseShape": "triangle",
+            "pulseFilter": false
+          }
+        },
+        {
+          "id": "trip-pulse-fade",
+          "name": "Filter Fade",
+          "type": "PolySynth",
+          "note": "C4",
+          "options": {
+            "voice": "AMSynth",
+            "maxPolyphony": 4,
+            "voiceOptions": {
+              "envelope": {
+                "attack": 0.08,
+                "decay": 0.6,
+                "sustain": 0.65,
+                "release": 1.6
+              },
+              "oscillator": { "type": "sawtooth" }
+            }
+          },
+          "effects": [
+            { "type": "Chorus", "options": { "frequency": 0.9, "delayTime": 3.6, "depth": 0.55, "wet": 0.4 } }
+          ],
+          "defaults": {
+            "pulseRate": "4n",
+            "pulseDepth": 0.75,
+            "pulseShape": "sine",
+            "pulseFilter": true
+          }
+        }
+      ]
+    },
     "keyboard": {
       "defaultCharacterId": "rhodes-keys",
       "characters": [

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -5,6 +5,7 @@ const BASE_INSTRUMENT_COLORS: Record<string, string> = {
   bass: "#1abc9c",
   keyboard: "#2ecc71",
   arp: "#9b59b6",
+  pulse: "#ff6bd6",
 };
 
 export const FALLBACK_INSTRUMENT_COLOR = "#27E0B0";


### PR DESCRIPTION
## Summary
- add a Pulse instrument factory that builds a PolySynth feeding tremolo or auto-filter nodes and exposes modulation controls
- integrate Pulse node lifecycle management into the runtime instrument factory and trigger map
- ensure the offline exporter instantiates and disposes Pulse modulation nodes alongside other instruments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59851bc388328a80d581adb5553e3